### PR TITLE
Add complex rules for French Mac Keyboard for Microsoft Remote Desktop

### DIFF
--- a/docs/extra_descriptions/french_mac_keyboard_remote_desktop.json.html
+++ b/docs/extra_descriptions/french_mac_keyboard_remote_desktop.json.html
@@ -1,0 +1,18 @@
+<p style="margin-top: 20px; font-weight: bold">
+  Version 1.0
+</p>
+<p>Schedule features:</p>
+	<ul>
+	 	<li>We do not have yet tools to distinguish the remote session window from those which sometimes open asking for credentials before the remote connexion is set. Beware of passwords that use symbols that are not common to the PC and Mac keyboard.</li>
+	 	<li>You can not use the option "Use F1, F2, etc. as standard function keys" in a specific application yet. But as we regularly need F5 to "update" on Windows, my advice is to activate this option permanently. I'm afraid there will never be any change on this point.</li>
+	 	<li>Some configurations require the use of unexpected keys: <a href="https://github.com/tekezo/Karabiner-Elements/issues/1172">Current key to use for complex editing on Mac French keyboard # 1172</a> .</li>
+	</ul>
+<p>Known troubles:</p>
+	<ul>
+	 	<li>When the virtual keyboard is opened in your remote Windows session, some keys may behave strangely (for example, a grave accent).</li>
+	 	<li>MacBook users with Touch Bar may need to add these rules: <a href="https://pqrs.org/osx/karabiner/help.html#touch-bar-function-keys">Touch bar does not change to f1-f12 when I press the key fn</a>.</li>
+	</ul>
+<p>More information:</p>
+	<ul>
+	 	<li><a href="http://www.e-gaulue.com/en/2018/01/13/french-mac-keyboard-with-microsoft-remote-desktop-app-under-sierra-or-more-recent">French Mac Keyboard with Microsoft Remote Desktop App under Sierra or more recent</a></li>
+	</ul>

--- a/docs/groups.json
+++ b/docs/groups.json
@@ -128,6 +128,10 @@
           "path": "json/remote-desktop.json"
         },
         {
+          "path": "json/french_mac_keyboard_remote_desktop.json",
+          "extra_description_path": "extra_descriptions/french_mac_keyboard_remote_desktop.json.html"
+        },
+        {
           "path": "json/tmux_prefix.json",
           "extra_description_path": "extra_descriptions/tmux_prefix.json.html"
         },

