### PR TITLE
*Added rule*: Caps and enter to ctrl. Ctrl to caps.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -23,6 +23,18 @@
 
           <div class="panel panel-default">
       <div class="panel-heading">
+        <h3 class="panel-title">Caps and return to ctrl. Ctrl to caps.</h3>
+      </div>
+      <div class="panel-body">
+        <ul>
+          <li>Post left_ctrl when return_or_enter is hold.</li><li>Post escape if caps is pressed alone, left_ctrl otherwise</li><li>Map left_ctrl to caps_lock.</li>
+        </ul>
+        <a class="btn btn-primary btn-sm" style="margin-left: 40px" data-json-path="json/caps_and_return_to_ctrl.json">Import</a>
+      </div>
+    </div>
+
+          <div class="panel panel-default">
+      <div class="panel-heading">
         <h3 class="panel-title">Change caps_lock key</h3>
       </div>
       <div class="panel-body">

--- a/docs/json/caps_and_return_to_ctrl.json
+++ b/docs/json/caps_and_return_to_ctrl.json
@@ -1,0 +1,78 @@
+{
+  "title": "Caps and return to ctrl. Ctrl to caps.",
+  "rules": [
+    {
+      "description": "Post left_ctrl when return_or_enter is hold.",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "return_or_enter",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_control"
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "return_or_enter"
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Post escape if caps is pressed alone, left_ctrl otherwise",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "caps_lock",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_control"
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "escape"
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Map left_ctrl to caps_lock.",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "left_control",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "caps_lock"
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}

--- a/src/index.html.erb
+++ b/src/index.html.erb
@@ -21,6 +21,7 @@
         <a href="https://github.com/pqrs-org/KE-complex_modifications">GitHub</a>
       </div>
 
+      <%= file_import_panel("docs/json/caps_and_return_to_ctrl.json") %>
       <%= file_import_panel("docs/json/caps_lock.json") %>
       <%= file_import_panel("docs/json/exchange_numbers_and_symbols.json") %>
       <%= file_import_panel("docs/json/control.json") %>

--- a/src/json/caps_and_return_to_ctrl.json.erb
+++ b/src/json/caps_and_return_to_ctrl.json.erb
@@ -1,0 +1,37 @@
+{
+    "title": "Caps and return to ctrl. Ctrl to caps.",
+    "rules": [
+        {
+            "description": "Post left_ctrl when return_or_enter is hold.",
+            "manipulators": [
+                {
+                    "from": <%= from("return_or_enter", [], ["any"]) %>,
+                    "to": <%= to([["right_control"]]) %>,
+                    "to_if_alone": <%= to([["return_or_enter"]]) %>,
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "Post escape if caps is pressed alone, left_ctrl otherwise",
+            "manipulators": [
+                {
+                    "from": <%= from("caps_lock", [], ["any"]) %>,
+                    "to": <%= to([["left_control"]]) %>,
+                    "to_if_alone": <%= to([["escape"]]) %>,
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "Map left_ctrl to caps_lock.",
+            "manipulators": [
+                {
+                    "from": <%= from("left_control", [], ["any"]) %>,
+                    "to": <%= to([["caps_lock"]]) %>,
+                    "type": "basic"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This idea of a complex-rules repo is very very nice!  Wonderful Job. Below the commit string.

I find this rule extremely useful when using emacs!