### PR TITLE
Update each_key with a few niceties

### DIFF
--- a/docs/json/dvorak_layout.json
+++ b/docs/json/dvorak_layout.json
@@ -24,9 +24,6 @@
             {
               "key_code": "grave_accent_and_tilde"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -49,9 +46,6 @@
             {
               "key_code": "1"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -74,9 +68,6 @@
             {
               "key_code": "2"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -99,9 +90,6 @@
             {
               "key_code": "4"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -124,9 +112,6 @@
             {
               "key_code": "5"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -149,9 +134,6 @@
             {
               "key_code": "6"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -174,9 +156,6 @@
             {
               "key_code": "7"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -199,9 +178,6 @@
             {
               "key_code": "8"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -224,9 +200,6 @@
             {
               "key_code": "8"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -249,9 +222,6 @@
             {
               "key_code": "9"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -274,9 +244,6 @@
             {
               "key_code": "open_bracket"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -299,9 +266,6 @@
             {
               "key_code": "close_bracket"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -324,9 +288,6 @@
             {
               "key_code": "quote"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -349,9 +310,6 @@
             {
               "key_code": "comma"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -374,9 +332,6 @@
             {
               "key_code": "period"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -399,9 +354,6 @@
             {
               "key_code": "p"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -424,9 +376,6 @@
             {
               "key_code": "y"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -449,9 +398,6 @@
             {
               "key_code": "f"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -474,9 +420,6 @@
             {
               "key_code": "g"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -499,9 +442,6 @@
             {
               "key_code": "c"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -524,9 +464,6 @@
             {
               "key_code": "r"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -549,9 +486,6 @@
             {
               "key_code": "l"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -574,9 +508,6 @@
             {
               "key_code": "slash"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -599,9 +530,6 @@
             {
               "key_code": "equal_sign"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -624,9 +552,6 @@
             {
               "key_code": "backslash"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -649,9 +574,6 @@
             {
               "key_code": "a"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -674,9 +596,6 @@
             {
               "key_code": "o"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -699,9 +618,6 @@
             {
               "key_code": "e"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -724,9 +640,6 @@
             {
               "key_code": "u"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -749,9 +662,6 @@
             {
               "key_code": "i"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -774,9 +684,6 @@
             {
               "key_code": "d"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -799,9 +706,6 @@
             {
               "key_code": "h"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -824,9 +728,6 @@
             {
               "key_code": "t"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -849,9 +750,6 @@
             {
               "key_code": "n"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -874,9 +772,6 @@
             {
               "key_code": "s"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -899,9 +794,6 @@
             {
               "key_code": "hyphen"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -924,9 +816,6 @@
             {
               "key_code": "semicolon"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -949,9 +838,6 @@
             {
               "key_code": "q"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -974,9 +860,6 @@
             {
               "key_code": "j"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -999,9 +882,6 @@
             {
               "key_code": "k"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1024,9 +904,6 @@
             {
               "key_code": "x"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1049,9 +926,6 @@
             {
               "key_code": "b"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1074,9 +948,6 @@
             {
               "key_code": "m"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1099,9 +970,6 @@
             {
               "key_code": "w"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1124,9 +992,6 @@
             {
               "key_code": "v"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1149,9 +1014,6 @@
             {
               "key_code": "z"
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1180,9 +1042,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1211,9 +1070,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1242,9 +1098,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1273,9 +1126,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1304,9 +1154,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1335,9 +1182,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1366,9 +1210,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1397,9 +1238,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1428,9 +1266,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1459,9 +1294,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1490,9 +1322,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1521,9 +1350,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1552,9 +1378,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1583,9 +1406,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1614,9 +1434,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1645,9 +1462,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1676,9 +1490,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1707,9 +1518,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1738,9 +1546,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1769,9 +1574,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1800,9 +1602,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1831,9 +1630,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1862,9 +1658,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1893,9 +1686,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1924,9 +1714,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1955,9 +1742,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -1986,9 +1770,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2017,9 +1798,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2048,9 +1826,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2079,9 +1854,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2110,9 +1882,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2141,9 +1910,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2172,9 +1938,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2203,9 +1966,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2234,9 +1994,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2265,9 +2022,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2296,9 +2050,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2327,9 +2078,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2358,9 +2106,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2389,9 +2134,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2420,9 +2162,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2451,9 +2190,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2482,9 +2218,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2513,9 +2246,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2544,9 +2274,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2575,9 +2302,6 @@
                 "left_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2606,9 +2330,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2637,9 +2358,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2668,9 +2386,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2699,9 +2414,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2730,9 +2442,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2761,9 +2470,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2792,9 +2498,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2823,9 +2526,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2854,9 +2554,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2885,9 +2582,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2916,9 +2610,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2947,9 +2638,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -2978,9 +2666,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3009,9 +2694,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3040,9 +2722,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3071,9 +2750,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3102,9 +2778,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3133,9 +2806,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3164,9 +2834,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3195,9 +2862,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3226,9 +2890,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3257,9 +2918,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3288,9 +2946,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3319,9 +2974,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3350,9 +3002,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3381,9 +3030,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3412,9 +3058,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3443,9 +3086,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3474,9 +3114,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3505,9 +3142,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3536,9 +3170,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3567,9 +3198,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3598,9 +3226,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3629,9 +3254,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3660,9 +3282,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3691,9 +3310,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3722,9 +3338,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3753,9 +3366,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3784,9 +3394,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3815,9 +3422,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3846,9 +3450,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3877,9 +3478,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3908,9 +3506,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3939,9 +3534,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -3970,9 +3562,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         },
         {
@@ -4001,9 +3590,6 @@
                 "right_shift"
               ]
             }
-          ],
-          "conditions": [
-
           ]
         }
       ]

--- a/scripts/erb2json.rb
+++ b/scripts/erb2json.rb
@@ -77,11 +77,11 @@ def each_key(source_keys_list: :source_keys_list, dest_keys_list: :dest_keys_lis
     data << d
   end
 
-  data
-end
-
-def each_key(source_keys_list, dest_keys_list, from_mandatory_modifiers, from_optional_modifiers, to_pre_events, to_modifiers, to_post_events, conditions)
-  JSON.generate(_each_key(source_keys_list, dest_keys_list, from_mandatory_modifiers, from_optional_modifiers, to_pre_events, to_modifiers, to_post_events, conditions))
+  if as_json
+    JSON.generate(data)
+  else
+    data
+  end
 end
 
 def frontmost_application(type, app_aliases)

--- a/scripts/erb2json.rb
+++ b/scripts/erb2json.rb
@@ -68,9 +68,11 @@ def each_key(source_keys_list: :source_keys_list, dest_keys_list: :dest_keys_lis
     end
     d['to'] = JSON.parse(to(events))
 
-    d['conditions'] = []
-    conditions.each do |c|
-      d['conditions'] << c
+    if conditions.any?
+      d['conditions'] = []
+      conditions.each do |c|
+        d['conditions'] << c
+      end
     end
     data << d
   end

--- a/scripts/erb2json.rb
+++ b/scripts/erb2json.rb
@@ -45,7 +45,7 @@ def to(events)
 end
 
 
-def _each_key(source_keys_list, dest_keys_list, from_mandatory_modifiers, from_optional_modifiers, to_pre_events, to_modifiers, to_post_events, conditions)
+def each_key(source_keys_list: :source_keys_list, dest_keys_list: :dest_keys_list, from_mandatory_modifiers: [], from_optional_modifiers: [], to_pre_events: [], to_modifiers: [], to_post_events: [], conditions: [], as_json: false)
   data = []
   source_keys_list.each_with_index do |from_key,index|
     to_key = dest_keys_list[index]

--- a/src/json/dvorak_layout.json.erb
+++ b/src/json/dvorak_layout.json.erb
@@ -13,35 +13,24 @@
 			"a","o","e","u","i","d","h","t","n","s","hyphen",
 			"semicolon","q","j","k","x","b","m","w","v","z",
         ]
-        manipulators = _each_key(
-            remap_source_keys, 	# source_keys_list
-            remap_dest_keys,	# dest_keyslist
-            [],                 # from_mandatory_modifiers
-            optional_modifiers, # from_optional_modifiers
-            [],                 # to_pre_events
-            [],                 # to_modifiers
-            [],                 # to_post_events
-            []                  # conditions
+        manipulators = each_key(
+            source_keys_list: remap_source_keys,
+            dest_keys_list: remap_dest_keys,
+            from_optional_modifiers: optional_modifiers
         )
-        manipulators += _each_key(
-            remap_source_keys, 	# source_keys_list
-            remap_dest_keys,	# dest_keyslist
-            ["left_shift"],     # from_mandatory_modifiers
-            optional_modifiers, # from_optional_modifiers
-            [],                 # to_pre_events
-            ["left_shift"],     # to_modifiers
-            [],                 # to_post_events
-            []                  # conditions
+        manipulators += each_key(
+            source_keys_list: remap_source_keys,
+            dest_keys_list: remap_dest_keys,
+            from_mandatory_modifiers: ["left_shift"],
+            from_optional_modifiers: optional_modifiers,
+            to_modifiers: ["left_shift"]
         )
-        manipulators += _each_key(
-            remap_source_keys, 	# source_keys_list
-            remap_dest_keys,	# dest_keyslist
-            ["right_shift"],    # from_mandatory_modifiers
-            optional_modifiers, # from_optional_modifiers
-            [],                 # to_pre_events
-            ["right_shift"],    # to_modifiers
-            [],                 # to_post_events
-            []                  # conditions
+        manipulators += each_key(
+            source_keys_list: remap_source_keys,
+            dest_keys_list: remap_dest_keys,
+            from_mandatory_modifiers: ["right_shift"],
+            from_optional_modifiers: optional_modifiers,
+            to_modifiers: ["right_shift"]
         )
     %>
     "title": "Dvorak Keyboard",

--- a/src/json/tmux_prefix.json.erb
+++ b/src/json/tmux_prefix.json.erb
@@ -44,48 +44,45 @@
             "description": "Tmux Prefix Mode [ ctrl+B as prefix ]",
             "manipulators":
             <%= each_key(
-                default_tmux_keys, 	# source_keys_list
-                default_tmux_keys,	# dest_keyslist
-                [],                 # from_mandatory_modifiers
-                ["caps_lock"],      # from_optional_modifiers
-                [                   # to_pre_events
+                source_keys_list: default_tmux_keys,
+                dest_keys_list: default_tmux_keys,
+                from_mandatory_modifiers: [],
+                from_optional_modifiers: ["caps_lock"],
+                to_pre_events: [
                     ["b", ["left_control"]],
                 ],
-                [],                 # to_modifiers
-                [],                 # to_post_events
-                [{"type"=>"variable_if","name"=>"tmux_prefix_mode","value"=>1}]                  # conditions
+                conditions: [{"type"=>"variable_if","name"=>"tmux_prefix_mode","value"=>1}],
+                as_json: true
             ) %>
         },
         {
             "description": "Tmux Prefix Mode [ ctrl+A as prefix ]",
             "manipulators":
             <%= each_key(
-                default_tmux_keys, 	# source_keys_list
-                default_tmux_keys,	# dest_keyslist
-                [],                 # from_mandatory_modifiers
-                ["caps_lock"],      # from_optional_modifiers
-                [                   # to_pre_events
+                source_keys_list: default_tmux_keys,
+                dest_keys_list: default_tmux_keys,
+                from_mandatory_modifiers: [],
+                from_optional_modifiers: ["caps_lock"],
+                to_pre_events: [
                     ["a", ["left_control"]],
                 ],
-                [],                 # to_modifiers
-                [],                 # to_post_events
-                [{"type"=>"variable_if","name"=>"tmux_prefix_mode","value"=>1}]                  # conditions
+                conditions: [{"type"=>"variable_if","name"=>"tmux_prefix_mode","value"=>1}],
+                as_json: true
             ) %>
         },
         {
             "description": "Tmux Prefix Mode [ ctrl+Space as prefix ]",
             "manipulators":
             <%= each_key(
-                default_tmux_keys, 	# source_keys_list
-                default_tmux_keys,	# dest_keyslist
-                [],                 # from_mandatory_modifiers
-                ["caps_lock"],      # from_optional_modifiers
-                [                   # to_pre_events
+                source_keys_list: default_tmux_keys,
+                dest_keys_list: default_tmux_keys,
+                from_mandatory_modifiers: [],
+                from_optional_modifiers: ["caps_lock"],
+                to_pre_events: [
                     ["spacebar", ["left_control"]],
                 ],
-                [],                 # to_modifiers
-                [],                 # to_post_events
-                [{"type"=>"variable_if","name"=>"tmux_prefix_mode","value"=>1}]                  # conditions
+                conditions: [{"type"=>"variable_if","name"=>"tmux_prefix_mode","value"=>1}],
+                as_json: true
             ) %>
         }
     ]


### PR DESCRIPTION
This PR combines `each_key` and `_each_key` into one function, which leverages keyword arguments to make function calls more readable and less verbose (i.e. you don't have to pass unused arguments). It also adds a check for presence of `conditions` to prevent them from showing up as a value-less key in the final JSON file.