### PR TITLE
Swap keybindings of cmd+arrows and ctrl+arrows

### DIFF
--- a/docs/json/command_arrows_to_ctrl_arrows.json
+++ b/docs/json/command_arrows_to_ctrl_arrows.json
@@ -1,0 +1,186 @@
+{
+  "title": "Exchange command + arrows keys with control + arrows keys",
+  "rules": [
+    {
+      "description": "Exchange command + arrow keys with control + arrow keys",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_arrow",
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow",
+              "modifiers": [
+                "control"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_arrow",
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow",
+              "modifiers": [
+                "control"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "up_arrow",
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow",
+              "modifiers": [
+                "control"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "down_arrow",
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "down_arrow",
+              "modifiers": [
+                "control"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_arrow",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow",
+              "modifiers": [
+                "command"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_arrow",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow",
+              "modifiers": [
+                "command"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "up_arrow",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow",
+              "modifiers": [
+                "command"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "down_arrow",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "down_arrow",
+              "modifiers": [
+                "command"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/command_arrows_to_ctrl_arrows.json.erb
+++ b/src/json/command_arrows_to_ctrl_arrows.json.erb
@@ -1,0 +1,50 @@
+{
+    "title": "Exchange command + arrows keys with control + arrows keys",
+    "rules": [
+        {
+            "description": "Exchange command + arrow keys with control + arrow keys",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("right_arrow", ["command"], ["any"]) %>,
+                    "to": <%= to([["right_arrow", ["control"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("left_arrow", ["command"], ["any"]) %>,
+                    "to": <%= to([["left_arrow", ["control"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("up_arrow", ["command"], ["any"]) %>,
+                    "to": <%= to([["up_arrow", ["control"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("down_arrow", ["command"], ["any"]) %>,
+                    "to": <%= to([["down_arrow", ["control"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("right_arrow", ["control"], ["any"]) %>,
+                    "to": <%= to([["right_arrow", ["command"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("left_arrow", ["control"], ["any"]) %>,
+                    "to": <%= to([["left_arrow", ["command"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("up_arrow", ["control"], ["any"]) %>,
+                    "to": <%= to([["up_arrow", ["command"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("down_arrow", ["control"], ["any"]) %>,
+                    "to": <%= to([["down_arrow", ["command"]]]) %>
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Similar to the existing script to swap "command + arrow keys" and "option + arrow keys", this script swaps between "command + arrow keys" and "control + arrow keys". 