### PR TITLE
updated numeric keypad modifiers for compatibility with vi mode

### DIFF
--- a/docs/json/numeric_keypad.json
+++ b/docs/json/numeric_keypad.json
@@ -13,7 +13,7 @@
             {
               "key_code": "fn",
               "modifiers": [
-                "left_control"
+                "left_option"
               ]
             }
           ],
@@ -29,7 +29,7 @@
             "key_code": "spacebar",
             "modifiers": {
               "mandatory": [
-                "control",
+                "option",
                 "fn"
               ]
             }
@@ -46,7 +46,7 @@
             "key_code": "m",
             "modifiers": {
               "mandatory": [
-                "control",
+                "option",
                 "fn"
               ]
             }
@@ -63,7 +63,7 @@
             "key_code": "comma",
             "modifiers": {
               "mandatory": [
-                "control",
+                "option",
                 "fn"
               ]
             }
@@ -80,7 +80,7 @@
             "key_code": "period",
             "modifiers": {
               "mandatory": [
-                "control",
+                "option",
                 "fn"
               ]
             }
@@ -97,7 +97,7 @@
             "key_code": "j",
             "modifiers": {
               "mandatory": [
-                "control",
+                "option",
                 "fn"
               ]
             }
@@ -114,7 +114,7 @@
             "key_code": "k",
             "modifiers": {
               "mandatory": [
-                "control",
+                "option",
                 "fn"
               ]
             }
@@ -131,7 +131,7 @@
             "key_code": "l",
             "modifiers": {
               "mandatory": [
-                "control",
+                "option",
                 "fn"
               ]
             }
@@ -148,7 +148,7 @@
             "key_code": "u",
             "modifiers": {
               "mandatory": [
-                "control",
+                "option",
                 "fn"
               ]
             }
@@ -165,7 +165,7 @@
             "key_code": "i",
             "modifiers": {
               "mandatory": [
-                "control",
+                "option",
                 "fn"
               ]
             }
@@ -182,7 +182,7 @@
             "key_code": "o",
             "modifiers": {
               "mandatory": [
-                "control",
+                "option",
                 "fn"
               ]
             }
@@ -190,6 +190,125 @@
           "to": [
             {
               "key_code": "keypad_9"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "slash",
+            "modifiers": {
+              "mandatory": [
+                "option",
+                "fn"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "keypad_enter"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "semicolon",
+            "modifiers": {
+              "mandatory": [
+                "option",
+                "fn"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "keypad_plus"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "p",
+            "modifiers": {
+              "mandatory": [
+                "option",
+                "fn"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "keypad_hyphen"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "0",
+            "modifiers": {
+              "mandatory": [
+                "option",
+                "fn"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "keypad_asterisk"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "9",
+            "modifiers": {
+              "mandatory": [
+                "option",
+                "fn"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "keypad_slash"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "8",
+            "modifiers": {
+              "mandatory": [
+                "option",
+                "fn"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "keypad_equal_sign"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "7",
+            "modifiers": {
+              "mandatory": [
+                "option",
+                "fn"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_or_backspace"
             }
           ]
         }

--- a/src/json/numeric_keypad.json.erb
+++ b/src/json/numeric_keypad.json.erb
@@ -4,64 +4,99 @@
         {
             "description": "Use a virtual numeric keypad by holding Tab. Pressing Tab alone sends Tab key",
             "manipulators": [
-                <%# change Tab to Left_control + Fn if pressed with other keys %>
+                <%# change Tab to Left_option + Fn if pressed with other keys %>
                 {
                     "type": "basic",
                     "from": <%= from("tab", [], []) %>,
-                    "to": <%= to([["fn", ["left_control"]]]) %>,
+                    "to": <%= to([["fn", ["left_option"]]]) %>,
                     "to_if_alone": <%= to([["tab"]]) %>
                 },
 
-                <%# change Control + Fn + SPACEBAR/M/,/./J/K/L/U/I/O to numeric keypad %>
+                <%# change Option + Fn + SPACEBAR/M/,/./J/K/L/U/I/O to numeric keypad %>
                 {
                     "type": "basic",
-                    "from": <%= from("spacebar", ["control","fn"], []) %>,
+                    "from": <%= from("spacebar", ["option","fn"], []) %>,
                     "to": <%= to([["keypad_0"]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("m", ["control","fn"], []) %>,
+                    "from": <%= from("m", ["option","fn"], []) %>,
                     "to": <%= to([["keypad_1"]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("comma", ["control","fn"], []) %>,
+                    "from": <%= from("comma", ["option","fn"], []) %>,
                     "to": <%= to([["keypad_2"]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("period", ["control","fn"], []) %>,
+                    "from": <%= from("period", ["option","fn"], []) %>,
                     "to": <%= to([["keypad_3"]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("j", ["control","fn"], []) %>,
+                    "from": <%= from("j", ["option","fn"], []) %>,
                     "to": <%= to([["keypad_4"]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("k", ["control","fn"], []) %>,
+                    "from": <%= from("k", ["option","fn"], []) %>,
                     "to": <%= to([["keypad_5"]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("l", ["control","fn"], []) %>,
+                    "from": <%= from("l", ["option","fn"], []) %>,
                     "to": <%= to([["keypad_6"]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("u", ["control","fn"], []) %>,
+                    "from": <%= from("u", ["option","fn"], []) %>,
                     "to": <%= to([["keypad_7"]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("i", ["control","fn"], []) %>,
+                    "from": <%= from("i", ["option","fn"], []) %>,
                     "to": <%= to([["keypad_8"]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("o", ["control","fn"], []) %>,
+                    "from": <%= from("o", ["option","fn"], []) %>,
                     "to": <%= to([["keypad_9"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("slash", ["option","fn"], []) %>,
+                    "to": <%= to([["keypad_enter"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("semicolon", ["option","fn"], []) %>,
+                    "to": <%= to([["keypad_plus"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("p", ["option","fn"], []) %>,
+                    "to": <%= to([["keypad_hyphen"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("0", ["option","fn"], []) %>,
+                    "to": <%= to([["keypad_asterisk"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("9", ["option","fn"], []) %>,
+                    "to": <%= to([["keypad_slash"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("8", ["option","fn"], []) %>,
+                    "to": <%= to([["keypad_equal_sign"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("7", ["option","fn"], []) %>,
+                    "to": <%= to([["delete_or_backspace"]]) %>
                 }
             ]
         }


### PR DESCRIPTION
following pull request #28 I've changed the modifier keys to Option + Fn for compatibility with vi mode.

I also added more keys like + - / * Enter for a more complete numeric keypad layout.

One thing I could not get working is mapping Tab + Right_option to keypad_period