### PR TITLE
update rule “command_arrows_to_option_arrows”

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -155,11 +155,11 @@
 
           <div class="panel panel-default">
       <div class="panel-heading">
-        <h3 class="panel-title">Exchange Command + arrows keys and Option + arrows keys</h3>
+        <h3 class="panel-title">Exchange command + arrows keys with option + arrows keys</h3>
       </div>
       <div class="panel-body">
         <ul>
-          <li>Exchange left comand + arrow keys and left option + arrow keys</li>
+          <li>Exchange command + arrow keys with option + arrow keys</li>
         </ul>
         <a class="btn btn-primary btn-sm" style="margin-left: 40px" href="karabiner://karabiner/assets/complex_modifications/import?url=https%3A%2F%2Fpqrs.org%2Fosx%2Fkarabiner%2Fcomplex_modifications%2Fjson%2Fcommand_arrows_to_option_arrows.json">Import</a>
       </div>

--- a/docs/json/command_arrows_to_option_arrows.json
+++ b/docs/json/command_arrows_to_option_arrows.json
@@ -1,186 +1,186 @@
 {
-    "title": "Exchange Command + arrows keys and Option + arrows keys",
-    "rules": [
+  "title": "Exchange command + arrows keys with option + arrows keys",
+  "rules": [
+    {
+      "description": "Exchange command + arrow keys with option + arrow keys",
+      "manipulators": [
         {
-            "description": "Exchange left comand + arrow keys and left option + arrow keys",
-            "manipulators": [
-                {
-                    "type": "basic",
-                    "from": {
-                        "key_code": "right_arrow",
-                        "modifiers": {
-                            "mandatory": [
-                                "left_command"
-                            ],
-                            "optional": [
-                                "any"
-                            ]
-                        }
-                    },
-                    "to": [
-                        {
-                            "key_code": "right_arrow",
-                            "modifiers": [
-                                "left_option"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "type": "basic",
-                    "from": {
-                        "key_code": "left_arrow",
-                        "modifiers": {
-                            "mandatory": [
-                                "left_command"
-                            ],
-                            "optional": [
-                                "any"
-                            ]
-                        }
-                    },
-                    "to": [
-                        {
-                            "key_code": "left_arrow",
-                            "modifiers": [
-                                "left_option"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "type": "basic",
-                    "from": {
-                        "key_code": "up_arrow",
-                        "modifiers": {
-                            "mandatory": [
-                                "left_command"
-                            ],
-                            "optional": [
-                                "any"
-                            ]
-                        }
-                    },
-                    "to": [
-                        {
-                            "key_code": "up_arrow",
-                            "modifiers": [
-                                "left_option"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "type": "basic",
-                    "from": {
-                        "key_code": "down_arrow",
-                        "modifiers": {
-                            "mandatory": [
-                                "left_command"
-                            ],
-                            "optional": [
-                                "any"
-                            ]
-                        }
-                    },
-                    "to": [
-                        {
-                            "key_code": "down_arrow",
-                            "modifiers": [
-                                "left_option"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "type": "basic",
-                    "from": {
-                        "key_code": "right_arrow",
-                        "modifiers": {
-                            "mandatory": [
-                                "left_option"
-                            ],
-                            "optional": [
-                                "any"
-                            ]
-                        }
-                    },
-                    "to": [
-                        {
-                            "key_code": "right_arrow",
-                            "modifiers": [
-                                "left_command"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "type": "basic",
-                    "from": {
-                        "key_code": "left_arrow",
-                        "modifiers": {
-                            "mandatory": [
-                                "left_option"
-                            ],
-                            "optional": [
-                                "any"
-                            ]
-                        }
-                    },
-                    "to": [
-                        {
-                            "key_code": "left_arrow",
-                            "modifiers": [
-                                "left_command"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "type": "basic",
-                    "from": {
-                        "key_code": "up_arrow",
-                        "modifiers": {
-                            "mandatory": [
-                                "left_option"
-                            ],
-                            "optional": [
-                                "any"
-                            ]
-                        }
-                    },
-                    "to": [
-                        {
-                            "key_code": "up_arrow",
-                            "modifiers": [
-                                "left_command"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "type": "basic",
-                    "from": {
-                        "key_code": "down_arrow",
-                        "modifiers": {
-                            "mandatory": [
-                                "left_option"
-                            ],
-                            "optional": [
-                                "any"
-                            ]
-                        }
-                    },
-                    "to": [
-                        {
-                            "key_code": "down_arrow",
-                            "modifiers": [
-                                "left_command"
-                            ]
-                        }
-                    ]
-                }
-            ]
+          "type": "basic",
+          "from": {
+            "key_code": "right_arrow",
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_arrow",
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "up_arrow",
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "down_arrow",
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "down_arrow",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_arrow",
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow",
+              "modifiers": [
+                "command"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_arrow",
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow",
+              "modifiers": [
+                "command"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "up_arrow",
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow",
+              "modifiers": [
+                "command"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "down_arrow",
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "down_arrow",
+              "modifiers": [
+                "command"
+              ]
+            }
+          ]
         }
-    ]
+      ]
+    }
+  ]
 }

--- a/src/json/command_arrows_to_option_arrows.json.erb
+++ b/src/json/command_arrows_to_option_arrows.json.erb
@@ -1,48 +1,48 @@
 {
-    "title": "Exchange Command + arrows keys and Option + arrows keys",
+    "title": "Exchange command + arrows keys with option + arrows keys",
     "rules": [
         {
-            "description": "Exchange left comand + arrow keys and left option + arrow keys",
+            "description": "Exchange command + arrow keys with option + arrow keys",
             "manipulators": [
                 {
                     "type": "basic",
-                    "from": <%= from("right_arrow", ["left_command"], ["any"]) %>,
-                    "to": <%= to([["right_arrow", ["left_option"]]]) %>
+                    "from": <%= from("right_arrow", ["command"], ["any"]) %>,
+                    "to": <%= to([["right_arrow", ["option"]]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("left_arrow", ["left_command"], ["any"]) %>,
-                    "to": <%= to([["left_arrow", ["left_option"]]]) %>
+                    "from": <%= from("left_arrow", ["command"], ["any"]) %>,
+                    "to": <%= to([["left_arrow", ["option"]]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("up_arrow", ["left_command"], ["any"]) %>,
-                    "to": <%= to([["up_arrow", ["left_option"]]]) %>
+                    "from": <%= from("up_arrow", ["command"], ["any"]) %>,
+                    "to": <%= to([["up_arrow", ["option"]]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("down_arrow", ["left_command"], ["any"]) %>,
-                    "to": <%= to([["down_arrow", ["left_option"]]]) %>
+                    "from": <%= from("down_arrow", ["command"], ["any"]) %>,
+                    "to": <%= to([["down_arrow", ["option"]]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("right_arrow", ["left_option"], ["any"]) %>,
-                    "to": <%= to([["right_arrow", ["left_command"]]]) %>
+                    "from": <%= from("right_arrow", ["option"], ["any"]) %>,
+                    "to": <%= to([["right_arrow", ["command"]]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("left_arrow", ["left_option"], ["any"]) %>,
-                    "to": <%= to([["left_arrow", ["left_command"]]]) %>
+                    "from": <%= from("left_arrow", ["option"], ["any"]) %>,
+                    "to": <%= to([["left_arrow", ["command"]]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("up_arrow", ["left_option"], ["any"]) %>,
-                    "to": <%= to([["up_arrow", ["left_command"]]]) %>
+                    "from": <%= from("up_arrow", ["option"], ["any"]) %>,
+                    "to": <%= to([["up_arrow", ["command"]]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("down_arrow", ["left_option"], ["any"]) %>,
-                    "to": <%= to([["down_arrow", ["left_command"]]]) %>
+                    "from": <%= from("down_arrow", ["option"], ["any"]) %>,
+                    "to": <%= to([["down_arrow", ["command"]]]) %>
                 }
             ]
         }


### PR DESCRIPTION
- fix typo
- directly apply on command/option instead of left_command/left_option