### PR TITLE
do not fix path to ruby executable (for make)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 all:
-	sh scripts/update-json.sh
-	/usr/bin/ruby scripts/erb2html.rb < src/index.html.erb > docs/index.html
-	/usr/bin/ruby scripts/erb2html.rb < src/example.html.erb > docs/example.html
-	sh scripts/apply-lint.sh
+	scripts/update-json.sh
+	scripts/erb2html.rb < src/index.html.erb > docs/index.html
+	scripts/erb2html.rb < src/example.html.erb > docs/example.html
+	scripts/apply-lint.sh
 
 rebuild:
 	touch src/json/*

--- a/scripts/apply-lint.sh
+++ b/scripts/apply-lint.sh
@@ -2,5 +2,5 @@
 
 for srcfile in docs/json/*.json; do
   echo "check $srcfile"
-  /usr/bin/ruby scripts/lint.rb < "$srcfile" || exit 1
+  scripts/lint.rb < "$srcfile" || exit 1
 done

--- a/scripts/erb2html.rb
+++ b/scripts/erb2html.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 require 'erb'
 require 'json'

--- a/scripts/erb2json.rb
+++ b/scripts/erb2json.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 require 'erb'
 require 'json'

--- a/scripts/lint.rb
+++ b/scripts/lint.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 require 'json'
 

--- a/scripts/update-json.sh
+++ b/scripts/update-json.sh
@@ -3,7 +3,7 @@
 for srcfile in src/json/*.erb; do
   dstfile="docs/json/`basename $srcfile .erb`"
   if [ "$srcfile" -nt "$dstfile" ]; then
-    if /usr/bin/ruby scripts/erb2json.rb < "$srcfile" > "$dstfile"; then
+    if scripts/erb2json.rb < "$srcfile" > "$dstfile"; then
       echo "$dstfile"
     else
       rm -f "$dstfile"


### PR DESCRIPTION
With `/usr/bin/ruby` fixed path,
`make` fails if user installed ruby by such Homebrew and has GEM_HOME for different version.

    $ make
    sh scripts/update-json.sh
    /usr/bin/ruby scripts/erb2html.rb < src/index.html.erb > docs/index.html
    /usr/local/gems/gems/json-2.1.0/lib/json/ext/parser.bundle: [BUG] Segmentation fault
    ruby 2.0.0p648 (2015-12-16 revision 53162) [universal.x86_64-darwin16]

    -- Crash Report log information --------------------------------------------
   ...

It is better to use `#/usr/bin/env ruby` as shebang, and commands are not necessary in Makefile.