### PR TITLE
add vim arrow. left_control + hjkl, and shift/option/command + arrow i…

### DIFF
--- a/src/json/vi_mode_arrow.json.erb
+++ b/src/json/vi_mode_arrow.json.erb
@@ -1,0 +1,102 @@
+{
+    "title":"Vi Mode, left_control + hjkl. shift/option/command + arrow working.",
+    "rules": [
+        {
+            "description": "Vi Mode [left_control + hjkl]",
+            "manipulators": [
+                {
+                    "from": {
+                        "key_code": "h",
+                        "modifiers": {
+                            "mandatory": [
+                                "control"
+                            ],
+                            "optional": [
+                                "caps_lock",
+                                "command",
+                                "option",
+                                "shift",
+                                "fn"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "left_arrow"
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "from": {
+                        "key_code": "j",
+                        "modifiers": {
+                            "mandatory": [
+                                "control"
+                            ],
+                            "optional": [
+                                "caps_lock",
+                                "command",
+                                "option",
+                                "shift",
+                                "fn"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "down_arrow"
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "from": {
+                        "key_code": "k",
+                        "modifiers": {
+                            "mandatory": [
+                                "control"
+                            ],
+                            "optional": [
+                                "caps_lock",
+                                "command",
+                                "option",
+                                "shift",
+                                "fn"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "up_arrow"
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "from": {
+                        "key_code": "l",
+                        "modifiers": {
+                            "mandatory": [
+                                "control"
+                            ],
+                            "optional": [
+                                "caps_lock",
+                                "command",
+                                "option",
+                                "shift",
+                                "fn"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "right_arrow"
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Vi Mode, left_control + hjkl. 
shift/option/command + arrow working, Control + (other any key) is working.
I has try vim mode(ver 4.3), it not support control, if change D/S to control, control + C not working.
I has try vim arrow style, but is not support shift/option/command + arrow.