### PR TITLE
Adds rule "Equals + Delete to Forward Delete"

### DIFF
--- a/docs/groups.json
+++ b/docs/groups.json
@@ -267,6 +267,9 @@
         },
         {
           "path": "json/mousebuttons_copy_paste_screenshot.json"
+        },
+        {
+          "path": "json/equals_del_to_forward_del.json"
         }
       ]
     },

--- a/docs/json/equals_del_to_forward_del.json
+++ b/docs/json/equals_del_to_forward_del.json
@@ -1,0 +1,55 @@
+{
+  "title": "Equals + Delete to Forward Delete",
+  "rules": [
+    {
+      "description": "= + Del to Forward Del",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "equal_sign"
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "equals_for_forward_delete",
+                "value": 1
+              }
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "equal_sign"
+            }
+          ],
+          "to_after_key_up": [
+            {
+              "set_variable": {
+                "name": "equals_for_forward_delete",
+                "value": 0
+              }
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "delete_or_backspace"
+          },
+          "to": [
+            {
+              "key_code": "delete_forward"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "equals_for_forward_delete",
+              "value": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This adds a rule that maps `=`+`Del` to `Forward Del`. It is equivalent to a rule that existed in the old Karabiner (before Karabiner-Elements, in pre-Sierra OS).

> This is my first PR to any Karabiner-related repos, I've read the README.md and tried to follow the style of other files but please let me know if I've violated any conventions 🙂 