### PR TITLE
Add caps lock to slash/backslash (German keyboard layout)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,7 @@
 
       
 
-      <ul class="toc list-group"><li class="list-group-item list-group-item-info">Table of Contents</li><li class="list-group-item"><span class="badge">10</span><a href="#modifier_keys">Modifier Keys</a></li><li class="list-group-item"><span class="badge">11</span><a href="#emulation_modes">Emulation Modes</a></li><li class="list-group-item"><span class="badge">4</span><a href="#application_specific">Application Specific</a></li><li class="list-group-item"><span class="badge">2</span><a href="#alternative_keyboard_layouts">Alternative Keyboard Layouts</a></li><li class="list-group-item"><span class="badge">1</span><a href="#International">International (Language Specific)</a></li><li class="list-group-item"><span class="badge">5</span><a href="#key_specific">Key Specific</a></li><li class="list-group-item"><span class="badge">2</span><a href="#os_functionality">OS Functionality</a></li><li class="list-group-item"><span class="badge">3</span><a href="#personal_settings">Personal Settings</a></li><li class="list-group-item"><span class="badge">1</span><a href="#miscellaneous">Miscellaneous</a></li></ul>
+      <ul class="toc list-group"><li class="list-group-item list-group-item-info">Table of Contents</li><li class="list-group-item"><span class="badge">10</span><a href="#modifier_keys">Modifier Keys</a></li><li class="list-group-item"><span class="badge">11</span><a href="#emulation_modes">Emulation Modes</a></li><li class="list-group-item"><span class="badge">4</span><a href="#application_specific">Application Specific</a></li><li class="list-group-item"><span class="badge">3</span><a href="#alternative_keyboard_layouts">Alternative Keyboard Layouts</a></li><li class="list-group-item"><span class="badge">1</span><a href="#International">International (Language Specific)</a></li><li class="list-group-item"><span class="badge">5</span><a href="#key_specific">Key Specific</a></li><li class="list-group-item"><span class="badge">2</span><a href="#os_functionality">OS Functionality</a></li><li class="list-group-item"><span class="badge">3</span><a href="#personal_settings">Personal Settings</a></li><li class="list-group-item"><span class="badge">1</span><a href="#miscellaneous">Miscellaneous</a></li></ul>
       <div class="text-left" style="margin-bottom: 30px">
         <a href="javascript:$('.collapse').collapse('show')">Expand All</a> |
         <a href="javascript:$('.collapse').collapse('hide')">Collapse All</a>
@@ -455,6 +455,15 @@
         </div>
         <div class="panel-body">
               <div class="panel panel-default">
+      <div class="panel-heading">
+        <a class="panel-title btn btn-link" role="button" data-toggle="collapse" href="#caps_lock_german" aria-expanded="false" aria-controls="caps_lock_german">Change caps_lock key (German keyboard layout)</a>
+        <a class="btn btn-primary btn-sm pull-right" data-json-path="json/caps_lock_german.json">Import</a>
+      </div>
+      <div class="list-group collapse" id="caps_lock_german">
+          <div class="list-group-item">Change caps_lock key to slash.</div><div class="list-group-item">Change caps_lock key to backslash.</div>
+      </div>
+    </div>
+    <div class="panel panel-default">
       <div class="panel-heading">
         <a class="panel-title btn btn-link" role="button" data-toggle="collapse" href="#dvorak_layout" aria-expanded="false" aria-controls="dvorak_layout">Dvorak Keyboard</a>
         <a class="btn btn-primary btn-sm pull-right" data-json-path="json/dvorak_layout.json">Import</a>

--- a/docs/json/caps_lock_german.json
+++ b/docs/json/caps_lock_german.json
@@ -1,0 +1,63 @@
+{
+  "title": "Change caps_lock key (German keyboard layout)",
+  "rules": [
+    {
+      "description": "Change caps_lock key to slash.",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "caps_lock",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "7",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "escape"
+            }
+          ]
+        }
+      ]
+    },{
+      "description": "Change caps_lock key to backslash.",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "caps_lock",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "7",
+              "modifiers": [
+                "left_option",
+                "left_shift"
+              ]
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "escape"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/index.html.erb
+++ b/src/index.html.erb
@@ -61,6 +61,7 @@
           ])
 
           add_group("Alternative Keyboard Layouts","alternative_keyboard_layouts",[
+              "docs/json/caps_lock_german.json",
               "docs/json/dvorak_layout.json",
               "docs/json/colemak_layout.json"
           ])


### PR DESCRIPTION
Since it's not possible to address slash and backslash with Karabiner on a German keyboard, I added these two complex mods in order to redirect caps lock to these keys.