### PR TITLE
Use right_command+h/j/k/l/;/' to switch current tab/window/application

### DIFF
--- a/docs/json/application_window_tab_switch_with_right_cmd_hjklsemiquote.json
+++ b/docs/json/application_window_tab_switch_with_right_cmd_hjklsemiquote.json
@@ -1,0 +1,175 @@
+{
+  "title": "Use right_command+h/j/k/l/;/' to switch current tab/window/application",
+  "rules": [
+    {
+      "description": "Use right_command+;/' to cycle through running applications (like command+tab).",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "quote",
+            "modifiers": {
+              "mandatory": [
+                "right_command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "tab",
+              "modifiers": [
+                "left_command"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "semicolon",
+            "modifiers": {
+              "mandatory": [
+                "right_command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "tab",
+              "modifiers": [
+                "left_command",
+                "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Use right_command+h/l to switch tabs in an application.",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "mandatory": [
+                "right_command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "tab",
+              "modifiers": [
+                "left_control"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "h",
+            "modifiers": {
+              "mandatory": [
+                "right_command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "tab",
+              "modifiers": [
+                "left_control",
+                "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Use right_command+j/k to switch windows of the foreground application .",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "k",
+            "modifiers": {
+              "mandatory": [
+                "right_command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "left_command"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "mandatory": [
+                "right_command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "left_command",
+                "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Disable left_command+(tab/shift+tab) (to retrain reflexes using the other manipulators).",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "tab",
+            "modifiers": {
+              "mandatory": [
+                "left_command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "out"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "tab",
+            "modifiers": {
+              "mandatory": [
+                "left_command",
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "out"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/index.html.erb
+++ b/src/index.html.erb
@@ -39,6 +39,7 @@
       <%= file_import_panel("docs/json/block_one_handed_combos.json") %>
       <%= file_import_panel("docs/json/numeric_keypad.json") %>
       <%= file_import_panel("docs/json/hhkb_mode.json") %>
+      <%= file_import_panel("docs/json/application_window_tab_switch_with_right_cmd_hjklsemiquote.json") %>
 
       <!-- For specific languages -->
       <%= file_import_panel("docs/json/japanese.json") %>

--- a/src/json/application_window_tab_switch_with_right_cmd_hjklsemiquote.json.erb
+++ b/src/json/application_window_tab_switch_with_right_cmd_hjklsemiquote.json.erb
@@ -1,0 +1,65 @@
+{
+    "title": "Use right_command+h/j/k/l/;/' to switch current tab/window/application",
+    "rules": [
+        {
+            "description": "Use right_command+;/' to cycle through running applications (like command+tab).",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("quote", ["right_command"], []) %>,
+                    "to": <%= to([["tab", ["left_command"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("semicolon", ["right_command"], []) %>,
+                    "to": <%= to([["tab", ["left_command", "left_shift"]]]) %>
+                }
+            ]
+        },
+        {
+            "description": "Use right_command+h/l to switch tabs in an application.",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("l", ["right_command"], []) %>,
+                    "to": <%= to([["tab", ["left_control"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("h", ["right_command"], []) %>,
+                    "to": <%= to([["tab", ["left_control", "left_shift"]]]) %>
+                }
+            ]
+        },
+        {
+            "description": "Use right_command+j/k to switch windows of the foreground application .",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("k", ["right_command"], []) %>,
+                    "to": <%= to([["grave_accent_and_tilde", ["left_command"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("j", ["right_command"], []) %>,
+                    "to": <%= to([["grave_accent_and_tilde", ["left_command", "left_shift"]]]) %>
+                }
+            ]
+        },
+        {
+            "description": "Disable left_command+(tab/shift+tab) (to retrain reflexes using the other manipulators).",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("tab", ["left_command"], []) %>,
+                    "to": <%= to([["out"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("tab", ["left_command", "left_shift"], []) %>,
+                    "to": <%= to([["out"]]) %>
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Use `⌘+;/'` switch applications (instead of ⌘+Tab,) `⌘+j/k` switch open windows and `⌘+h/l` switch tabs.  It is intended to offload some common work from the left hand to the right hand in order to better distribute physical effort.