### PR TITLE
Add japanese-specific vim's rule

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -629,7 +629,7 @@
         <a class="btn btn-primary btn-sm pull-right" data-json-path="json/japanese.json">Import</a>
       </div>
       <div class="list-group collapse" id="japanese">
-          <div class="list-group-item">コマンドキーを単体で押したときに、英数・かなキーを送信する。（左コマンドキーは英数、右コマンドキーはかな）</div>
+          <div class="list-group-item">コマンドキーを単体で押したときに、英数・かなキーを送信する。（左コマンドキーは英数、右コマンドキーはかな）</div><div class="list-group-item">escキーを押したときに、英数キーも送信する(vim用)</div><div class="list-group-item">Ctrl+[を押したときに、英数キーも送信する(vim用)</div>
       </div>
     </div>
     <div class="panel panel-default">

--- a/docs/json/japanese.json
+++ b/docs/json/japanese.json
@@ -47,6 +47,52 @@
           ]
         }
       ]
+    },
+    {
+      "description": "escキーを押したときに、英数キーも送信する(vim用)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "escape"
+          },
+          "to": [
+            {
+              "key_code": "escape"
+            },
+            {
+              "key_code": "japanese_eisuu"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Ctrl+[を押したときに、英数キーも送信する(vim用)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "open_bracket",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "open_bracket",
+              "modifiers": [
+                "control"
+              ]
+            },
+            {
+              "key_code": "japanese_eisuu"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/json/japanese.json.erb
+++ b/src/json/japanese.json.erb
@@ -17,6 +17,26 @@
                     "to_if_alone": <%= to([["japanese_kana"]]) %>
                 }
             ]
+        },
+        {
+            "description": "escキーを押したときに、英数キーも送信する(vim用)",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("escape", [], []) %>,
+                    "to": <%= to([["escape"], ["japanese_eisuu"]]) %>
+                }
+            ]
+        },
+        {
+            "description": "Ctrl+[を押したときに、英数キーも送信する(vim用)",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("open_bracket", ["control"], []) %>,
+                    "to": <%= to([["open_bracket", ["control"]], ["japanese_eisuu"]]) %>
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
hi @tekezo !

This is my suggestion to add the following rules in japanese rule
- "Escape to Escape & Japanese_Eisuu"
- "Ctrl+[ to Ctrl+[ & Japanese_Eisuu"

Basically these rules are for vim. However I think some people may like this rules by different reasons.

Ideally, I don't want add "Ctrl+[ to Ctrl+[ & Japanese_Eisuu" because it's not beautiful. But "Escape to Escape & Japanese_Eisuu" couldn't cover "Ctrl+[", so I added the rule.