### PR TITLE
Add complex modifications for exchanging control+tab and command+tab

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,7 @@
 
       
 
-      <ul class="toc list-group"><li class="list-group-item list-group-item-info">Table of Contents</li><li class="list-group-item"><span class="badge">10</span><a href="#modifier_keys">Modifier Keys</a></li><li class="list-group-item"><span class="badge">14</span><a href="#emulation_modes">Emulation Modes</a></li><li class="list-group-item"><span class="badge">6</span><a href="#application_specific">Application Specific</a></li><li class="list-group-item"><span class="badge">4</span><a href="#alternative_keyboard_layouts">Alternative Keyboard Layouts</a></li><li class="list-group-item"><span class="badge">3</span><a href="#International">International (Language Specific)</a></li><li class="list-group-item"><span class="badge">5</span><a href="#key_specific">Key Specific</a></li><li class="list-group-item"><span class="badge">2</span><a href="#os_functionality">OS Functionality</a></li><li class="list-group-item"><span class="badge">3</span><a href="#personal_settings">Personal Settings</a></li><li class="list-group-item"><span class="badge">3</span><a href="#miscellaneous">Miscellaneous</a></li></ul>
+      <ul class="toc list-group"><li class="list-group-item list-group-item-info">Table of Contents</li><li class="list-group-item"><span class="badge">10</span><a href="#modifier_keys">Modifier Keys</a></li><li class="list-group-item"><span class="badge">14</span><a href="#emulation_modes">Emulation Modes</a></li><li class="list-group-item"><span class="badge">6</span><a href="#application_specific">Application Specific</a></li><li class="list-group-item"><span class="badge">4</span><a href="#alternative_keyboard_layouts">Alternative Keyboard Layouts</a></li><li class="list-group-item"><span class="badge">3</span><a href="#International">International (Language Specific)</a></li><li class="list-group-item"><span class="badge">6</span><a href="#key_specific">Key Specific</a></li><li class="list-group-item"><span class="badge">2</span><a href="#os_functionality">OS Functionality</a></li><li class="list-group-item"><span class="badge">3</span><a href="#personal_settings">Personal Settings</a></li><li class="list-group-item"><span class="badge">3</span><a href="#miscellaneous">Miscellaneous</a></li></ul>
       <div class="text-left" style="margin-bottom: 30px">
         <a href="javascript:$('.collapse').collapse('show')">Expand All</a> |
         <a href="javascript:$('.collapse').collapse('hide')">Collapse All</a>
@@ -597,6 +597,15 @@
         </div>
         <div class="panel-body">
               <div class="panel panel-default">
+      <div class="panel-heading">
+        <a class="panel-title btn btn-link" role="button" data-toggle="collapse" href="#exchange_command_tab_and_control_tab" aria-expanded="false" aria-controls="exchange_command_tab_and_control_tab">Exchange Command+Tab (generally &#39;cycle through applications&#39;) and Control+Tab (generally &#39;cycle through tabs&#39;)</a>
+        <a class="btn btn-primary btn-sm pull-right" data-json-path="json/exchange_command_tab_and_control_tab.json">Import</a>
+      </div>
+      <div class="list-group collapse" id="exchange_command_tab_and_control_tab">
+          <div class="list-group-item">Change Command+Tab to Control+Tab</div><div class="list-group-item">Change Control+Tab to Command+Tab</div>
+      </div>
+    </div>
+    <div class="panel panel-default">
       <div class="panel-heading">
         <a class="panel-title btn btn-link" role="button" data-toggle="collapse" href="#exchange_numbers_and_symbols" aria-expanded="false" aria-controls="exchange_numbers_and_symbols">Exchange numbers and symbols</a>
         <a class="btn btn-primary btn-sm pull-right" data-json-path="json/exchange_numbers_and_symbols.json">Import</a>

--- a/docs/json/exchange_command_tab_and_control_tab.json
+++ b/docs/json/exchange_command_tab_and_control_tab.json
@@ -1,0 +1,59 @@
+{
+  "title": "Exchange Command+Tab (generally 'cycle through applications') and Control+Tab (generally 'cycle through tabs')",
+  "rules": [
+    {
+      "description": "Change Command+Tab to Control+Tab",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "tab",
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "tab",
+              "modifiers": [
+                "control"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Change Control+Tab to Command+Tab",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "tab",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "tab",
+              "modifiers": [
+                "command"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}

--- a/src/index.html.erb
+++ b/src/index.html.erb
@@ -79,6 +79,7 @@
           ])
 
           add_group("Key Specific","key_specific",[
+              "docs/json/exchange_command_tab_and_control_tab.json",
               "docs/json/exchange_numbers_and_symbols.json",
               "docs/json/exchange_semicolon_and_colon.json",
               "docs/json/nonbreaking_space.json",

--- a/src/json/exchange_command_tab_and_control_tab.json.erb
+++ b/src/json/exchange_command_tab_and_control_tab.json.erb
@@ -1,0 +1,59 @@
+{
+    "title": "Exchange Command+Tab (generally 'cycle through applications') and Control+Tab (generally 'cycle through tabs')",
+    "rules": [
+        {
+            "description": "Change Command+Tab to Control+Tab",
+            "manipulators": [
+                {
+                    "from": {
+                        "key_code": "tab",
+                        "modifiers": {
+                            "mandatory": [
+                                "command"
+                            ],
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "tab",
+                            "modifiers": [
+                                "control"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "Change Control+Tab to Command+Tab",
+            "manipulators": [
+                {
+                    "from": {
+                        "key_code": "tab",
+                        "modifiers": {
+                            "mandatory": [
+                                "control"
+                            ],
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "tab",
+                            "modifiers": [
+                                "command"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This makes using capslock->control instead of left_control on mac
keyboards much nicer for people like me (i.e. those who switch between
tabs more often than between applications).