### PR TITLE
Updates outdated modkeys (right alt) to (right option) for dvorak layout

### DIFF
--- a/docs/json/dvorak_layout.json
+++ b/docs/json/dvorak_layout.json
@@ -13,10 +13,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -35,10 +35,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -57,10 +57,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -79,10 +79,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -101,10 +101,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -123,10 +123,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -145,10 +145,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -167,10 +167,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -189,10 +189,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -211,10 +211,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -233,10 +233,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -255,10 +255,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -277,10 +277,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -299,10 +299,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -321,10 +321,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -343,10 +343,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -365,10 +365,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -387,10 +387,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -409,10 +409,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -431,10 +431,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -453,10 +453,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -475,10 +475,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -497,10 +497,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -519,10 +519,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -541,10 +541,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -563,10 +563,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -585,10 +585,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -607,10 +607,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -629,10 +629,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -651,10 +651,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -673,10 +673,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -695,10 +695,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -717,10 +717,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -739,10 +739,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -761,10 +761,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -783,10 +783,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -805,10 +805,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -827,10 +827,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -849,10 +849,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -871,10 +871,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -893,10 +893,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -915,10 +915,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -937,10 +937,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -959,10 +959,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -981,10 +981,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1003,10 +1003,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1028,10 +1028,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1056,10 +1056,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1084,10 +1084,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1112,10 +1112,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1140,10 +1140,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1168,10 +1168,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1196,10 +1196,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1224,10 +1224,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1252,10 +1252,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1280,10 +1280,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1308,10 +1308,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1336,10 +1336,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1364,10 +1364,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1392,10 +1392,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1420,10 +1420,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1448,10 +1448,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1476,10 +1476,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1504,10 +1504,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1532,10 +1532,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1560,10 +1560,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1588,10 +1588,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1616,10 +1616,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1644,10 +1644,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1672,10 +1672,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1700,10 +1700,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1728,10 +1728,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1756,10 +1756,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1784,10 +1784,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1812,10 +1812,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1840,10 +1840,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1868,10 +1868,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1896,10 +1896,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1924,10 +1924,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1952,10 +1952,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -1980,10 +1980,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2008,10 +2008,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2036,10 +2036,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2064,10 +2064,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2092,10 +2092,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2120,10 +2120,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2148,10 +2148,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2176,10 +2176,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2204,10 +2204,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2232,10 +2232,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2260,10 +2260,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2288,10 +2288,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2316,10 +2316,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2344,10 +2344,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2372,10 +2372,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2400,10 +2400,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2428,10 +2428,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2456,10 +2456,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2484,10 +2484,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2512,10 +2512,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2540,10 +2540,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2568,10 +2568,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2596,10 +2596,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2624,10 +2624,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2652,10 +2652,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2680,10 +2680,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2708,10 +2708,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2736,10 +2736,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2764,10 +2764,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2792,10 +2792,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2820,10 +2820,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2848,10 +2848,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2876,10 +2876,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2904,10 +2904,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2932,10 +2932,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2960,10 +2960,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -2988,10 +2988,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -3016,10 +3016,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -3044,10 +3044,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -3072,10 +3072,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -3100,10 +3100,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -3128,10 +3128,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -3156,10 +3156,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -3184,10 +3184,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -3212,10 +3212,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -3240,10 +3240,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -3268,10 +3268,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -3296,10 +3296,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -3324,10 +3324,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -3352,10 +3352,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -3380,10 +3380,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -3408,10 +3408,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -3436,10 +3436,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -3464,10 +3464,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -3492,10 +3492,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -3520,10 +3520,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -3548,10 +3548,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },
@@ -3576,10 +3576,10 @@
                 "caps_lock",
                 "left_command",
                 "left_control",
-                "left_alt",
+                "left_option",
                 "right_command",
                 "right_control",
-                "right_alt"
+                "right_option"
               ]
             }
           },

--- a/src/json/dvorak_layout.json.erb
+++ b/src/json/dvorak_layout.json.erb
@@ -1,6 +1,6 @@
 {
     <%
-        optional_modifiers = ["caps_lock","left_command","left_control","left_alt","right_command","right_control","right_alt"]
+        optional_modifiers = ["caps_lock","left_command","left_control","left_option","right_command","right_control","right_option"]
         remap_source_keys = [
 			"grave_accent_and_tilde","1","2","4","5","6","7","8","9","0","hyphen","equal_sign",
 			"q","w","e","r","t","y","u","i","o","p","open_bracket","close_bracket","backslash",


### PR DESCRIPTION
This PR tries to fix the issue I had where the `option` key does no longer work properly with the Dvorak layout on Karabiner Elements. I changed the the modifier keys from `right_alt` to `right_option`.

@Reviewers: I suspect that the file `src/json/dvorak_layout.json.erb` is used to automatically generate the `dvorak_layout.json` so I made changes there as well.