### PR TITLE
Adds lshift => escape rule.

### DIFF
--- a/docs/json/lshift_to_escape.json
+++ b/docs/json/lshift_to_escape.json
@@ -1,0 +1,31 @@
+{
+  "title": "Change left shift to escape if alone",
+  "rules": [
+    {
+      "description": "Change left_shift to escape if alone.",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_shift",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_shift"
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "escape"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/lshift_to_escape.json.erb
+++ b/src/json/lshift_to_escape.json.erb
@@ -1,0 +1,16 @@
+{
+    "title": "Change shift key",
+    "rules": [
+        {
+            "description": "Change left_shift to caps_lock if alone.",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("left_shift", [], ["any"]) %>,
+                    "to": <%= to([["left_shift"]]) %>,
+                    "to_if_alone": <%= to([["escape"]]) %>
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
When I run `make`, I get the following error. Where might the invalid byte be?
I'm running on mac 10.12.5 with ruby version 1.9.3p484.

```
make
sh scripts/update-json.sh
/usr/bin/ruby scripts/erb2html.rb < src/index.html.erb > docs/index.html
/usr/lib/ruby/vendor_ruby/json/common.rb:155:in `encode': "\xEF" on US-ASCII (Encoding::InvalidByteSequenceError)
	from /usr/lib/ruby/vendor_ruby/json/common.rb:155:in `initialize'
	from /usr/lib/ruby/vendor_ruby/json/common.rb:155:in `new'
	from /usr/lib/ruby/vendor_ruby/json/common.rb:155:in `parse'
	from scripts/erb2html.rb:19:in `block in file_import_panel'
	from scripts/erb2html.rb:18:in `open'
	from scripts/erb2html.rb:18:in `file_import_panel'
	from (erb):50:in `<main>'
	from /usr/lib/ruby/1.9.1/erb.rb:838:in `eval'
	from /usr/lib/ruby/1.9.1/erb.rb:838:in `result'
	from scripts/erb2html.rb:49:in `<main>'
make: *** [all] Error 1
```

Also, when I add the lshift_to_escape.json file to
`~/.config/karabiner/assets/complex_modifications`

I see no change in the list of complex modification rules in 
`Karabiner-Elements Preferences > Complex Modifications > Rules > Add rule`. Why might that be?