### PR TITLE
Anti-RSI App Switch

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,7 @@
 
       
 
-      <ul class="toc list-group"><li class="list-group-item list-group-item-info">Table of Contents</li><li class="list-group-item"><span class="badge">11</span><a href="#modifier_keys">Modifier Keys</a></li><li class="list-group-item"><span class="badge">17</span><a href="#emulation_modes">Emulation Modes</a></li><li class="list-group-item"><span class="badge">8</span><a href="#application_specific">Application Specific</a></li><li class="list-group-item"><span class="badge">5</span><a href="#alternative_keyboard_layouts">Alternative Keyboard Layouts</a></li><li class="list-group-item"><span class="badge">5</span><a href="#International">International (Language Specific)</a></li><li class="list-group-item"><span class="badge">8</span><a href="#key_specific">Key Specific</a></li><li class="list-group-item"><span class="badge">2</span><a href="#os_functionality">OS Functionality</a></li><li class="list-group-item"><span class="badge">4</span><a href="#personal_settings">Personal Settings</a></li><li class="list-group-item"><span class="badge">4</span><a href="#miscellaneous">Miscellaneous</a></li></ul>
+      <ul class="toc list-group"><li class="list-group-item list-group-item-info">Table of Contents</li><li class="list-group-item"><span class="badge">11</span><a href="#modifier_keys">Modifier Keys</a></li><li class="list-group-item"><span class="badge">17</span><a href="#emulation_modes">Emulation Modes</a></li><li class="list-group-item"><span class="badge">8</span><a href="#application_specific">Application Specific</a></li><li class="list-group-item"><span class="badge">5</span><a href="#alternative_keyboard_layouts">Alternative Keyboard Layouts</a></li><li class="list-group-item"><span class="badge">5</span><a href="#International">International (Language Specific)</a></li><li class="list-group-item"><span class="badge">8</span><a href="#key_specific">Key Specific</a></li><li class="list-group-item"><span class="badge">3</span><a href="#os_functionality">OS Functionality</a></li><li class="list-group-item"><span class="badge">4</span><a href="#personal_settings">Personal Settings</a></li><li class="list-group-item"><span class="badge">4</span><a href="#miscellaneous">Miscellaneous</a></li></ul>
       <div class="text-left" style="margin-bottom: 30px">
         <a href="#" onclick="$('.collapse').collapse('toggle'); return false;">Expand/Collapse All</a>
       </div>
@@ -780,6 +780,15 @@
       </div>
       <div class="list-group collapse" id="application_window_tab_switch_with_right_cmd_hjklsemiquote">
           <div class="list-group-item">Use right_command+;/&#39; to cycle through running applications (like command+tab).</div><div class="list-group-item">Use right_command+h/l to switch tabs in an application.</div><div class="list-group-item">Use right_command+j/k to switch windows of the foreground application .</div><div class="list-group-item">Disable left_command+(tab/shift+tab) (to retrain reflexes using the other manipulators).</div>
+      </div>
+    </div>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <a class="panel-title btn btn-link" role="button" data-toggle="collapse" href="#anti_rsi_app_switch" aria-expanded="false" aria-controls="anti_rsi_app_switch">Anti-RSI App Switch (LCMD+Space to LCMD+Tab, LOpt+Space to LCMD+` and reverse +LShift).</a>
+        <a class="btn btn-primary btn-sm pull-right" data-json-path="json/anti_rsi_app_switch.json">Import</a>
+      </div>
+      <div class="list-group collapse" id="anti_rsi_app_switch">
+          <div class="list-group-item">Anti-RSI App Switch (LCMD+Space to LCMD+Tab, LOpt+Space to LCMD+` and reverse +LShift).</div>
       </div>
     </div>
 

--- a/docs/json/anti_rsi_app_switch.json
+++ b/docs/json/anti_rsi_app_switch.json
@@ -1,0 +1,102 @@
+{
+  "title": "Anti-RSI App Switch (LCMD+Space to LCMD+Tab, LOpt+Space to LCMD+` and reverse +LShift).",
+  "rules": [
+    {
+      "description": "Anti-RSI App Switch (LCMD+Space to LCMD+Tab, LOpt+Space to LCMD+` and reverse +LShift).",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "spacebar",
+            "modifiers": {
+              "mandatory": [
+                "left_command"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "tab",
+              "modifiers": [
+                "left_command"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "spacebar",
+            "modifiers": {
+              "mandatory": [
+                "left_command",
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "tab",
+              "modifiers": [
+                "left_command",
+                "left_shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "spacebar",
+            "modifiers": {
+              "mandatory": [
+                "left_option"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "left_command"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "spacebar",
+            "modifiers": {
+              "mandatory": [
+                "left_option",
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "left_command",
+                "left_shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}

--- a/src/index.html.erb
+++ b/src/index.html.erb
@@ -100,7 +100,8 @@
 
           add_group("OS Functionality","os_functionality",[
               "docs/json/launch_apps.json",
-              "docs/json/application_window_tab_switch_with_right_cmd_hjklsemiquote.json"
+              "docs/json/application_window_tab_switch_with_right_cmd_hjklsemiquote.json",
+              "docs/json/anti_rsi_app_switch.json"
           ])
 
           add_group("Personal Settings","personal_settings",[


### PR DESCRIPTION
Anti-RSI (prevents a Repetitive Stress Injury) remapping of `Cmd+Tab`/``Cmd+` `` to `LCmd+LShift`/`LOpt+LShift` (`RCmd+LShift` is still usable for Spotlight/Quicksilver).

Extra useful on the new super-flat Macbook keyboards.