### PR TITLE
Enable HHKB compatible mode

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -233,6 +233,18 @@
       </div>
     </div>
 
+          <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Happy Hacking Keyboard Compatible Mode (rev 1)</h3>
+      </div>
+      <div class="panel-body">
+        <ul>
+          <li>HHKB Arrow Mode (fn + semicolon/slash/open_bracket/quote to arrow keys, etc)</li><li>HHKB Media Key Mode (fn + a/s to Volume down/up)</li>
+        </ul>
+        <a class="btn btn-primary btn-sm" style="margin-left: 40px" href="karabiner://karabiner/assets/complex_modifications/import?url=https%3A%2F%2Fpqrs.org%2Fosx%2Fkarabiner%2Fcomplex_modifications%2Fjson%2Fhhkb_mode.json">Import</a>
+      </div>
+    </div>
+
 
       <!-- For specific languages -->
           <div class="panel panel-default">

--- a/docs/index.html
+++ b/docs/index.html
@@ -239,7 +239,7 @@
       </div>
       <div class="panel-body">
         <ul>
-          <li>HHKB Arrow Mode (fn + semicolon/slash/open_bracket/quote to arrow keys, etc)</li><li>HHKB Media Key Mode (fn + a/s to Volume down/up)</li>
+          <li>HHKB Arrow Mode (fn + semicolon/slash/open_bracket/quote to arrow keys, etc)</li><li>HHKB Media Key Mode (fn + asdf to Volume down/up/mute, eject)</li>
         </ul>
         <a class="btn btn-primary btn-sm" style="margin-left: 40px" href="karabiner://karabiner/assets/complex_modifications/import?url=https%3A%2F%2Fpqrs.org%2Fosx%2Fkarabiner%2Fcomplex_modifications%2Fjson%2Fhhkb_mode.json">Import</a>
       </div>

--- a/docs/json/hhkb_mode.json
+++ b/docs/json/hhkb_mode.json
@@ -1,0 +1,215 @@
+{
+  "title": "Happy Hacking Keyboard Compatible Mode (rev 1)",
+  "rules": [
+    {
+      "description": "HHKB Arrow Mode (fn + semicolon/slash/open_bracket/quote to arrow keys, etc)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "semicolon",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock",
+                "option",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "slash",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock",
+                "option",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "down_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "open_bracket",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock",
+                "option",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "quote",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock",
+                "option",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock",
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "page_up"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "period",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock",
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "page_down"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "k",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "home"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "comma",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "end"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "HHKB Media Key Mode (fn + a/s to Volume down/up)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "volume_decrement"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "s",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "volume_increment"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/json/hhkb_mode.json
+++ b/docs/json/hhkb_mode.json
@@ -169,7 +169,7 @@
       ]
     },
     {
-      "description": "HHKB Media Key Mode (fn + a/s to Volume down/up)",
+      "description": "HHKB Media Key Mode (fn + asdf to Volume down/up/mute, eject)",
       "manipulators": [
         {
           "type": "basic",
@@ -206,6 +206,44 @@
           "to": [
             {
               "key_code": "volume_increment"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "d",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "mute"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "f",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "eject"
             }
           ]
         }

--- a/src/index.html.erb
+++ b/src/index.html.erb
@@ -38,6 +38,7 @@
       <%= file_import_panel("docs/json/launch_apps.json") %>
       <%= file_import_panel("docs/json/block_one_handed_combos.json") %>
       <%= file_import_panel("docs/json/numeric_keypad.json") %>
+      <%= file_import_panel("docs/json/hhkb_mode.json") %>
 
       <!-- For specific languages -->
       <%= file_import_panel("docs/json/japanese.json") %>

--- a/src/json/hhkb_mode.json.erb
+++ b/src/json/hhkb_mode.json.erb
@@ -51,7 +51,7 @@
             ]
         },
         {
-            "description": "HHKB Media Key Mode (fn + a/s to Volume down/up)",
+            "description": "HHKB Media Key Mode (fn + asdf to Volume down/up/mute, eject)",
             "manipulators": [
                 {
                     "type": "basic",
@@ -62,6 +62,16 @@
                     "type": "basic",
                     "from": <%= from("s", ["fn"], ["caps_lock"]) %>,
                     "to": <%= to([["volume_increment"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("d", ["fn"], ["caps_lock"]) %>,
+                    "to": <%= to([["mute"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("f", ["fn"], ["caps_lock"]) %>,
+                    "to": <%= to([["eject"]]) %>
                 }
             ]
         }

--- a/src/json/hhkb_mode.json.erb
+++ b/src/json/hhkb_mode.json.erb
@@ -1,0 +1,69 @@
+{
+    "title": "Happy Hacking Keyboard Compatible Mode (rev 1)",
+    "rules": [
+        {
+            "description": "HHKB Arrow Mode (fn + semicolon/slash/open_bracket/quote to arrow keys, etc)",
+            "manipulators": [
+
+                <%# change fn + semicolon/slash/open_bracket/quote to arrow keys %>
+                {
+                    "type": "basic",
+                    "from": <%= from("semicolon", ["fn"], ["caps_lock", "option", "command"]) %>,
+                    "to": <%= to([["left_arrow"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("slash", ["fn"], ["caps_lock", "option", "command"]) %>,
+                    "to": <%= to([["down_arrow"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("open_bracket", ["fn"], ["caps_lock", "option", "command"]) %>,
+                    "to": <%= to([["up_arrow"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("quote", ["fn"], ["caps_lock", "option", "command"]) %>,
+                    "to": <%= to([["right_arrow"]]) %>
+                },
+
+                <%# change fn + l/period/k/cooma to page_up/page_down/home/end %>
+                {
+                    "type": "basic",
+                    "from": <%= from("l", ["fn"], ["caps_lock", "option"]) %>,
+                    "to": <%= to([["page_up"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("period", ["fn"], ["caps_lock", "option"]) %>,
+                    "to": <%= to([["page_down"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("k", ["fn"], ["caps_lock"]) %>,
+                    "to": <%= to([["home"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("comma", ["fn"], ["caps_lock"]) %>,
+                    "to": <%= to([["end"]]) %>
+                }
+            ]
+        },
+        {
+            "description": "HHKB Media Key Mode (fn + a/s to Volume down/up)",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("a", ["fn"], ["caps_lock"]) %>,
+                    "to": <%= to([["volume_decrement"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("s", ["fn"], ["caps_lock"]) %>,
+                    "to": <%= to([["volume_increment"]]) %>
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This adds some of the HHKB compatible Arrow Key Mode that was available in Karabiner, with an extra media keys

https://github.com/tekezo/Karabiner/blob/05ca98733f3e3501e0679814c3795d1cb57e177f/src/core/server/Resources/include/checkbox/device_specific.xml#L518-L525

This is for the US layout (no English documentation available?)
http://www.pfu.fujitsu.com/hhkeyboard/manual/P3PC-5931-01.pdf