### PR TITLE
keybindings to launch new windows of Chrome or iTerm2

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -211,6 +211,19 @@
 
           <div class="panel panel-default">
       <div class="panel-heading">
+        <h3 class="panel-title">Launch new Chrome or iTerm2 windows via keybindings</h3>
+      </div>
+      <div class="panel-body">
+        <ul>
+          <li>left control + left shift + ` (backtick) - launches a new iTerm2 window with the default profile</li><li>left control + left shift + 1 - launches a new Google Chrome window</li><li>This keybinding is set up to launch new windows of running applications, rather than launching applications themselves.  (Launching a running application only brings it to the foreground).  This is meant to mimic the launcher keybindings available in Ubuntu.</li>
+
+        </ul>
+        <a class="btn btn-primary btn-sm" style="margin-left: 40px" href="karabiner://karabiner/assets/complex_modifications/import?url=https%3A%2F%2Fpqrs.org%2Fosx%2Fkarabiner%2Fcomplex_modifications%2Fjson%2Flaunch_new_Chrome_or_iTerm2_windows.json">Import</a>
+      </div>
+    </div>
+
+          <div class="panel panel-default">
+      <div class="panel-heading">
         <h3 class="panel-title">Force the user to make key combination with two hands</h3>
       </div>
       <div class="panel-body">

--- a/docs/json/launch_new_Chrome_or_iTerm2_windows.json
+++ b/docs/json/launch_new_Chrome_or_iTerm2_windows.json
@@ -1,0 +1,49 @@
+{
+  "title": "Launch new Chrome or iTerm2 windows via keybindings",
+  "rules": [
+    {
+      "description": "left control + left shift + ` (backtick) - launches a new iTerm2 window with the default profile",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "grave_accent_and_tilde",
+            "modifiers": {
+              "mandatory": [
+                "left_control",
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "shell_command": "osascript -e 'tell app \"iTerm2\"' -e 'create window with default profile' -e activate -e end"
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "left control + left shift + 1 - launches a new Google Chrome window",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "1",
+            "modifiers": {
+              "mandatory": [
+                "left_control",
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "shell_command": "osascript -e 'tell app \"Google Chrome\"' -e 'make new window' -e activate -e end"
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}

--- a/src/extra_descriptions/launch_new_Chrome_or_iTerm2_windows.json.html
+++ b/src/extra_descriptions/launch_new_Chrome_or_iTerm2_windows.json.html
@@ -1,0 +1,1 @@
+<li>This keybinding is set up to launch new windows of running applications, rather than launching applications themselves.  (Launching a running application only brings it to the foreground).  This is meant to mimic the launcher keybindings available in Ubuntu.</li>

--- a/src/index.html.erb
+++ b/src/index.html.erb
@@ -36,6 +36,7 @@
       <%= file_import_panel("docs/json/delete.json") %>
       <%= file_import_panel("docs/json/change_command_l.json") %>
       <%= file_import_panel("docs/json/launch_apps.json") %>
+      <%= file_import_panel("docs/json/launch_new_Chrome_or_iTerm2_windows.json") %>
       <%= file_import_panel("docs/json/block_one_handed_combos.json") %>
       <%= file_import_panel("docs/json/numeric_keypad.json") %>
 

--- a/src/json/launch_new_Chrome_or_iTerm2_windows.json
+++ b/src/json/launch_new_Chrome_or_iTerm2_windows.json
@@ -1,0 +1,40 @@
+{
+  "title": "Launch new Chrome or iTerm2 windows via keybindings",
+  "rules": [{
+      "description": "Lcontrol Lshift backtick = new iTerm2 terminal",
+      "manipulators": [{
+        "from": {
+          "key_code": "grave_accent_and_tilde",
+          "modifiers": {
+            "mandatory": [
+              "left_control",
+              "left_shift"
+            ]
+          }
+        },
+        "to": [{
+          "shell_command": "osascript -e 'tell app \"iTerm2\"' -e 'create window with default profile' -e activate -e end"
+        }],
+        "type": "basic"
+      }]
+    },
+    {
+      "description": "Lcontrol Lshift 1 = new Chrome window",
+      "manipulators": [{
+        "from": {
+          "key_code": "1",
+          "modifiers": {
+            "mandatory": [
+              "left_control",
+              "left_shift"
+            ]
+          }
+        },
+        "to": [{
+          "shell_command": "osascript -e 'tell app \"Google Chrome\"' -e 'make new window' -e activate -e end"
+        }],
+        "type": "basic"
+      }]
+    }
+  ]
+}

--- a/src/json/launch_new_Chrome_or_iTerm2_windows.json.erb
+++ b/src/json/launch_new_Chrome_or_iTerm2_windows.json.erb
@@ -1,7 +1,7 @@
 {
   "title": "Launch new Chrome or iTerm2 windows via keybindings",
   "rules": [{
-      "description": "Lcontrol Lshift backtick = new iTerm2 terminal",
+      "description": "left control + left shift + ` (backtick) - launches a new iTerm2 window with the default profile",
       "manipulators": [{
         "from": {
           "key_code": "grave_accent_and_tilde",
@@ -19,7 +19,7 @@
       }]
     },
     {
-      "description": "Lcontrol Lshift 1 = new Chrome window",
+      "description": "left control + left shift + 1 - launches a new Google Chrome window",
       "manipulators": [{
         "from": {
           "key_code": "1",


### PR DESCRIPTION
As requested here: https://github.com/tekezo/Karabiner-Elements/pull/837, I am also putting this JSON in this repository.  

copied description from other PR:
This JSON example lets you open a new iTerm2 window via "left control, left shift, and `" or a new Chrome window via "left control, left shift, and 1", using the new shell_command in the complex modifications json element. (The ability to launch new windows, and not just applications, via keyboard bindings is much harder on Mac than Linux, and may be useful for recent converts like me trying to salvage their old Linux habits via Karabiner).