### PR TITLE
Added swap_yen_and_backslash rule.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,7 @@
 
       
 
-      <ul class="toc list-group"><li class="list-group-item list-group-item-info">Table of Contents</li><li class="list-group-item"><span class="badge">11</span><a href="#modifier_keys">Modifier Keys</a></li><li class="list-group-item"><span class="badge">17</span><a href="#emulation_modes">Emulation Modes</a></li><li class="list-group-item"><span class="badge">8</span><a href="#application_specific">Application Specific</a></li><li class="list-group-item"><span class="badge">6</span><a href="#alternative_keyboard_layouts">Alternative Keyboard Layouts</a></li><li class="list-group-item"><span class="badge">5</span><a href="#International">International (Language Specific)</a></li><li class="list-group-item"><span class="badge">9</span><a href="#key_specific">Key Specific</a></li><li class="list-group-item"><span class="badge">3</span><a href="#os_functionality">OS Functionality</a></li><li class="list-group-item"><span class="badge">4</span><a href="#personal_settings">Personal Settings</a></li><li class="list-group-item"><span class="badge">4</span><a href="#miscellaneous">Miscellaneous</a></li></ul>
+      <ul class="toc list-group"><li class="list-group-item list-group-item-info">Table of Contents</li><li class="list-group-item"><span class="badge">11</span><a href="#modifier_keys">Modifier Keys</a></li><li class="list-group-item"><span class="badge">17</span><a href="#emulation_modes">Emulation Modes</a></li><li class="list-group-item"><span class="badge">8</span><a href="#application_specific">Application Specific</a></li><li class="list-group-item"><span class="badge">6</span><a href="#alternative_keyboard_layouts">Alternative Keyboard Layouts</a></li><li class="list-group-item"><span class="badge">6</span><a href="#International">International (Language Specific)</a></li><li class="list-group-item"><span class="badge">9</span><a href="#key_specific">Key Specific</a></li><li class="list-group-item"><span class="badge">3</span><a href="#os_functionality">OS Functionality</a></li><li class="list-group-item"><span class="badge">4</span><a href="#personal_settings">Personal Settings</a></li><li class="list-group-item"><span class="badge">4</span><a href="#miscellaneous">Miscellaneous</a></li></ul>
       <div class="text-left" style="margin-bottom: 30px">
         <a href="#" onclick="$('.collapse').collapse('toggle'); return false;">Expand/Collapse All</a>
       </div>
@@ -675,6 +675,15 @@
       </div>
       <div class="list-group collapse" id="swap_pound_and_hash">
           <div class="list-group-item">Exchange £ shift-3 and # option-3</div>
+      </div>
+    </div>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <a class="panel-title btn btn-link" role="button" data-toggle="collapse" href="#swap_yen_and_backslash" aria-expanded="false" aria-controls="swap_yen_and_backslash">Swap ¥ and \ for Japanese Romaji input on US Keyboards</a>
+        <a class="btn btn-primary btn-sm pull-right" data-json-path="json/swap_yen_and_backslash.json">Import</a>
+      </div>
+      <div class="list-group collapse" id="swap_yen_and_backslash">
+          <div class="list-group-item">Change Backslash to Alt+Backslash</div><div class="list-group-item">Change Alt+Backslash to Backslash</div>
       </div>
     </div>
 

--- a/docs/json/swap_yen_and_backslash.json
+++ b/docs/json/swap_yen_and_backslash.json
@@ -1,0 +1,45 @@
+{
+  "title": "Swap ¥ and \\ for Japanese Romaji input on US Keyboards",
+  "rules": [
+    {
+      "description": "Change Backslash to Alt+Backslash",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "backslash"
+          },
+          "to": [
+            {
+              "key_code": "backslash",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Change Alt+Backslash to Backslash",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "backslash",
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "backslash"
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}

--- a/src/index.html.erb
+++ b/src/index.html.erb
@@ -85,7 +85,8 @@
             "docs/json/jis_to_ascii.json",
             "docs/json/german_pc_shortcuts.json",
             "docs/json/czech_pc_shortcuts.json",
-            "docs/json/swap_pound_and_hash.json"
+            "docs/json/swap_pound_and_hash.json",
+            "docs/json/swap_yen_and_backslash.json"
           ])
 
           add_group("Key Specific","key_specific",[

--- a/src/json/swap_yen_and_backslash.json.erb
+++ b/src/json/swap_yen_and_backslash.json.erb
@@ -1,0 +1,45 @@
+{
+    "title": "Swap ¥ and \\ for Japanese Romaji input on US Keyboards",
+    "rules": [
+        {
+            "description": "Change Backslash to Alt+Backslash",
+            "manipulators": [
+                {
+                    "from": {
+                        "key_code": "backslash"
+                    },
+                    "to": [
+                        {
+                            "key_code": "backslash",
+                            "modifiers": [
+                                "option"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "Change Alt+Backslash to Backslash",
+            "manipulators": [
+                {
+                    "from": {
+                        "key_code": "backslash",
+                        "modifiers": {
+                            "mandatory": [
+                                "option"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "backslash"
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Instead of using the US Keyboard layout, I use Japanese input with Romaji (that way, I can just ctrl+Space and get ひらがな／カタカナ。The Romaji layout hides the backslash under "Alt+\", though, and the lone "\" yields ¥. This config swaps the two.

Eventually it would be cool to get the Romaji layout to match the US keyboard layout exactly (I think there are a few other differences with special characters), but "¥"/"\" is the only difference I've actually noticed.