### PR TITLE
Modern Space Cadet rev2: more granular settings

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1113,7 +1113,7 @@
     </div>
     <div class="panel panel-default">
       <div class="panel-heading">
-        <a class="panel-title btn btn-link" role="button" data-toggle="collapse" href="#space_cadet" aria-expanded="false" aria-controls="space_cadet">Modern Space Cadet</a>
+        <a class="panel-title btn btn-link" role="button" data-toggle="collapse" href="#space_cadet" aria-expanded="false" aria-controls="space_cadet">Modern Space Cadet (rev2)</a>
         <a class="btn btn-primary btn-sm pull-right" data-json-path="json/space_cadet.json">Import</a>
       </div>
       <div class="list-group collapse" id="space_cadet">

--- a/docs/index.html
+++ b/docs/index.html
@@ -1117,7 +1117,7 @@
         <a class="btn btn-primary btn-sm pull-right" data-json-path="json/space_cadet.json">Import</a>
       </div>
       <div class="list-group collapse" id="space_cadet">
-          <div class="list-group-item">Caps Lock to Escape on single press, Control on press and hold.</div><div class="list-group-item">Control to Caps Lock on single press, &#39;Hyper Key&#39; on press and hold.</div><div class="list-group-item">Better Shifting (parentheses on shift keys)</div>
+          <div class="list-group-item">Caps Lock to Escape on single press, Control on press and hold.</div><div class="list-group-item">Control to Caps Lock on single press, &#39;Hyper Key&#39; on press and hold.</div><div class="list-group-item">Better Shifting: Parentheses on shift keys</div><div class="list-group-item">Better Shifting: Shift rolls</div><div class="list-group-item">Better Shifting: End parenthesis on shift + space</div>
       </div>
     </div>
 

--- a/docs/json/space_cadet.json
+++ b/docs/json/space_cadet.json
@@ -59,7 +59,50 @@
       ]
     },
     {
-      "description": "Better Shifting (parentheses on shift keys)",
+      "description": "Better Shifting: Parentheses on shift keys",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_shift"
+          },
+          "to": [
+            {
+              "key_code": "left_shift"
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "9",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_shift"
+          },
+          "to": [
+            {
+              "key_code": "right_shift"
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "0",
+              "modifiers": [
+                "right_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Better Shifting: Shift rolls",
       "manipulators": [
         {
           "type": "basic",
@@ -128,7 +171,12 @@
               ]
             }
           ]
-        },
+        }
+      ]
+    },
+    {
+      "description": "Better Shifting: End parenthesis on shift + space",
+      "manipulators": [
         {
           "type": "basic",
           "from": {
@@ -148,44 +196,6 @@
             },
             {
               "key_code": "spacebar"
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "left_shift"
-          },
-          "to": [
-            {
-              "key_code": "left_shift"
-            }
-          ],
-          "to_if_alone": [
-            {
-              "key_code": "9",
-              "modifiers": [
-                "left_shift"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "right_shift"
-          },
-          "to": [
-            {
-              "key_code": "right_shift"
-            }
-          ],
-          "to_if_alone": [
-            {
-              "key_code": "0",
-              "modifiers": [
-                "right_shift"
-              ]
             }
           ]
         }

--- a/docs/json/space_cadet.json
+++ b/docs/json/space_cadet.json
@@ -1,5 +1,5 @@
 {
-  "title": "Modern Space Cadet",
+  "title": "Modern Space Cadet (rev2)",
   "rules": [
     {
       "description": "Caps Lock to Escape on single press, Control on press and hold.",

--- a/src/json/space_cadet.json.erb
+++ b/src/json/space_cadet.json.erb
@@ -1,5 +1,5 @@
 {
-    "title": "Modern Space Cadet",
+    "title": "Modern Space Cadet (rev2)",
     "rules": [
         {
             "description": "Caps Lock to Escape on single press, Control on press and hold.",

--- a/src/json/space_cadet.json.erb
+++ b/src/json/space_cadet.json.erb
@@ -24,7 +24,24 @@
             ]
         },
         {
-            "description": "Better Shifting (parentheses on shift keys)",
+            "description": "Better Shifting: Parentheses on shift keys",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("left_shift", [], []) %>,
+                    "to": <%= to([["left_shift"]]) %>,
+                    "to_if_alone": <%= to([["9", ["left_shift"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("right_shift", [], []) %>,
+                    "to": <%= to([["right_shift"]]) %>,
+                    "to_if_alone": <%= to([["0", ["right_shift"]]]) %>
+                }
+            ]
+        },
+        {
+            "description": "Better Shifting: Shift rolls",
             "manipulators": [
                 {
                     "type": "basic",
@@ -37,23 +54,16 @@
                     "from": <%= from("right_shift", ["left_shift"], []) %>,
                     "to": <%= to([["right_shift"], ["left_shift"]]) %>,
                     "to_if_alone": <%= to([["9", ["right_shift"]], ["0", ["right_shift"]]]) %>
-                },
+                }
+            ]
+        },
+        {
+            "description": "Better Shifting: End parenthesis on shift + space",
+            "manipulators": [
                 {
                     "type": "basic",
                     "from": <%= from("spacebar", ["right_shift"], []) %>,
                     "to": <%= to([["0", ["right_shift"]], ["spacebar"]]) %>
-                },
-                {
-                    "type": "basic",
-                    "from": <%= from("left_shift", [], []) %>,
-                    "to": <%= to([["left_shift"]]) %>,
-                    "to_if_alone": <%= to([["9", ["left_shift"]]]) %>
-                },
-                {
-                    "type": "basic",
-                    "from": <%= from("right_shift", [], []) %>,
-                    "to": <%= to([["right_shift"]]) %>,
-                    "to_if_alone": <%= to([["0", ["right_shift"]]]) %>
                 }
             ]
         }


### PR DESCRIPTION
I split the 'Better Shifting' rules into three separate rulesets because I realised users might not want all three settings at the same time.