### PR TITLE
Dvorak Keyboard layout; updated each_key() to have two sets of keys

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -505,6 +505,20 @@
     </div>
 
 
+      <!-- Full keyboard layouts -->
+          <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Dvorak Keyboard</h3>
+      </div>
+      <div class="panel-body">
+        <ul>
+          <li>Remap keys to use Dvorak keyboard layout</li>
+        </ul>
+        <a class="btn btn-primary btn-sm" style="margin-left: 40px" data-json-path="json/dvorak_layout.json">Import</a>
+      </div>
+    </div>
+
+
       <!-- For specific languages -->
           <div class="panel panel-default">
       <div class="panel-heading">

--- a/docs/json/dvorak_layout.json
+++ b/docs/json/dvorak_layout.json
@@ -7,7 +7,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "grave_accent_and_tilde"
+            "key_code": "grave_accent_and_tilde",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -21,7 +32,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "1"
+            "key_code": "1",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -35,7 +57,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "2"
+            "key_code": "2",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -49,7 +82,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "4"
+            "key_code": "4",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -63,7 +107,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "5"
+            "key_code": "5",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -77,7 +132,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "6"
+            "key_code": "6",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -91,7 +157,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "7"
+            "key_code": "7",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -105,7 +182,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "8"
+            "key_code": "8",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -119,7 +207,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "9"
+            "key_code": "9",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -133,7 +232,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "0"
+            "key_code": "0",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -147,7 +257,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "hyphen"
+            "key_code": "hyphen",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -161,7 +282,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "equal_sign"
+            "key_code": "equal_sign",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -175,7 +307,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "q"
+            "key_code": "q",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -189,7 +332,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "w"
+            "key_code": "w",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -203,133 +357,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "e"
-          },
-          "to": [
-            {
-              "key_code": "."
+            "key_code": "e",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
             }
-          ],
-          "conditions": [
-
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "r"
-          },
-          "to": [
-            {
-              "key_code": "p"
-            }
-          ],
-          "conditions": [
-
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "t"
-          },
-          "to": [
-            {
-              "key_code": "y"
-            }
-          ],
-          "conditions": [
-
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "y"
-          },
-          "to": [
-            {
-              "key_code": "f"
-            }
-          ],
-          "conditions": [
-
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "u"
-          },
-          "to": [
-            {
-              "key_code": "g"
-            }
-          ],
-          "conditions": [
-
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "i"
-          },
-          "to": [
-            {
-              "key_code": "c"
-            }
-          ],
-          "conditions": [
-
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "o"
-          },
-          "to": [
-            {
-              "key_code": "r"
-            }
-          ],
-          "conditions": [
-
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "p"
-          },
-          "to": [
-            {
-              "key_code": "l"
-            }
-          ],
-          "conditions": [
-
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "open_bracket"
-          },
-          "to": [
-            {
-              "key_code": "slash"
-            }
-          ],
-          "conditions": [
-
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "close_bracket"
           },
           "to": [
             {
@@ -343,7 +382,243 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "backslash"
+            "key_code": "r",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "p"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "t",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "y"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "y",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "u",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "g"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "c"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "o",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "r"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "p",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "l"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "open_bracket",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "slash"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "close_bracket",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "equal_sign"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "backslash",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -357,7 +632,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "a"
+            "key_code": "a",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -371,7 +657,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "s"
+            "key_code": "s",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -385,7 +682,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "d"
+            "key_code": "d",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -399,7 +707,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "f"
+            "key_code": "f",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -413,7 +732,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "g"
+            "key_code": "g",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -427,7 +757,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "h"
+            "key_code": "h",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -441,7 +782,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "j"
+            "key_code": "j",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -455,7 +807,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "k"
+            "key_code": "k",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -469,7 +832,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "l"
+            "key_code": "l",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -483,7 +857,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "semicolon"
+            "key_code": "semicolon",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -497,7 +882,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "quote"
+            "key_code": "quote",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -511,7 +907,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "z"
+            "key_code": "z",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -525,7 +932,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "x"
+            "key_code": "x",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -539,7 +957,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "c"
+            "key_code": "c",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -553,7 +982,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "v"
+            "key_code": "v",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -567,7 +1007,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "b"
+            "key_code": "b",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -581,7 +1032,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "n"
+            "key_code": "n",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -595,7 +1057,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "m"
+            "key_code": "m",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -609,7 +1082,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "comma"
+            "key_code": "comma",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -623,7 +1107,18 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "period"
+            "key_code": "period",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
@@ -637,11 +1132,2874 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "slash"
+            "key_code": "slash",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
           },
           "to": [
             {
               "key_code": "z"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "grave_accent_and_tilde",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "1",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "1",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "2",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "2",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "4",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "4",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "5",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "5",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "6",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "6",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "7",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "7",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "8",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "8",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "9",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "8",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "0",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "9",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "hyphen",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "open_bracket",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "equal_sign",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "close_bracket",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "q",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "quote",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "w",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "comma",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "e",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "period",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "r",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "p",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "t",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "y",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "y",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "u",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "g",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "c",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "o",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "r",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "p",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "l",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "open_bracket",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "slash",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "close_bracket",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "equal_sign",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "backslash",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "backslash",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "a",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "s",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "o",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "d",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "e",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "f",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "u",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "g",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "i",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "h",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "d",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "h",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "k",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "t",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "n",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "semicolon",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "s",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "quote",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "hyphen",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "z",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "semicolon",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "x",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "q",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "c",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "v",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "b",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "x",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "n",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "b",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "m",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "m",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "comma",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "w",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "period",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "v",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "slash",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "z",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "grave_accent_and_tilde",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "1",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "1",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "2",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "2",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "4",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "4",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "5",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "5",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "6",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "6",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "7",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "7",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "8",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "8",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "9",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "8",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "0",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "9",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "hyphen",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "open_bracket",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "equal_sign",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "close_bracket",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "q",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "quote",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "w",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "comma",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "e",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "period",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "r",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "p",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "t",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "y",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "y",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "u",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "g",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "c",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "o",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "r",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "p",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "l",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "open_bracket",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "slash",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "close_bracket",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "equal_sign",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "backslash",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "backslash",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "a",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "s",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "o",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "d",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "e",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "f",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "u",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "g",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "i",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "h",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "d",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "h",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "k",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "t",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "n",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "semicolon",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "s",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "quote",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "hyphen",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "z",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "semicolon",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "x",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "q",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "c",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "v",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "b",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "x",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "n",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "b",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "m",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "m",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "comma",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "w",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "period",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "v",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "slash",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_command",
+                "left_control",
+                "left_alt",
+                "right_command",
+                "right_control",
+                "right_alt"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "z",
+              "modifiers": [
+                "right_shift"
+              ]
             }
           ],
           "conditions": [

--- a/docs/json/dvorak_layout.json
+++ b/docs/json/dvorak_layout.json
@@ -1,0 +1,654 @@
+{
+  "title": "Dvorak Keyboard",
+  "rules": [
+    {
+      "description": "Remap keys to use Dvorak keyboard layout",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "grave_accent_and_tilde"
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "1"
+          },
+          "to": [
+            {
+              "key_code": "1"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "2"
+          },
+          "to": [
+            {
+              "key_code": "2"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "4"
+          },
+          "to": [
+            {
+              "key_code": "4"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "5"
+          },
+          "to": [
+            {
+              "key_code": "5"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "6"
+          },
+          "to": [
+            {
+              "key_code": "6"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "7"
+          },
+          "to": [
+            {
+              "key_code": "7"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "8"
+          },
+          "to": [
+            {
+              "key_code": "8"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "9"
+          },
+          "to": [
+            {
+              "key_code": "8"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "0"
+          },
+          "to": [
+            {
+              "key_code": "9"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "hyphen"
+          },
+          "to": [
+            {
+              "key_code": "open_bracket"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "equal_sign"
+          },
+          "to": [
+            {
+              "key_code": "close_bracket"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "q"
+          },
+          "to": [
+            {
+              "key_code": "quote"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "w"
+          },
+          "to": [
+            {
+              "key_code": "comma"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "e"
+          },
+          "to": [
+            {
+              "key_code": "."
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "r"
+          },
+          "to": [
+            {
+              "key_code": "p"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "t"
+          },
+          "to": [
+            {
+              "key_code": "y"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "y"
+          },
+          "to": [
+            {
+              "key_code": "f"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "u"
+          },
+          "to": [
+            {
+              "key_code": "g"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "i"
+          },
+          "to": [
+            {
+              "key_code": "c"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "o"
+          },
+          "to": [
+            {
+              "key_code": "r"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "p"
+          },
+          "to": [
+            {
+              "key_code": "l"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "open_bracket"
+          },
+          "to": [
+            {
+              "key_code": "slash"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "close_bracket"
+          },
+          "to": [
+            {
+              "key_code": "period"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "backslash"
+          },
+          "to": [
+            {
+              "key_code": "backslash"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "a"
+          },
+          "to": [
+            {
+              "key_code": "a"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "s"
+          },
+          "to": [
+            {
+              "key_code": "o"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "d"
+          },
+          "to": [
+            {
+              "key_code": "e"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "f"
+          },
+          "to": [
+            {
+              "key_code": "u"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "g"
+          },
+          "to": [
+            {
+              "key_code": "i"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "h"
+          },
+          "to": [
+            {
+              "key_code": "d"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "j"
+          },
+          "to": [
+            {
+              "key_code": "h"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "k"
+          },
+          "to": [
+            {
+              "key_code": "t"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "l"
+          },
+          "to": [
+            {
+              "key_code": "n"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "semicolon"
+          },
+          "to": [
+            {
+              "key_code": "s"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "quote"
+          },
+          "to": [
+            {
+              "key_code": "hyphen"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "z"
+          },
+          "to": [
+            {
+              "key_code": "semicolon"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "x"
+          },
+          "to": [
+            {
+              "key_code": "q"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "c"
+          },
+          "to": [
+            {
+              "key_code": "j"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "v"
+          },
+          "to": [
+            {
+              "key_code": "k"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "b"
+          },
+          "to": [
+            {
+              "key_code": "x"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "n"
+          },
+          "to": [
+            {
+              "key_code": "b"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "m"
+          },
+          "to": [
+            {
+              "key_code": "m"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "comma"
+          },
+          "to": [
+            {
+              "key_code": "w"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "period"
+          },
+          "to": [
+            {
+              "key_code": "v"
+            }
+          ],
+          "conditions": [
+
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "slash"
+          },
+          "to": [
+            {
+              "key_code": "z"
+            }
+          ],
+          "conditions": [
+
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/erb2json.rb
+++ b/scripts/erb2json.rb
@@ -18,14 +18,11 @@ def _from(key_code, mandatory_modifiers, optional_modifiers)
     data['modifiers']['optional'] = [] if data['modifiers']['optional'].nil?
     data['modifiers']['optional'] << m
   end
-  return data
+  data
 end
 
 def from(key_code, mandatory_modifiers, optional_modifiers)
-
-  data = _from(key_code, mandatory_modifiers, optional_modifiers)
-  JSON.generate(data)
-
+  JSON.generate(_from(key_code, mandatory_modifiers, optional_modifiers))
 end
 
 def _to(events)
@@ -40,13 +37,13 @@ def _to(events)
 
     data << d
   end
-  return data
+  data
 end
 
 def to(events)
-  data = to(events)
-  JSON.generate(data)
+  JSON.generate(_to(events))
 end
+
 
 def _each_key(source_keys_list, dest_keys_list, from_mandatory_modifiers, from_optional_modifiers, to_pre_events, to_modifiers, to_post_events, conditions)
   data = []
@@ -69,7 +66,7 @@ def _each_key(source_keys_list, dest_keys_list, from_mandatory_modifiers, from_o
     to_post_events.each do |e|
       events << e
     end
-    d['to'] = _to(events)
+    d['to'] = JSON.parse(to(events))
 
     d['conditions'] = []
     conditions.each do |c|
@@ -78,14 +75,11 @@ def _each_key(source_keys_list, dest_keys_list, from_mandatory_modifiers, from_o
     data << d
   end
 
-  return data
+  data
 end
 
 def each_key(source_keys_list, dest_keys_list, from_mandatory_modifiers, from_optional_modifiers, to_pre_events, to_modifiers, to_post_events, conditions)
-
-  data = _each_key(source_keys_list, dest_keys_list, from_mandatory_modifiers, from_optional_modifiers, to_pre_events, to_modifiers, to_post_events, conditions)
-  JSON.generate(data)
-
+  JSON.generate(_each_key(source_keys_list, dest_keys_list, from_mandatory_modifiers, from_optional_modifiers, to_pre_events, to_modifiers, to_post_events, conditions))
 end
 
 def frontmost_application(type, app_aliases)

--- a/scripts/erb2json.rb
+++ b/scripts/erb2json.rb
@@ -3,7 +3,7 @@
 require 'erb'
 require 'json'
 
-def from(key_code, mandatory_modifiers, optional_modifiers)
+def _from(key_code, mandatory_modifiers, optional_modifiers)
   data = {}
   data['key_code'] = key_code
 
@@ -18,11 +18,17 @@ def from(key_code, mandatory_modifiers, optional_modifiers)
     data['modifiers']['optional'] = [] if data['modifiers']['optional'].nil?
     data['modifiers']['optional'] << m
   end
-
-  JSON.generate(data)
+  return data
 end
 
-def to(events)
+def from()
+
+  data = _from(key_code, mandatory_modifiers, optional_modifiers)
+  JSON.generate(data)
+
+end
+
+def _to(events)
   data = []
 
   events.each do |e|
@@ -34,17 +40,21 @@ def to(events)
 
     data << d
   end
+  return data
+end
 
+def to(events)
+  data = to(events)
   JSON.generate(data)
 end
 
-def each_key(source_keys_list, dest_keys_list, from_mandatory_modifiers, from_optional_modifiers, to_pre_events, to_modifiers, to_post_events, conditions)
+def _each_key(source_keys_list, dest_keys_list, from_mandatory_modifiers, from_optional_modifiers, to_pre_events, to_modifiers, to_post_events, conditions)
   data = []
   source_keys_list.each_with_index do |from_key,index|
     to_key = dest_keys_list[index]
     d = {}
     d['type'] = 'basic'
-    d['from'] = JSON.parse(from(from_key, from_mandatory_modifiers, from_optional_modifiers))
+    d['from'] = _from(from_key, from_mandatory_modifiers, from_optional_modifiers)
 
     # Compile list of events to add to "to" section
     events = []
@@ -59,7 +69,7 @@ def each_key(source_keys_list, dest_keys_list, from_mandatory_modifiers, from_op
     to_post_events.each do |e|
       events << e
     end
-    d['to'] = JSON.parse(to(events))
+    d['to'] = _to(events)
 
     d['conditions'] = []
     conditions.each do |c|
@@ -68,7 +78,14 @@ def each_key(source_keys_list, dest_keys_list, from_mandatory_modifiers, from_op
     data << d
   end
 
+  return data
+end
+
+def each_key(source_keys_list, dest_keys_list, from_mandatory_modifiers, from_optional_modifiers, to_pre_events, to_modifiers, to_post_events, conditions)
+
+  data = _each_key(source_keys_list, dest_keys_list, from_mandatory_modifiers, from_optional_modifiers, to_pre_events, to_modifiers, to_post_events, conditions)
   JSON.generate(data)
+
 end
 
 def frontmost_application(type, app_aliases)

--- a/scripts/erb2json.rb
+++ b/scripts/erb2json.rb
@@ -38,12 +38,13 @@ def to(events)
   JSON.generate(data)
 end
 
-def each_key(keys_list, from_mandatory_modifiers, from_optional_modifiers, to_pre_events, to_modifiers, to_post_events, conditions)
+def each_key(source_keys_list, dest_keys_list, from_mandatory_modifiers, from_optional_modifiers, to_pre_events, to_modifiers, to_post_events, conditions)
   data = []
-  keys_list.each do |k|
+  source_keys_list.each_with_index do |from_key,index|
+    to_key = dest_keys_list[index]
     d = {}
     d['type'] = 'basic'
-    d['from'] = JSON.parse(from(k, from_mandatory_modifiers, from_optional_modifiers))
+    d['from'] = JSON.parse(from(from_key, from_mandatory_modifiers, from_optional_modifiers))
 
     # Compile list of events to add to "to" section
     events = []
@@ -51,9 +52,9 @@ def each_key(keys_list, from_mandatory_modifiers, from_optional_modifiers, to_pr
       events << e
     end
     if to_modifiers[0].nil?
-      events << [k]
+      events << [to_key]
     else
-      events << [k, to_modifiers]
+      events << [to_key, to_modifiers]
     end
     to_post_events.each do |e|
       events << e

--- a/scripts/erb2json.rb
+++ b/scripts/erb2json.rb
@@ -21,7 +21,7 @@ def _from(key_code, mandatory_modifiers, optional_modifiers)
   return data
 end
 
-def from()
+def from(key_code, mandatory_modifiers, optional_modifiers)
 
   data = _from(key_code, mandatory_modifiers, optional_modifiers)
   JSON.generate(data)

--- a/src/index.html.erb
+++ b/src/index.html.erb
@@ -48,6 +48,9 @@
       <%= file_import_panel("docs/json/swap_alt_cmd_in_autodesk_maya.json") %>
       <%= file_import_panel("docs/json/pok3r-media.json") %>
 
+      <!-- Full keyboard layouts -->
+      <%= file_import_panel("docs/json/dvorak_layout.json") %>
+
       <!-- For specific languages -->
       <%= file_import_panel("docs/json/japanese.json") %>
 

--- a/src/json/dvorak_layout.json.erb
+++ b/src/json/dvorak_layout.json.erb
@@ -1,0 +1,33 @@
+{
+    <%
+        remap_source_keys = [
+			"grave_accent_and_tilde","1","2","4","5","6","7","8","9","0","hyphen","equal_sign",
+			"q","w","e","r","t","y","u","i","o","p","open_bracket","close_bracket","backslash",
+			"a","s","d","f","g","h","j","k","l","semicolon","quote",
+			"z","x","c","v","b","n","m","comma","period","slash",
+		]
+        remap_dest_keys = [
+			"grave_accent_and_tilde","1","2","4","5","6","7","8","8","9","open_bracket","close_bracket",
+			"quote","comma",".","p","y","f","g","c","r","l","slash","period","backslash",
+			"a","o","e","u","i","d","h","t","n","s","hyphen",
+			"semicolon","q","j","k","x","b","m","w","v","z",
+        ]
+    %>
+    "title": "Dvorak Keyboard",
+    "rules": [
+        {
+            "description": "Remap keys to use Dvorak keyboard layout",
+            "manipulators":
+            <%= each_key(
+                remap_source_keys, 	# source_keys_list
+                remap_dest_keys,	# dest_keyslist
+                [],                 # from_mandatory_modifiers
+                [],                 # from_optional_modifiers
+                [],                 # to_pre_events
+                [],                 # to_modifiers
+                [],                 # to_post_events
+                []                  # conditions
+            ) %>
+        }
+    ]
+}

--- a/src/json/dvorak_layout.json.erb
+++ b/src/json/dvorak_layout.json.erb
@@ -1,5 +1,6 @@
 {
     <%
+        optional_modifiers = ["caps_lock","left_command","left_control","left_alt","right_command","right_control","right_alt"]
         remap_source_keys = [
 			"grave_accent_and_tilde","1","2","4","5","6","7","8","9","0","hyphen","equal_sign",
 			"q","w","e","r","t","y","u","i","o","p","open_bracket","close_bracket","backslash",
@@ -8,26 +9,47 @@
 		]
         remap_dest_keys = [
 			"grave_accent_and_tilde","1","2","4","5","6","7","8","8","9","open_bracket","close_bracket",
-			"quote","comma",".","p","y","f","g","c","r","l","slash","period","backslash",
+			"quote","comma","period","p","y","f","g","c","r","l","slash","equal_sign","backslash",
 			"a","o","e","u","i","d","h","t","n","s","hyphen",
 			"semicolon","q","j","k","x","b","m","w","v","z",
         ]
+        manipulators = _each_key(
+            remap_source_keys, 	# source_keys_list
+            remap_dest_keys,	# dest_keyslist
+            [],                 # from_mandatory_modifiers
+            optional_modifiers, # from_optional_modifiers
+            [],                 # to_pre_events
+            [],                 # to_modifiers
+            [],                 # to_post_events
+            []                  # conditions
+        )
+        manipulators += _each_key(
+            remap_source_keys, 	# source_keys_list
+            remap_dest_keys,	# dest_keyslist
+            ["left_shift"],     # from_mandatory_modifiers
+            optional_modifiers, # from_optional_modifiers
+            [],                 # to_pre_events
+            ["left_shift"],     # to_modifiers
+            [],                 # to_post_events
+            []                  # conditions
+        )
+        manipulators += _each_key(
+            remap_source_keys, 	# source_keys_list
+            remap_dest_keys,	# dest_keyslist
+            ["right_shift"],    # from_mandatory_modifiers
+            optional_modifiers, # from_optional_modifiers
+            [],                 # to_pre_events
+            ["right_shift"],    # to_modifiers
+            [],                 # to_post_events
+            []                  # conditions
+        )
     %>
     "title": "Dvorak Keyboard",
     "rules": [
         {
             "description": "Remap keys to use Dvorak keyboard layout",
             "manipulators":
-            <%= each_key(
-                remap_source_keys, 	# source_keys_list
-                remap_dest_keys,	# dest_keyslist
-                [],                 # from_mandatory_modifiers
-                [],                 # from_optional_modifiers
-                [],                 # to_pre_events
-                [],                 # to_modifiers
-                [],                 # to_post_events
-                []                  # conditions
-            ) %>
+            <%= JSON.generate(manipulators) %>
         }
     ]
 }

--- a/src/json/tmux_prefix.json.erb
+++ b/src/json/tmux_prefix.json.erb
@@ -38,45 +38,48 @@
             "description": "Tmux Prefix Mode [ ctrl+B as prefix ]",
             "manipulators":
             <%= each_key(
-                default_tmux_keys,
-                [],
-                ["caps_lock"],
-                [
+                default_tmux_keys, 	# source_keys_list
+                default_tmux_keys,	# dest_keyslist
+                [],                 # from_mandatory_modifiers
+                ["caps_lock"],      # from_optional_modifiers
+                [                   # to_pre_events
                     ["b", ["left_control"]],
                 ],
-                [],
-                [],
-                [{"type"=>"variable_if","name"=>"tmux_prefix_mode","value"=>1}]
+                [],                 # to_modifiers
+                [],                 # to_post_events
+                [{"type"=>"variable_if","name"=>"tmux_prefix_mode","value"=>1}]                  # conditions
             ) %>
         },
         {
             "description": "Tmux Prefix Mode [ ctrl+A as prefix ]",
             "manipulators":
             <%= each_key(
-                default_tmux_keys,
-                [],
-                ["caps_lock"],
-                [
+                default_tmux_keys, 	# source_keys_list
+                default_tmux_keys,	# dest_keyslist
+                [],                 # from_mandatory_modifiers
+                ["caps_lock"],      # from_optional_modifiers
+                [                   # to_pre_events
                     ["a", ["left_control"]],
                 ],
-                [],
-                [],
-                [{"type"=>"variable_if","name"=>"tmux_prefix_mode","value"=>1}]
+                [],                 # to_modifiers
+                [],                 # to_post_events
+                [{"type"=>"variable_if","name"=>"tmux_prefix_mode","value"=>1}]                  # conditions
             ) %>
         },
         {
             "description": "Tmux Prefix Mode [ ctrl+Space as prefix ]",
             "manipulators":
             <%= each_key(
-                default_tmux_keys,
-                [],
-                ["caps_lock"],
-                [
+                default_tmux_keys, 	# source_keys_list
+                default_tmux_keys,	# dest_keyslist
+                [],                 # from_mandatory_modifiers
+                ["caps_lock"],      # from_optional_modifiers
+                [                   # to_pre_events
                     ["spacebar", ["left_control"]],
                 ],
-                [],
-                [],
-                [{"type"=>"variable_if","name"=>"tmux_prefix_mode","value"=>1}]
+                [],                 # to_modifiers
+                [],                 # to_post_events
+                [{"type"=>"variable_if","name"=>"tmux_prefix_mode","value"=>1}]                  # conditions
             ) %>
         }
     ]


### PR DESCRIPTION
In order to create a quick way to map a lot of keys from one key to another, I updated each_key() to include one more parameter: dest_keys_list. Now you can easily map "a", "b", "c" to "x","y","z", which is very useful for creating recipes for alternative keyboard layouts like Dvorak. (Note: I had to updated my tmux recipe to work with this)

In addition, I renamed from() and to() to _from() and _to() and made it only return the data object (instead of printing the JSON generated).  This allows more flexibility so I can use those functions inside each_key() without having to parse the JSON. 

But don't worry, I added wrapper from() and to() so all existing recipes are still valid.