### PR TITLE
Add Russian rule: remap ` to ё

### DIFF
--- a/src/json/russian.json.erb
+++ b/src/json/russian.json.erb
@@ -1,0 +1,25 @@
+{
+    "title": "For Russian",
+    "rules": [
+        {
+            "description": "Change grave accent (`) to ё in Russian layout",
+            "manipulators": [
+                {
+                    "conditions": [
+                        {
+                            "type": "input_source_if",
+                            "input_sources": [
+                                {
+                                    "language": "ru"
+                                }
+                            ]
+                        }
+                    ],
+                    "type": "basic",
+                    "from": <%= from("grave_accent_and_tilde", [], ["any"]) %>,
+                    "to": <%= to([["non_us_backslash"]]) %>
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
See https://github.com/tekezo/Karabiner-Elements/issues/100