### PR TITLE
Pok3r Escape Key

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -351,6 +351,15 @@
     </div>
     <div class="panel panel-default">
       <div class="panel-heading">
+        <a class="panel-title btn btn-link" role="button" data-toggle="collapse" href="#pok3r-escape" aria-expanded="false" aria-controls="pok3r-escape">Pok3r Escape Key</a>
+        <a class="btn btn-primary btn-sm pull-right" data-json-path="json/pok3r-escape.json">Import</a>
+      </div>
+      <div class="list-group collapse" id="pok3r-escape">
+          <div class="list-group-item">Pok3r Escape key (grave_accent_and_tilde as Escape and fn + grave_accent_and_tilde as grave_accent_and_tilde)</div>
+      </div>
+    </div>
+    <div class="panel panel-default">
+      <div class="panel-heading">
         <a class="panel-title btn btn-link" role="button" data-toggle="collapse" href="#pc_shortcuts" aria-expanded="false" aria-controls="pc_shortcuts">PC-Style Shortcuts</a>
         <a class="btn btn-primary btn-sm pull-right" data-json-path="json/pc_shortcuts.json">Import</a>
       </div>

--- a/docs/json/pok3r-escape.json
+++ b/docs/json/pok3r-escape.json
@@ -1,0 +1,40 @@
+{
+  "title": "Pok3r Escape Key",
+  "rules": [
+    {
+      "description": "Pok3r Escape key on 'grave_accent_and_tilde', and grave accent as fn+grave_accent_and_tilde",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "grave_accent_and_tilde",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "grave_accent_and_tilde"
+          },
+          "to": [
+            {
+              "key_code": "escape"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/json/pok3r-escape.json
+++ b/docs/json/pok3r-escape.json
@@ -2,7 +2,7 @@
   "title": "Pok3r Escape Key",
   "rules": [
     {
-      "description": "Pok3r Escape key on 'grave_accent_and_tilde', and grave accent as fn+grave_accent_and_tilde",
+      "description": "Pok3r Escape key (grave_accent_and_tilde as Escape and fn + grave_accent_and_tilde as grave_accent_and_tilde)",
       "manipulators": [
         {
           "type": "basic",


### PR DESCRIPTION
* Adding a complex modification to support Pok3r style escape key. [_grave_accent_and_tilde_] becomes [_escape_] and [_fn_]+[_grave_accent_and_tilde_] becomes [_grave_accent_and_tilde_].
* No changes to the current behavior of the [_escape_] key are made.
* Pairs really well with the "Map fn + number keys to function keys" on new MacBooks (>= 2016) where the [_escape_] and function keys [F1 ~ F12] are all virtual keys in the touch bar.