### PR TITLE
Created rules for Poker Keyboard escape behavior

### DIFF
--- a/docs/groups.json
+++ b/docs/groups.json
@@ -86,6 +86,9 @@
           "path": "json/new-poker-ii.json"
         },
         {
+          "path": "json/poker-escape.json"
+        },
+        {
           "path": "json/pc_shortcuts.json"
         },
         {

--- a/docs/json/poker-escape.json
+++ b/docs/json/poker-escape.json
@@ -1,0 +1,50 @@
+{
+  "title": "Change Poker Keyboard escape behavior",
+  "rules": [
+    {
+      "description": "Change left command+escape to escape",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "escape",
+            "modifiers": {
+              "mandatory": [
+                "left_command"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "escape"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change escape to grave accent and tilde",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "escape",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/json/poker-escape.json
+++ b/docs/json/poker-escape.json
@@ -2,7 +2,7 @@
   "title": "Change Poker Keyboard escape behavior",
   "rules": [
     {
-      "description": "Change left command+escape to escape",
+      "description": "Change left option+escape to escape",
       "manipulators": [
         {
           "type": "basic",
@@ -10,7 +10,7 @@
             "key_code": "escape",
             "modifiers": {
               "mandatory": [
-                "left_command"
+                "left_option"
               ],
               "optional": [
                 "any"

--- a/src/json/poker-escape.json.erb
+++ b/src/json/poker-escape.json.erb
@@ -2,11 +2,11 @@
     "title": "Change Poker Keyboard escape behavior",
     "rules": [
         {
-            "description": "Change left command+escape to escape",
+            "description": "Change left option+escape to escape",
             "manipulators": [
                 {
                     "type": "basic",
-                    "from": <%= from("escape", ["left_command"], ["any"]) %>,
+                    "from": <%= from("escape", ["left_option"], ["any"]) %>,
                     "to": <%= to([["escape"]]) %>
                 }
             ]

--- a/src/json/poker-escape.json.erb
+++ b/src/json/poker-escape.json.erb
@@ -1,0 +1,25 @@
+{
+    "title": "Change Poker Keyboard escape behavior",
+    "rules": [
+        {
+            "description": "Change left command+escape to escape",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("escape", ["left_command"], ["any"]) %>,
+                    "to": <%= to([["escape"]]) %>
+                }
+            ]
+        },
+        {
+            "description": "Change escape to grave accent and tilde",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("escape", [], ["any"]) %>,
+                    "to": <%= to([["grave_accent_and_tilde"]]) %>
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Creates rules for Escape behavior with Poker Keyboard: swaps escape and grave accent and tilde, left command + escape for escape. This is useful when you type in languages making heavy use of accents and tildes.