### PR TITLE
Fine volume controls by default

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,7 @@
 
       
 
-      <ul class="toc list-group"><li class="list-group-item list-group-item-info">Table of Contents</li><li class="list-group-item"><span class="badge">11</span><a href="#modifier_keys">Modifier Keys</a></li><li class="list-group-item"><span class="badge">17</span><a href="#emulation_modes">Emulation Modes</a></li><li class="list-group-item"><span class="badge">8</span><a href="#application_specific">Application Specific</a></li><li class="list-group-item"><span class="badge">5</span><a href="#alternative_keyboard_layouts">Alternative Keyboard Layouts</a></li><li class="list-group-item"><span class="badge">5</span><a href="#International">International (Language Specific)</a></li><li class="list-group-item"><span class="badge">8</span><a href="#key_specific">Key Specific</a></li><li class="list-group-item"><span class="badge">2</span><a href="#os_functionality">OS Functionality</a></li><li class="list-group-item"><span class="badge">4</span><a href="#personal_settings">Personal Settings</a></li><li class="list-group-item"><span class="badge">3</span><a href="#miscellaneous">Miscellaneous</a></li></ul>
+      <ul class="toc list-group"><li class="list-group-item list-group-item-info">Table of Contents</li><li class="list-group-item"><span class="badge">11</span><a href="#modifier_keys">Modifier Keys</a></li><li class="list-group-item"><span class="badge">17</span><a href="#emulation_modes">Emulation Modes</a></li><li class="list-group-item"><span class="badge">8</span><a href="#application_specific">Application Specific</a></li><li class="list-group-item"><span class="badge">5</span><a href="#alternative_keyboard_layouts">Alternative Keyboard Layouts</a></li><li class="list-group-item"><span class="badge">5</span><a href="#International">International (Language Specific)</a></li><li class="list-group-item"><span class="badge">8</span><a href="#key_specific">Key Specific</a></li><li class="list-group-item"><span class="badge">2</span><a href="#os_functionality">OS Functionality</a></li><li class="list-group-item"><span class="badge">4</span><a href="#personal_settings">Personal Settings</a></li><li class="list-group-item"><span class="badge">4</span><a href="#miscellaneous">Miscellaneous</a></li></ul>
       <div class="text-left" style="margin-bottom: 30px">
         <a href="#" onclick="$('.collapse').collapse('toggle'); return false;">Expand/Collapse All</a>
       </div>
@@ -888,6 +888,15 @@
       </div>
       <div class="list-group collapse" id="exchange_underscore_and_backslash">
           <div class="list-group-item">Exchange underscore and backslash</div>
+      </div>
+    </div>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <a class="panel-title btn btn-link" role="button" data-toggle="collapse" href="#fine_volume_control" aria-expanded="false" aria-controls="fine_volume_control">Fine volume contol</a>
+        <a class="btn btn-primary btn-sm pull-right" data-json-path="json/fine_volume_control.json">Import</a>
+      </div>
+      <div class="list-group collapse" id="fine_volume_control">
+          <div class="list-group-item">Map volume controls to fine volume controls (Option + Shift + Volume)</div>
       </div>
     </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -896,7 +896,7 @@
         <a class="btn btn-primary btn-sm pull-right" data-json-path="json/fine_volume_control.json">Import</a>
       </div>
       <div class="list-group collapse" id="fine_volume_control">
-          <div class="list-group-item">Map volume controls to fine volume controls (Option + Shift + Volume)</div>
+          <div class="list-group-item">Map volume controls to fine volume controls (Option + Shift + Volume)</div><div class="list-group-item">Map fn + volume controls to fine volume controls (Option + Shift + Volume)</div>
       </div>
     </div>
 

