### PR TITLE
fix command / control bug in VMs (Rule virtual_machine.json)

### DIFF
--- a/docs/json/virtual_machine.json
+++ b/docs/json/virtual_machine.json
@@ -7,7 +7,7 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "control",
+            "key_code": "left_control",
             "modifiers": {
               "optional": [
                 "any"
@@ -51,7 +51,51 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "command",
+            "key_code": "right_control",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_command"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.vmware\\.fusion$",
+                "^com\\.vmware\\.horizon$",
+                "^com\\.vmware\\.view$",
+                "^com\\.parallels\\.desktop$",
+                "^com\\.parallels\\.vm$",
+                "^com\\.parallels\\.desktop\\.console$",
+                "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
+                "^com\\.vmware\\.proxyApp\\.",
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.microsoft\\.rdc$",
+                "^com\\.microsoft\\.rdc\\.mac$",
+                "^com\\.microsoft\\.rdc\\.osx\\.beta$",
+                "^net\\.sf\\.cord$",
+                "^com\\.thinomenon\\.RemoteDesktopConnection$",
+                "^com\\.itap-mobile\\.qmote$",
+                "^com\\.nulana\\.remotixmac$",
+                "^com\\.p5sys\\.jump\\.mac\\.viewer$",
+                "^com\\.p5sys\\.jump\\.mac\\.viewer\\.web$",
+                "^com\\.teamviewer\\.TeamViewer$",
+                "^com\\.vmware\\.horizon$",
+                "^com\\.2X\\.Client\\.Mac$"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_command",
             "modifiers": {
               "optional": [
                 "any"
@@ -61,6 +105,50 @@
           "to": [
             {
               "key_code": "left_control"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.vmware\\.fusion$",
+                "^com\\.vmware\\.horizon$",
+                "^com\\.vmware\\.view$",
+                "^com\\.parallels\\.desktop$",
+                "^com\\.parallels\\.vm$",
+                "^com\\.parallels\\.desktop\\.console$",
+                "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
+                "^com\\.vmware\\.proxyApp\\.",
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.microsoft\\.rdc$",
+                "^com\\.microsoft\\.rdc\\.mac$",
+                "^com\\.microsoft\\.rdc\\.osx\\.beta$",
+                "^net\\.sf\\.cord$",
+                "^com\\.thinomenon\\.RemoteDesktopConnection$",
+                "^com\\.itap-mobile\\.qmote$",
+                "^com\\.nulana\\.remotixmac$",
+                "^com\\.p5sys\\.jump\\.mac\\.viewer$",
+                "^com\\.p5sys\\.jump\\.mac\\.viewer\\.web$",
+                "^com\\.teamviewer\\.TeamViewer$",
+                "^com\\.vmware\\.horizon$",
+                "^com\\.2X\\.Client\\.Mac$"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_command",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_control"
             }
           ],
           "conditions": [

--- a/src/json/virtual_machine.json.erb
+++ b/src/json/virtual_machine.json.erb
@@ -6,18 +6,30 @@
             "manipulators": [
                 {
                     "type": "basic",
-                    "from": <%= from("control", [], ["any"]) %>,
+                    "from": <%= from("left_control", [], ["any"]) %>,
                     "to": <%= to([["left_command"]]) %>,
                     "conditions": [ <%= frontmost_application_if(["virtual_machine", "remote_desktop"]) %> ]
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("command", [], ["any"]) %>,
+                    "from": <%= from("right_control", [], ["any"]) %>,
+                    "to": <%= to([["right_command"]]) %>,
+                    "conditions": [ <%= frontmost_application_if(["virtual_machine", "remote_desktop"]) %> ]
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("left_command", [], ["any"]) %>,
                     "to": <%= to([["left_control"]]) %>,
+                    "conditions": [ <%= frontmost_application_if(["virtual_machine", "remote_desktop"]) %> ]
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("right_command", [], ["any"]) %>,
+                    "to": <%= to([["right_control"]]) %>,
                     "conditions": [ <%= frontmost_application_if(["virtual_machine", "remote_desktop"]) %> ]
                 }
             ]
-        }, 
+        },
         {
             "description": "Left Control -> Command unless in virtual machine/remote desktop",
             "manipulators": [
@@ -28,6 +40,6 @@
                     "conditions": [ <%= frontmost_application_unless(["remote_desktop", "virtual_machine"]) %> ]
                 }
             ]
-        } 
+        }
     ]
 }


### PR DESCRIPTION
Hi, 

there was an issue in the `virtual_machine.json` rule, see issue https://github.com/tekezo/Karabiner-Elements/issues/1091. The configuration I propose works well for me in my virtual machine using Ubuntu.
I think the problem was that `command` and `control` do not exist as a type but only `left_control`, `right_control`, `left_command`, and `right_command`. 

Cheers
René