### PR TITLE
Add a template to exchange command+backspace and option+backspace

### DIFF
--- a/docs/json/exchange_command_backspace_and_option_backspace.json
+++ b/docs/json/exchange_command_backspace_and_option_backspace.json
@@ -1,0 +1,59 @@
+{
+  "title": "Exchange Command+Backward-Delete (delete current line) and Option+Backward-Delete (delete current word)",
+  "rules": [
+    {
+      "description": "Change Command+Backward-Delete and Option+Backward-Delete",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "delete_or_backspace",
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_or_backspace",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Change Option+Backward-Delete to Command+Backward-Delete",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "delete_or_backspace",
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_or_backspace",
+              "modifiers": [
+                "command"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/exchange_command_backspace_and_option_backspace.json.erb
+++ b/src/json/exchange_command_backspace_and_option_backspace.json.erb
@@ -1,0 +1,59 @@
+{
+    "title": "Exchange Command+Backward-Delete (delete current line) and Option+Backward-Delete (delete current word)",
+    "rules": [
+        {
+            "description": "Change Command+Backward-Delete and Option+Backward-Delete",
+            "manipulators": [
+                {
+                    "from": {
+                        "key_code": "delete_or_backspace",
+                        "modifiers": {
+                            "mandatory": [
+                                "command"
+                            ],
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "delete_or_backspace",
+                            "modifiers": [
+                                "option"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "Change Option+Backward-Delete to Command+Backward-Delete",
+            "manipulators": [
+                {
+                    "from": {
+                        "key_code": "delete_or_backspace",
+                        "modifiers": {
+                            "mandatory": [
+                                "option"
+                            ],
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "delete_or_backspace",
+                            "modifiers": [
+                                "command"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
A new script to swap between "command + backspace" and "option + backspace", effectively swapping "delete current line" and "delete current word"