### PR TITLE
Post space is pressed alone, left_ctrl otherwise

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -133,7 +133,15 @@
           <div class="list-group-item">Change left_control + letter to left_command + letter</div><div class="list-group-item">Change fn + letter to left_control + letter</div>
       </div>
     </div>
-
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <a class="panel-title btn btn-link" role="button" data-toggle="collapse" href="#spacebar_changes" aria-expanded="false" aria-controls="spacebar_changes">Spacebar changes</a>
+        <a class="btn btn-primary btn-sm pull-right" data-json-path="json/spacebar_changes.json">Import</a>
+      </div>
+      <div class="list-group collapse" id="spacebar_changes">
+          <div class="list-group-item">Post space is pressed alone, left_ctrl otherwise</div>
+      </div>
+    </div>
         </div>
       </div>
       <div class="panel panel-primary" id="emulation_modes">

--- a/docs/json/spacebar_changes.json
+++ b/docs/json/spacebar_changes.json
@@ -1,0 +1,31 @@
+{
+    "title": "Spacebar changes",
+    "rules": [        
+        {
+            "description": "Post space is pressed alone, left_ctrl otherwise",
+            "manipulators": [
+		{
+		    "from": {
+			"key_code": "spacebar",
+			"modifiers": {
+			    "optional": [
+				"any"
+			    ]
+			}
+		    },
+		    "to": [
+			{
+			    "key_code": "left_control"
+			}
+		    ],
+		    "to_if_alone": [
+			{
+			    "key_code": "spacebar"
+			}
+		    ],
+		    "type": "basic"
+		}
+	    ]
+        }
+    ]
+}

--- a/src/json/spacebar_changes.json.erb
+++ b/src/json/spacebar_changes.json.erb
@@ -1,0 +1,16 @@
+{
+    "title": "Spacebar changes",
+    "rules": [        
+        {
+            "description": "Post space is pressed alone, left_ctrl otherwise",
+            "manipulators": [
+                {
+                    "from": <%= from("spacebar", [], ["any"]) %>,
+                    "to": <%= to([["left_control"]]) %>,
+                    "to_if_alone": <%= to([["spacebar"]]) %>,
+                    "type": "basic"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Handy feature for emacs users. Single space alone posts space. Space + other key = Ctrl + other key. 
There is one problem with delay. Typing fast with spaces is sometimes understood as Ctlr.