### PR TITLE
add mappings for exchange_hyphen_and_underscore and exchange_underscore_and_backslash

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,7 @@
 
       
 
-      <ul class="toc list-group"><li class="list-group-item list-group-item-info">Table of Contents</li><li class="list-group-item"><span class="badge">10</span><a href="#modifier_keys">Modifier Keys</a></li><li class="list-group-item"><span class="badge">11</span><a href="#emulation_modes">Emulation Modes</a></li><li class="list-group-item"><span class="badge">4</span><a href="#application_specific">Application Specific</a></li><li class="list-group-item"><span class="badge">2</span><a href="#alternative_keyboard_layouts">Alternative Keyboard Layouts</a></li><li class="list-group-item"><span class="badge">1</span><a href="#International">International (Language Specific)</a></li><li class="list-group-item"><span class="badge">5</span><a href="#key_specific">Key Specific</a></li><li class="list-group-item"><span class="badge">2</span><a href="#os_functionality">OS Functionality</a></li><li class="list-group-item"><span class="badge">3</span><a href="#personal_settings">Personal Settings</a></li><li class="list-group-item"><span class="badge">1</span><a href="#miscellaneous">Miscellaneous</a></li></ul>
+      <ul class="toc list-group"><li class="list-group-item list-group-item-info">Table of Contents</li><li class="list-group-item"><span class="badge">10</span><a href="#modifier_keys">Modifier Keys</a></li><li class="list-group-item"><span class="badge">11</span><a href="#emulation_modes">Emulation Modes</a></li><li class="list-group-item"><span class="badge">4</span><a href="#application_specific">Application Specific</a></li><li class="list-group-item"><span class="badge">2</span><a href="#alternative_keyboard_layouts">Alternative Keyboard Layouts</a></li><li class="list-group-item"><span class="badge">1</span><a href="#International">International (Language Specific)</a></li><li class="list-group-item"><span class="badge">5</span><a href="#key_specific">Key Specific</a></li><li class="list-group-item"><span class="badge">2</span><a href="#os_functionality">OS Functionality</a></li><li class="list-group-item"><span class="badge">3</span><a href="#personal_settings">Personal Settings</a></li><li class="list-group-item"><span class="badge">3</span><a href="#miscellaneous">Miscellaneous</a></li></ul>
       <div class="text-left" style="margin-bottom: 30px">
         <a href="javascript:$('.collapse').collapse('show')">Expand All</a> |
         <a href="javascript:$('.collapse').collapse('hide')">Collapse All</a>
@@ -655,6 +655,24 @@
       </div>
       <div class="list-group collapse" id="block_one_handed_combos">
           <div class="list-group-item">Block left-handed command + left-handed key</div><div class="list-group-item">Block left-handed shift + left-handed key</div><div class="list-group-item">Block left-handed option + left-handed key</div><div class="list-group-item">Block left-handed control + left-handed key</div><div class="list-group-item">Block right-handed command + right-handed key</div><div class="list-group-item">Block right-handed shift + right-handed key</div><div class="list-group-item">Block right-handed option + right-handed key</div><div class="list-group-item">Block right-handed control + right-handed key</div>
+      </div>
+    </div>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <a class="panel-title btn btn-link" role="button" data-toggle="collapse" href="#exchange_hyphen_and_underscore" aria-expanded="false" aria-controls="exchange_hyphen_and_underscore">Exchange hyphen and underscore</a>
+        <a class="btn btn-primary btn-sm pull-right" data-json-path="json/exchange_hyphen_and_underscore.json">Import</a>
+      </div>
+      <div class="list-group collapse" id="exchange_hyphen_and_underscore">
+          <div class="list-group-item">Exchange hyphen and underscore</div>
+      </div>
+    </div>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <a class="panel-title btn btn-link" role="button" data-toggle="collapse" href="#exchange_underscore_and_backslash" aria-expanded="false" aria-controls="exchange_underscore_and_backslash">Exchange underscore and backslash</a>
+        <a class="btn btn-primary btn-sm pull-right" data-json-path="json/exchange_underscore_and_backslash.json">Import</a>
+      </div>
+      <div class="list-group collapse" id="exchange_underscore_and_backslash">
+          <div class="list-group-item">Exchange underscore and backslash</div>
       </div>
     </div>
 

--- a/docs/json/exchange_hyphen_and_underscore.json
+++ b/docs/json/exchange_hyphen_and_underscore.json
@@ -1,0 +1,48 @@
+{
+  "title": "Exchange hyphen and underscore",
+  "rules": [
+    {
+      "description": "Exchange hyphen and underscore",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "hyphen",
+            "modifiers": {
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "hyphen",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "hyphen",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "hyphen"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/json/exchange_underscore_and_backslash.json
+++ b/docs/json/exchange_underscore_and_backslash.json
@@ -1,0 +1,48 @@
+{
+  "title": "Exchange underscore and backslash",
+  "rules": [
+    {
+      "description": "Exchange underscore and backslash",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "backslash",
+            "modifiers": {
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "hyphen",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "hyphen",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "backslash"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/index.html.erb
+++ b/src/index.html.erb
@@ -89,7 +89,9 @@
           ])
 
           add_group("Miscellaneous","miscellaneous",[
-              "docs/json/block_one_handed_combos.json"
+              "docs/json/block_one_handed_combos.json",
+              "docs/json/exchange_hyphen_and_underscore.json",
+              "docs/json/exchange_underscore_and_backslash.json"
           ])
 
       %>

--- a/src/json/exchange_hyphen_and_underscore.json.erb
+++ b/src/json/exchange_hyphen_and_underscore.json.erb
@@ -1,0 +1,13 @@
+{
+    "title": "Exchange hyphen and underscore",
+    "rules": [
+        {
+            "description": "Exchange hyphen and underscore",
+            "manipulators": [
+                { "type": "basic", "from": <%= from("hyphen", [], ["caps_lock"]) %>, "to": <%= to([["hyphen", ["left_shift"]]]) %> },
+
+                { "type": "basic", "from": <%= from("hyphen", ["shift"], ["caps_lock"]) %>, "to": <%= to([["hyphen"]]) %> }
+            ]
+        }
+    ]
+}

--- a/src/json/exchange_underscore_and_backslash.json.erb
+++ b/src/json/exchange_underscore_and_backslash.json.erb
@@ -1,0 +1,13 @@
+{
+    "title": "Exchange underscore and backslash",
+    "rules": [
+        {
+            "description": "Exchange underscore and backslash",
+            "manipulators": [
+                { "type": "basic", "from": <%= from("backslash", [], ["caps_lock"]) %>, "to": <%= to([["hyphen", ["left_shift"]]]) %> },
+
+                { "type": "basic", "from": <%= from("hyphen", ["shift"], ["caps_lock"]) %>, "to": <%= to([["backslash"]]) %> }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
I'd like to add a default complex modification for hyphen and underscore, as well as underscore and backslash (I and some colleagues use the latter to minimize needing to use shift with underscore or hyphen, lots of people use the hyphen - underscore swap I think).

If you look at:
https://github.com/tekezo/Karabiner-Elements/issues/329
will you see at least a couple people wanting this.

Cheers :)

