### PR TITLE
Add rule to map eisuu or kana combined with other keys to option

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1382,11 +1382,11 @@
         <div class="panel-body">
               <div class="panel panel-default">
       <div class="panel-heading">
-        <a class="panel-title btn btn-link" role="button" data-toggle="collapse" href="#japanese" aria-expanded="false" aria-controls="japanese">For Japanese （日本語環境向けの設定） (rev 2)</a>
+        <a class="panel-title btn btn-link" role="button" data-toggle="collapse" href="#japanese" aria-expanded="false" aria-controls="japanese">For Japanese （日本語環境向けの設定） (rev 3)</a>
         <a class="btn btn-primary btn-sm pull-right" data-json-path="json/japanese.json">Import</a>
       </div>
       <div class="list-group collapse" id="japanese">
-          <div class="list-group-item">コマンドキーを単体で押したときに、英数・かなキーを送信する。（左コマンドキーは英数、右コマンドキーはかな） (rev 2)</div><div class="list-group-item">escキーを押したときに、英数キーも送信する（vim用）</div><div class="list-group-item">Ctrl+[を押したときに、英数キーも送信する（vim用） (rev 2)</div>
+          <div class="list-group-item">コマンドキーを単体で押したときに、英数・かなキーを送信する。（左コマンドキーは英数、右コマンドキーはかな） (rev 2)</div><div class="list-group-item">英数キー・かなキーを他のキーと同時に押したとき、Optionキーも送信する</div><div class="list-group-item">escキーを押したときに、英数キーも送信する（vim用）</div><div class="list-group-item">Ctrl+[を押したときに、英数キーも送信する（vim用） (rev 2)</div>
       </div>
     </div>
     <div class="panel panel-default">

--- a/docs/json/japanese.json
+++ b/docs/json/japanese.json
@@ -1,5 +1,5 @@
 {
-  "title": "For Japanese （日本語環境向けの設定） (rev 2)",
+  "title": "For Japanese （日本語環境向けの設定） (rev 3)",
   "rules": [
     {
       "description": "コマンドキーを単体で押したときに、英数・かなキーを送信する。（左コマンドキーは英数、右コマンドキーはかな） (rev 2)",
@@ -40,6 +40,53 @@
             {
               "key_code": "right_command",
               "lazy": true
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "japanese_kana"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "英数キー・かなキーを他のキーと同時に押したとき、Optionキーも送信する",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "japanese_eisuu",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_option"
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "japanese_eisuu"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "japanese_kana",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_option"
             }
           ],
           "to_if_alone": [

--- a/src/json/japanese.json.erb
+++ b/src/json/japanese.json.erb
@@ -1,5 +1,5 @@
 {
-    "title": "For Japanese （日本語環境向けの設定） (rev 2)",
+    "title": "For Japanese （日本語環境向けの設定） (rev 3)",
     "rules": [
         {
             "description": "コマンドキーを単体で押したときに、英数・かなキーを送信する。（左コマンドキーは英数、右コマンドキーはかな） (rev 2)",
@@ -22,6 +22,31 @@
                         {
                             "key_code": "right_command",
                             "lazy": true
+                        }
+                    ],
+                    "to_if_alone": <%= to([["japanese_kana"]]) %>
+                }
+            ]
+        },
+        {
+            "description": "英数・かなキーを他のキーと同時に押したときに、Optionキーを送信する",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("japanese_eisuu", [], ["any"]) %>,
+                    "to": [
+                        {
+                            "key_code": "left_option"
+                        }
+                    ],
+                    "to_if_alone": <%= to([["japanese_eisuu"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("japanese_kana", [], ["any"]) %>,
+                    "to": [
+                        {
+                            "key_code": "right_option"
                         }
                     ],
                     "to_if_alone": <%= to([["japanese_kana"]]) %>


### PR DESCRIPTION
I often map eisuu and kana keys to option keys, since long ago for vim (make option+any key to ESC+that key).

I have used Hammerspoon for this, but is not complete because it always behaves like (Karabiner-Elements') "lazy" option enabled.
Not making this "lazy" is important because holding option key is mapped to force quit in dock, some hidden functions in menu or etc...

Thanks for creating Karabiner and Karabiner-Elements, they totally saved my life time..!