### PR TITLE
Don't exit fullscreen when pressing ESC in Safari

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,7 @@
 
       
 
-      <ul class="toc list-group"><li class="list-group-item list-group-item-info">Table of Contents</li><li class="list-group-item"><span class="badge">10</span><a href="#modifier_keys">Modifier Keys</a></li><li class="list-group-item"><span class="badge">13</span><a href="#emulation_modes">Emulation Modes</a></li><li class="list-group-item"><span class="badge">5</span><a href="#application_specific">Application Specific</a></li><li class="list-group-item"><span class="badge">4</span><a href="#alternative_keyboard_layouts">Alternative Keyboard Layouts</a></li><li class="list-group-item"><span class="badge">3</span><a href="#International">International (Language Specific)</a></li><li class="list-group-item"><span class="badge">5</span><a href="#key_specific">Key Specific</a></li><li class="list-group-item"><span class="badge">2</span><a href="#os_functionality">OS Functionality</a></li><li class="list-group-item"><span class="badge">3</span><a href="#personal_settings">Personal Settings</a></li><li class="list-group-item"><span class="badge">3</span><a href="#miscellaneous">Miscellaneous</a></li></ul>
+      <ul class="toc list-group"><li class="list-group-item list-group-item-info">Table of Contents</li><li class="list-group-item"><span class="badge">10</span><a href="#modifier_keys">Modifier Keys</a></li><li class="list-group-item"><span class="badge">13</span><a href="#emulation_modes">Emulation Modes</a></li><li class="list-group-item"><span class="badge">6</span><a href="#application_specific">Application Specific</a></li><li class="list-group-item"><span class="badge">4</span><a href="#alternative_keyboard_layouts">Alternative Keyboard Layouts</a></li><li class="list-group-item"><span class="badge">3</span><a href="#International">International (Language Specific)</a></li><li class="list-group-item"><span class="badge">5</span><a href="#key_specific">Key Specific</a></li><li class="list-group-item"><span class="badge">2</span><a href="#os_functionality">OS Functionality</a></li><li class="list-group-item"><span class="badge">3</span><a href="#personal_settings">Personal Settings</a></li><li class="list-group-item"><span class="badge">3</span><a href="#miscellaneous">Miscellaneous</a></li></ul>
       <div class="text-left" style="margin-bottom: 30px">
         <a href="javascript:$('.collapse').collapse('show')">Expand All</a> |
         <a href="javascript:$('.collapse').collapse('hide')">Collapse All</a>
@@ -489,6 +489,15 @@
       </div>
       <div class="list-group collapse" id="xcode">
           <div class="list-group-item">Xcode Visual Studio style (Run, Stop, Build, Step, Breakpoint)</div>
+      </div>
+    </div>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <a class="panel-title btn btn-link" role="button" data-toggle="collapse" href="#safari" aria-expanded="false" aria-controls="safari">Don&#39;t exit fullscreen when pressing ESC in Safari</a>
+        <a class="btn btn-primary btn-sm pull-right" data-json-path="json/safari.json">Import</a>
+      </div>
+      <div class="list-group collapse" id="safari">
+          <div class="list-group-item">Remap ESC to Option-ESC in Safari only</div>
       </div>
     </div>
 

--- a/docs/json/safari.json
+++ b/docs/json/safari.json
@@ -1,0 +1,32 @@
+{
+  "title": "Don't exit fullscreen when pressing ESC in Safari",
+  "rules": [
+    {
+      "description": "Remap ESC to Option-ESC in Safari only",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "escape"
+          },
+          "to_if_alone": [
+            {
+                "key_code": "escape",
+                "modifiers": [
+                    "left_option"
+                ]
+            }
+          ],
+         "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com.apple.Safari"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}

--- a/src/index.html.erb
+++ b/src/index.html.erb
@@ -60,7 +60,8 @@
               "docs/json/remote-desktop.json",
               "docs/json/tmux_prefix.json",
               "docs/json/launch_new_Chrome_or_iTerm2_windows.json",
-              "docs/json/xcode.json"
+              "docs/json/xcode.json",
+              "docs/json/safari.json"
           ])
 
           add_group("Alternative Keyboard Layouts","alternative_keyboard_layouts",[


### PR DESCRIPTION
Pressing ESC to exit fullscreen videos at some popular sites still works