### PR TITLE
add a complex mod to switch the square brackets with the parens,

### DIFF
--- a/src/json/swap-paren-and-sqbrackets.json.erb
+++ b/src/json/swap-paren-and-sqbrackets.json.erb
@@ -1,0 +1,86 @@
+{
+  "title": "Exchange paren and square bracket",
+  "rules": [
+    {
+      "description": "Exchange paren and square bracket",
+      "manipulators": [
+         {
+          "type": "basic",
+          "from": {
+            "key_code": "open_bracket",
+            "modifiers": {
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "9",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "9",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "open_bracket"
+            }
+          ]
+	    },
+	  {
+          "type": "basic",
+          "from": {
+            "key_code": "close_bracket",
+            "modifiers": {
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "0",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "0",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "close_bracket"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
putting the frequently used paren (at least for us lisp programmers) on a directly accessible key.