### PR TITLE
Add New Poker II (Backtick, tilde & i/j/k/l as arrows)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -28,7 +28,7 @@
 <li class="list-group-item"><span class="badge">11</span> 
  <a href="#modifier_keys">Modifier Keys</a></li> 
 
-<li class="list-group-item"><span class="badge">18</span> 
+<li class="list-group-item"><span class="badge">19</span> 
  <a href="#emulation_modes">Emulation Modes</a></li> 
 
 <li class="list-group-item"><span class="badge">11</span> 
@@ -514,6 +514,18 @@
         </div>
         <div class="list-group collapse" id="pok3r-escape-list-group">
             <div class="list-group-item">Pok3r Escape key (grave_accent_and_tilde as Escape and fn + grave_accent_and_tilde as grave_accent_and_tilde)</div>
+        </div>
+      </div>
+    </div>
+    <div class="panel-outer" id="new-poker-ii">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <a href="#new-poker-ii"><span class="glyphicon glyphicon-link" aria-hidden="true"></span></a>
+          <a class="panel-title btn btn-link" role="button" data-toggle="collapse" href="#new-poker-ii-list-group" aria-expanded="false" aria-controls="new-poker-ii-list-group">New Poker II (Backtick, tilde &amp; i/j/k/l as arrows)</a>
+          <a class="btn btn-primary btn-sm pull-right" data-json-path="json/new-poker-ii.json">Import</a>
+        </div>
+        <div class="list-group collapse" id="new-poker-ii-list-group">
+            <div class="list-group-item">Capslock + Esc to `</div><div class="list-group-item">L_Shift + Esc to ~</div><div class="list-group-item">L_Control + i/j/k/l to arrows</div>
         </div>
       </div>
     </div>

--- a/docs/json/new-poker-ii.json
+++ b/docs/json/new-poker-ii.json
@@ -1,0 +1,131 @@
+{
+  "title": "New Poker II (Backtick, tilde & i/j/k/l as arrows)",
+  "rules": [
+    {
+      "description": "Capslock + Esc to `",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "escape",
+            "modifiers": {
+              "mandatory": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde"
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "L_Shift + Esc to ~",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "escape",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "L_Control + i/j/k/l to arrows",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": [
+                "left_control"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "mandatory": [
+                "left_control"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "k",
+            "modifiers": {
+              "mandatory": [
+                "left_control"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "down_arrow"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "mandatory": [
+                "left_control"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow"
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}

--- a/src/index.html.erb
+++ b/src/index.html.erb
@@ -52,6 +52,7 @@
             "docs/json/fn_plus_plsemicolonquote_to_arrow_keys.json",
             "docs/json/pok3r-media.json",
             "docs/json/pok3r-escape.json",
+            "docs/json/new-poker-ii.json",
             "docs/json/pc_shortcuts.json",
             "docs/json/dos_style.json",
             "docs/json/mu_mode.json",


### PR DESCRIPTION
There're some changes on iKBC New Poker II (2017), compared to Pok3r, that may affect developer's experience on MacOS:

  * Fn + Esc to insert backtick (`), now can use Capslock + Esc
  * Fn + Shift + Esc to insert tilde (~), now can use L_Shift + Esc
  * Fn + WASD as arrow keys, now can use L_Control + IJKL