--- a/docs/json/fine_volume_control.json
+++ b/docs/json/fine_volume_control.json
@@ -7,9 +7,44 @@
         {
           "type": "basic",
           "from": {
+            "key_code": "f11"
+          },
+          "to": [
+            {
+              "key_code": "volume_decrement",
+              "modifiers": [
+                "left_shift",
+                "left_option"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "f12"
+          },
+          "to": [
+            {
+              "key_code": "volume_increment",
+              "modifiers": [
+                "left_shift",
+                "left_option"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Map fn + volume controls to fine volume controls (Option + Shift + Volume)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
             "key_code": "f11",
             "modifiers": {
-              "optional": [
+              "mandatory": [
                 "fn"
               ]
             }
@@ -29,7 +64,7 @@
           "from": {
             "key_code": "f12",
             "modifiers": {
-              "optional": [
+              "mandatory": [
                 "fn"
               ]
             }

--- a/docs/json/fine_volume_control.json
+++ b/docs/json/fine_volume_control.json
@@ -7,39 +7,9 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "volume_decrement"
-          },
-          "to": [
-            {
-              "key_code": "volume_decrement",
-              "modifiers": [
-                "left_shift",
-                "left_option"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "volume_increment"
-          },
-          "to": [
-            {
-              "key_code": "volume_increment",
-              "modifiers": [
-                "left_shift",
-                "left_option"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
             "key_code": "f11",
             "modifiers": {
-              "mandatory": [
+              "optional": [
                 "fn"
               ]
             }
@@ -59,7 +29,7 @@
           "from": {
             "key_code": "f12",
             "modifiers": {
-              "mandatory": [
+              "optional": [
                 "fn"
               ]
             }

--- a/docs/json/fine_volume_control.json
+++ b/docs/json/fine_volume_control.json
@@ -1,0 +1,80 @@
+{
+  "title": "Fine volume contol",
+  "rules": [
+    {
+      "description": "Map volume controls to fine volume controls (Option + Shift + Volume)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "volume_decrement"
+          },
+          "to": [
+            {
+              "key_code": "volume_decrement",
+              "modifiers": [
+                "left_shift",
+                "left_option"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "volume_increment"
+          },
+          "to": [
+            {
+              "key_code": "volume_increment",
+              "modifiers": [
+                "left_shift",
+                "left_option"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "f11",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "volume_decrement",
+              "modifiers": [
+                "left_shift",
+                "left_option"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "f12",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "volume_increment",
+              "modifiers": [
+                "left_shift",
+                "left_option"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/json/fine_volume_control.json
+++ b/docs/json/fine_volume_control.json
@@ -22,6 +22,22 @@
         {
           "type": "basic",
           "from": {
+            "key_code": "f11",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f11"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
             "key_code": "f12"
           },
           "to": [
@@ -31,6 +47,22 @@
                 "left_shift",
                 "left_option"
               ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "f12",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f12"
             }
           ]
         }

--- a/src/index.html.erb
+++ b/src/index.html.erb
@@ -113,7 +113,8 @@
           add_group("Miscellaneous","miscellaneous",[
               "docs/json/block_one_handed_combos.json",
               "docs/json/exchange_hyphen_and_underscore.json",
-              "docs/json/exchange_underscore_and_backslash.json"
+              "docs/json/exchange_underscore_and_backslash.json",
+              "docs/json/fine_volume_control.json"
           ])
 
       %>

--- a/src/json/fine_volume_control.json.erb
+++ b/src/json/fine_volume_control.json.erb
@@ -1,0 +1,30 @@
+{
+    "title": "Fine volume contol",
+    "rules": [
+        {
+            "description": "Map volume controls to fine volume controls (Option + Shift + Volume)",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("volume_decrement", [], []) %>,
+                    "to": <%= to([["volume_decrement", ["left_shift", "left_option"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("volume_increment", [], []) %>,
+                    "to": <%= to([["volume_increment", ["left_shift", "left_option"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("f11", ["fn"], []) %>,
+                    "to": <%= to([["volume_decrement", ["left_shift", "left_option"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("f12", ["fn"], []) %>,
+                    "to": <%= to([["volume_increment", ["left_shift", "left_option"]]]) %>
+                }
+            ]
+        }
+    ]
+}

--- a/src/json/fine_volume_control.json.erb
+++ b/src/json/fine_volume_control.json.erb
@@ -6,22 +6,12 @@
             "manipulators": [
                 {
                     "type": "basic",
-                    "from": <%= from("volume_decrement", [], []) %>,
+                    "from": <%= from("f11", [], ["fn"]) %>,
                     "to": <%= to([["volume_decrement", ["left_shift", "left_option"]]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("volume_increment", [], []) %>,
-                    "to": <%= to([["volume_increment", ["left_shift", "left_option"]]]) %>
-                },
-                {
-                    "type": "basic",
-                    "from": <%= from("f11", ["fn"], []) %>,
-                    "to": <%= to([["volume_decrement", ["left_shift", "left_option"]]]) %>
-                },
-                {
-                    "type": "basic",
-                    "from": <%= from("f12", ["fn"], []) %>,
+                    "from": <%= from("f12", [], ["fn"]) %>,
                     "to": <%= to([["volume_increment", ["left_shift", "left_option"]]]) %>
                 }
             ]

--- a/src/json/fine_volume_control.json.erb
+++ b/src/json/fine_volume_control.json.erb
@@ -11,8 +11,18 @@
                 },
                 {
                     "type": "basic",
+                    "from": <%= from("f11", ["fn"], []) %>,
+                    "to": <%= to([["f11"]]) %>
+                },
+                {
+                    "type": "basic",
                     "from": <%= from("f12", [], []) %>,
                     "to": <%= to([["volume_increment", ["left_shift", "left_option"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("f12", ["fn"], []) %>,
+                    "to": <%= to([["f12"]]) %>
                 }
             ]
         },

--- a/src/json/fine_volume_control.json.erb
+++ b/src/json/fine_volume_control.json.erb
@@ -6,12 +6,27 @@
             "manipulators": [
                 {
                     "type": "basic",
-                    "from": <%= from("f11", [], ["fn"]) %>,
+                    "from": <%= from("f11", [], []) %>,
                     "to": <%= to([["volume_decrement", ["left_shift", "left_option"]]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("f12", [], ["fn"]) %>,
+                    "from": <%= from("f12", [], []) %>,
+                    "to": <%= to([["volume_increment", ["left_shift", "left_option"]]]) %>
+                }
+            ]
+        },
+        {
+            "description": "Map fn + volume controls to fine volume controls (Option + Shift + Volume)",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("f11", ["fn"], []) %>,
+                    "to": <%= to([["volume_decrement", ["left_shift", "left_option"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("f12", ["fn"], []) %>,
                     "to": <%= to([["volume_increment", ["left_shift", "left_option"]]]) %>
                 }
             ]


### PR DESCRIPTION
As requested in #153.  
Remap regular volume controls (either with or without `fn`) to fine volume controls (i.e. `Option` + `Shift` + Volume Up/Down).