### PR TITLE
Added configuration for exchanging left command + arrows and left option + arrow

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -153,6 +153,18 @@
       </div>
     </div>
 
+          <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Exchange command + arrow keys and option + arrow keys</h3>
+      </div>
+      <div class="panel-body">
+        <ul>
+          <li>Change left command + arrow keys to left option + arrow keys.</li><li>Change left option + arrow keys to left command + arrow keys.</li>
+        </ul>
+        <a class="btn btn-primary btn-sm" style="margin-left: 40px" href="karabiner://karabiner/assets/complex_modifications/import?url=https%3A%2F%2Fpqrs.org%2Fosx%2Fkarabiner%2Fcomplex_modifications%2Fjson%2Fcommand_arrows_to_option_arrows.json">Import</a>
+      </div>
+    </div>
+
 
       <!-- For specific languages -->
           <div class="panel panel-default">

--- a/docs/json/command_arrows_to_option_arrows.json
+++ b/docs/json/command_arrows_to_option_arrows.json
@@ -1,0 +1,186 @@
+{
+    "title": "Exchange Command + arrows keys and Option + arrows keys",
+    "rules": [
+        {
+            "description": "Exchange left comand + arrow keys and left option + arrow keys",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "right_arrow",
+                        "modifiers": {
+                            "mandatory": [
+                                "left_command"
+                            ],
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "right_arrow",
+                            "modifiers": [
+                                "left_option"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "left_arrow",
+                        "modifiers": {
+                            "mandatory": [
+                                "left_command"
+                            ],
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "left_arrow",
+                            "modifiers": [
+                                "left_option"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "up_arrow",
+                        "modifiers": {
+                            "mandatory": [
+                                "left_command"
+                            ],
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "up_arrow",
+                            "modifiers": [
+                                "left_option"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "down_arrow",
+                        "modifiers": {
+                            "mandatory": [
+                                "left_command"
+                            ],
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "down_arrow",
+                            "modifiers": [
+                                "left_option"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "right_arrow",
+                        "modifiers": {
+                            "mandatory": [
+                                "left_option"
+                            ],
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "right_arrow",
+                            "modifiers": [
+                                "left_command"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "left_arrow",
+                        "modifiers": {
+                            "mandatory": [
+                                "left_option"
+                            ],
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "left_arrow",
+                            "modifiers": [
+                                "left_command"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "up_arrow",
+                        "modifiers": {
+                            "mandatory": [
+                                "left_option"
+                            ],
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "up_arrow",
+                            "modifiers": [
+                                "left_command"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "down_arrow",
+                        "modifiers": {
+                            "mandatory": [
+                                "left_option"
+                            ],
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "down_arrow",
+                            "modifiers": [
+                                "left_command"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/index.html.erb
+++ b/src/index.html.erb
@@ -32,6 +32,7 @@
       <%= file_import_panel("docs/json/diamond_cursor.json") %>
       <%= file_import_panel("docs/json/exchange_semicolon_and_colon.json") %>
       <%= file_import_panel("docs/json/ctrl_command_fn_letter_specials.json") %>
+      <%= file_import_panel("docs/json/command_arrows_to_option_arrows.json") %>
 
       <!-- For specific languages -->
       <%= file_import_panel("docs/json/japanese.json") %>

--- a/src/json/command_arrows_to_option_arrows.json.erb
+++ b/src/json/command_arrows_to_option_arrows.json.erb
@@ -1,0 +1,50 @@
+{
+    "title": "Exchange Command + arrows keys and Option + arrows keys",
+    "rules": [
+        {
+            "description": "Exchange left comand + arrow keys and left option + arrow keys",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("right_arrow", ["left_command"], ["any"]) %>,
+                    "to": <%= to([["right_arrow", ["left_option"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("left_arrow", ["left_command"], ["any"]) %>,
+                    "to": <%= to([["left_arrow", ["left_option"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("up_arrow", ["left_command"], ["any"]) %>,
+                    "to": <%= to([["up_arrow", ["left_option"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("down_arrow", ["left_command"], ["any"]) %>,
+                    "to": <%= to([["down_arrow", ["left_option"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("right_arrow", ["left_option"], ["any"]) %>,
+                    "to": <%= to([["right_arrow", ["left_command"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("left_arrow", ["left_option"], ["any"]) %>,
+                    "to": <%= to([["left_arrow", ["left_command"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("up_arrow", ["left_option"], ["any"]) %>,
+                    "to": <%= to([["up_arrow", ["left_command"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("down_arrow", ["left_option"], ["any"]) %>,
+                    "to": <%= to([["down_arrow", ["left_command"]]]) %>
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Useful for speed code selection and navigation, allows to move between, select and copy words without moving left finger from command key. It can be also useful for new Mac users coming from Windows.   