--- a/docs/json/french_mac_keyboard_remote_desktop.json
+++ b/docs/json/french_mac_keyboard_remote_desktop.json
@@ -1,0 +1,681 @@
+{
+  "title": "For French Mac Keyboard under Microsoft Remote Desktop",
+  "rules": [
+    {
+        "description": "French remap for Microsoft Remote Desktop (incl. beta): All drawn keyboard symbols in one rule / Tous les symboles dessinés en une seule règle",
+        "manipulators": [
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "6"
+            },
+            "to": [
+              {
+                "key_code": "slash",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          },
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "8"
+            },
+            "to": [
+              {
+                "key_code": "slash"
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          },
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "equal_sign"
+            },
+            "to": [
+              {
+                "key_code": "6"
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          },
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "equal_sign",
+              "modifiers": {
+                "mandatory": [
+                    "shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "8"
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          },
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "grave_accent_and_tilde"
+            },
+            "to": [
+              {
+                "key_code": "0",
+                "modifiers": [
+                  "right_option"
+                ]
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          },
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": {
+                "mandatory": [
+                    "shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "3",
+                "modifiers": [
+                  "right_option"
+                ]
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          },
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "close_bracket",
+              "modifiers": {
+                "mandatory": [
+                    "shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "backslash"
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          },
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "close_bracket",
+              "modifiers": {
+                "mandatory": [
+                    "option"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "e",
+                "modifiers": [
+                  "right_option"
+                ]
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          },
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "non_us_pound"
+            },
+            "to": [
+              {
+                "key_code": "7",
+                "modifiers": [
+                  "right_option"
+                ]
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          },
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "non_us_pound",
+              "modifiers": {
+                "mandatory": [
+                    "shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "close_bracket",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          },
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "slash"
+            },
+            "to": [
+              {
+                "key_code": "equal_sign"
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          },
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "slash",
+              "modifiers": {
+                "mandatory": [
+                    "shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "equal_sign",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          }
+        ]
+    },
+    {
+        "description": "French remap for Microsoft Remote Desktop (incl. beta): Swap left Cmd and Ctrl / Echange Ctrl et Cmd de gauche",
+        "manipulators": [
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "left_control",
+              "modifiers": {
+                "optional": [
+                  "any"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "left_command"
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          },
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "left_command",
+              "modifiers": {
+                "optional": [
+                  "any"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "left_control"
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          }
+        ]
+    },
+    {
+        "description": "French remap for Microsoft Remote Desktop (incl. beta): '6' to '§'",
+        "manipulators": [
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "6"
+            },
+            "to": [
+              {
+                "key_code": "slash",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          }
+        ]
+    },
+    {
+        "description": "French remap for Microsoft Remote Desktop (incl. beta): '8' to '!'",
+        "manipulators": [
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "8"
+            },
+            "to": [
+              {
+                "key_code": "slash"
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          }
+        ]
+    },
+    {
+        "description": "French remap for Microsoft Remote Desktop (incl. beta): '=' to '-'",
+        "manipulators": [
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "equal_sign"
+            },
+            "to": [
+              {
+                "key_code": "6"
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          }
+        ]
+    },
+    {
+        "description": "French remap for Microsoft Remote Desktop (incl. beta): '=' + Shift to '_'",
+        "manipulators": [
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "equal_sign",
+              "modifiers": {
+                "mandatory": [
+                    "shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "8"
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          }
+        ]
+    },
+    {
+        "description": "French remap for Microsoft Remote Desktop (incl. beta): 'non_us_backslash' to '@'",
+        "manipulators": [
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "grave_accent_and_tilde"
+            },
+            "to": [
+              {
+                "key_code": "0",
+                "modifiers": [
+                  "right_option"
+                ]
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          }
+        ]
+    },
+    {
+        "description": "French remap for Microsoft Remote Desktop (incl. beta): 'non_us_backslash' + shift to '#'",
+        "manipulators": [
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": {
+                "mandatory": [
+                    "shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "3",
+                "modifiers": [
+                  "right_option"
+                ]
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          }
+        ]
+    },
+    {
+        "description": "French remap for Microsoft Remote Desktop (incl. beta): 'close_bracket' + Shift to '*'",
+        "manipulators": [
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "close_bracket",
+              "modifiers": {
+                "mandatory": [
+                    "shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "backslash"
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          }
+        ]
+    },
+    {
+        "description": "French remap for Microsoft Remote Desktop (incl. beta): 'close_bracket' + Alt to '€'",
+        "manipulators": [
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "close_bracket",
+              "modifiers": {
+                "mandatory": [
+                    "option"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "e",
+                "modifiers": [
+                  "right_option"
+                ]
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          }
+        ]
+    },
+    {
+        "description": "French remap for Microsoft Remote Desktop (incl. beta): 'backslash' to '`'",
+        "manipulators": [
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "non_us_pound"
+            },
+            "to": [
+              {
+                "key_code": "7",
+                "modifiers": [
+                  "right_option"
+                ]
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          }
+        ]
+    },
+    {
+        "description": "French remap for Microsoft Remote Desktop (incl. beta): 'backslash' + Shift to '£'",
+        "manipulators": [
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "non_us_pound",
+              "modifiers": {
+                "mandatory": [
+                    "shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "close_bracket",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          }
+        ]
+    },
+    {
+        "description": "French remap for Microsoft Remote Desktop (incl. beta): 'slash' to '='",
+        "manipulators": [
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "slash"
+            },
+            "to": [
+              {
+                "key_code": "equal_sign"
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          }
+        ]
+    },
+    {
+        "description": "French remap for Microsoft Remote Desktop (incl. beta): 'slash' + Shift to '+'",
+        "manipulators": [
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "slash",
+              "modifiers": {
+                "mandatory": [
+                    "shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "equal_sign",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ],
+            "conditions": [
+              {
+                "type": "frontmost_application_if",
+                "bundle_identifiers": [
+                  "com\\.microsoft\\.rdc\\.(mac|osx)"
+                ]
+              }
+            ]
+          }
+        ]
+    }
+  ]
+}


### PR DESCRIPTION
Has been tested for one month now... Could interest others as for French user of Microsoft Remote Desktop App, Microsoft has always considered we had a PC keyboard.

Regards