### PR TITLE
Disable PC-Style Quit (Alt+F4) for RDC and VMs

### DIFF
--- a/docs/json/pc_shortcuts.json
+++ b/docs/json/pc_shortcuts.json
@@ -1805,6 +1805,34 @@
                 "left_command"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.microsoft\\.rdc$",
+                "^com\\.microsoft\\.rdc\\.mac$",
+                "^com\\.microsoft\\.rdc\\.osx\\.beta$",
+                "^net\\.sf\\.cord$",
+                "^com\\.thinomenon\\.RemoteDesktopConnection$",
+                "^com\\.itap-mobile\\.qmote$",
+                "^com\\.nulana\\.remotixmac$",
+                "^com\\.p5sys\\.jump\\.mac\\.viewer$",
+                "^com\\.p5sys\\.jump\\.mac\\.viewer\\.web$",
+                "^com\\.teamviewer\\.TeamViewer$",
+                "^com\\.vmware\\.horizon$",
+                "^com\\.2X\\.Client\\.Mac$",
+                "^com\\.vmware\\.fusion$",
+                "^com\\.vmware\\.horizon$",
+                "^com\\.vmware\\.view$",
+                "^com\\.parallels\\.desktop$",
+                "^com\\.parallels\\.vm$",
+                "^com\\.parallels\\.desktop\\.console$",
+                "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
+                "^com\\.vmware\\.proxyApp\\.",
+                "^com\\.parallels\\.winapp\\."
+              ]
+            }
           ]
         }
       ]

--- a/src/json/pc_shortcuts.json.erb
+++ b/src/json/pc_shortcuts.json.erb
@@ -385,7 +385,10 @@
                 {
                     "type": "basic",
                     "from": <%= from("f4", ["option"], []) %>,
-                    "to": <%= to([["q", ["left_command"]]]) %>
+                    "to": <%= to([["q", ["left_command"]]]) %>,
+                    "conditions": [
+                        <%= frontmost_application_unless(["remote_desktop", "virtual_machine"]) %>
+                    ]
                 }
             ]
         },


### PR DESCRIPTION
Previous modification did not disable this mapping for RDC and VMs

BTW
make didn't seem to be run after a recent change to include Teamviewer as a simple run of make on the repo added a lot of changes to docs/json/pc_shortcuts.json (which I didn't commit)