### PR TITLE
make change_grave_accent_into_escape work in more apps

### DIFF
--- a/docs/json/change_grave_accent_to_escape.json
+++ b/docs/json/change_grave_accent_to_escape.json
@@ -7,6 +7,17 @@
         {
           "type": "basic",
           "from": {
+            "key_code": "grave_accent_and_tilde"
+          },
+          "to": [
+            {
+              "key_code": "escape"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
             "key_code": "grave_accent_and_tilde",
             "modifiers": {
               "optional": [

--- a/src/json/change_grave_accent_to_escape.json
+++ b/src/json/change_grave_accent_to_escape.json
@@ -1,0 +1,205 @@
+"profiles": [
+    {
+        "complex_modifications": {
+            "parameters": {
+                "basic.to_if_alone_timeout_milliseconds": 1000
+            },
+            "rules": [
+                {
+                    "description": "Post Escape if grave_accent_and_tilde (backtick) is pressed alone; post grave_accent (backtick) if Option + grave_accent_and_tilde is pressed.",
+                    "manipulators": [
+                        {
+                            "from": {
+                                "key_code": "grave_accent_and_tilde",
+                                "modifiers": {
+                                    "optional": [
+                                        "left_command"
+                                    ]
+                                }
+                            },
+                            "to": [
+                                {
+                                    "key_code": "grave_accent_and_tilde",
+                                    "modifiers": [
+                                            "left_command"
+                                        ]
+                                }
+                            ],
+                            "to_if_alone": [
+                                {
+                                    "key_code": "escape",
+                                    "modifiers": {
+                                        "optional": [
+                                            "any"
+                                        ]
+                                    }
+                                }
+                            ],
+                            "type": "basic"
+                        },
+                        {
+                            "from": {
+                                "key_code": "grave_accent_and_tilde",
+                                "modifiers": {
+                                    "optional": [
+                                        "left_control"
+                                    ]
+                                }
+                            },
+                            "to": [
+                                {
+                                    "key_code": "grave_accent_and_tilde",
+                                    "modifiers": [
+                                            "left_control"
+                                        ]
+                                }
+                            ],
+                            "to_if_alone": [
+                                {
+                                    "key_code": "escape",
+                                    "modifiers": {
+                                        "optional": [
+                                            "any"
+                                        ]
+                                    }
+                                }
+                            ],
+                            "type": "basic"
+                        },
+                        {
+                            "from": {
+                                "key_code": "grave_accent_and_tilde",
+                                "modifiers": {
+                                    "optional": [
+                                        "left_option"
+                                    ]
+                                }
+                            },
+                            "to": [
+                                {
+                                    "key_code": "grave_accent_and_tilde"
+                                }
+                            ],
+                            "type": "basic"
+                        }
+                    ]
+                }
+            ]
+        },
+        "devices": [],
+        "fn_function_keys": [
+            {
+                "from": {
+                    "key_code": "f1"
+                },
+                "to": {
+                    "key_code": "display_brightness_decrement"
+                }
+            },
+            {
+                "from": {
+                    "key_code": "f2"
+                },
+                "to": {
+                    "key_code": "display_brightness_increment"
+                }
+            },
+            {
+                "from": {
+                    "key_code": "f3"
+                },
+                "to": {
+                    "key_code": "mission_control"
+                }
+            },
+            {
+                "from": {
+                    "key_code": "f4"
+                },
+                "to": {
+                    "key_code": "launchpad"
+                }
+            },
+            {
+                "from": {
+                    "key_code": "f5"
+                },
+                "to": {
+                    "key_code": "illumination_decrement"
+                }
+            },
+            {
+                "from": {
+                    "key_code": "f6"
+                },
+                "to": {
+                    "key_code": "illumination_increment"
+                }
+            },
+            {
+                "from": {
+                    "key_code": "f7"
+                },
+                "to": {
+                    "key_code": "rewind"
+                }
+            },
+            {
+                "from": {
+                    "key_code": "f8"
+                },
+                "to": {
+                    "key_code": "play_or_pause"
+                }
+            },
+            {
+                "from": {
+                    "key_code": "f9"
+                },
+                "to": {
+                    "key_code": "fastforward"
+                }
+            },
+            {
+                "from": {
+                    "key_code": "f10"
+                },
+                "to": {
+                    "key_code": "mute"
+                }
+            },
+            {
+                "from": {
+                    "key_code": "f11"
+                },
+                "to": {
+                    "key_code": "volume_decrement"
+                }
+            },
+            {
+                "from": {
+                    "key_code": "f12"
+                },
+                "to": {
+                    "key_code": "volume_increment"
+                }
+            }
+        ],
+        "name": "Default profile",
+        "selected": true,
+        "simple_modifications": [
+            {
+                "from": {
+                    "key_code": "caps_lock"
+                },
+                "to": {
+                    "key_code": "left_control"
+                }
+            }
+        ],
+        "virtual_hid_keyboard": {
+            "caps_lock_delay_milliseconds": 0,
+            "keyboard_type": "ansi"
+        }
+    }
+]


### PR DESCRIPTION
This makes the change_grave_accent_into_escape work in more apps (like PyCharm, WebStorm, Chrome, etc.) by making it use `to` rather than `to_if_alone`.

I don't know why this works better, but it does.