### PR TITLE
Improvements of the Neo2 configurations

### DIFF
--- a/docs/json/neo2.json
+++ b/docs/json/neo2.json
@@ -10,11 +10,7 @@
             "key_code": "backslash",
             "modifiers": {
               "optional": [
-                "shift",
-                "option",
-                "control",
-                "command",
-                "caps_lock"
+                "any"
               ]
             }
           },
@@ -30,31 +26,23 @@
             "key_code": "caps_lock",
             "modifiers": {
               "optional": [
-                "shift",
-                "option",
-                "control",
-                "command",
-                "caps_lock"
+                "any"
               ]
             }
           },
           "to": [
             {
-              "key_code": "right_option"
+              "key_code": "left_option"
             }
           ]
         },
         {
           "type": "basic",
           "from": {
-            "key_code": "grave_accent_and_tilde",
+            "key_code": "right_option",
             "modifiers": {
               "optional": [
-                "shift",
-                "option",
-                "control",
-                "command",
-                "caps_lock"
+                "any"
               ]
             }
           },
@@ -67,20 +55,54 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "right_option",
+            "key_code": "grave_accent_and_tilde",
             "modifiers": {
               "optional": [
-                "shift",
-                "option",
-                "control",
-                "command",
-                "caps_lock"
+                "any"
               ]
             }
           },
           "to": [
             {
-              "key_code": "left_command"
+              "set_variable": {
+                "name": "neo2_mod_4",
+                "value": 1
+              }
+            }
+          ],
+          "to_after_key_up": [
+            {
+              "set_variable": {
+                "name": "neo2_mod_4",
+                "value": 0
+              }
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_command",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "neo2_mod_4",
+                "value": 1
+              }
+            }
+          ],
+          "to_after_key_up": [
+            {
+              "set_variable": {
+                "name": "neo2_mod_4",
+                "value": 0
+              }
             }
           ]
         }
@@ -95,11 +117,7 @@
             "key_code": "non_us_pound",
             "modifiers": {
               "optional": [
-                "shift",
-                "option",
-                "control",
-                "command",
-                "caps_lock"
+                "any"
               ]
             }
           },
@@ -115,37 +133,13 @@
             "key_code": "caps_lock",
             "modifiers": {
               "optional": [
-                "shift",
-                "option",
-                "control",
-                "command",
-                "caps_lock"
+                "any"
               ]
             }
           },
           "to": [
             {
-              "key_code": "right_option"
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "non_us_backslash",
-            "modifiers": {
-              "optional": [
-                "shift",
-                "option",
-                "control",
-                "command",
-                "caps_lock"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "right_command"
+              "key_code": "left_option"
             }
           ]
         },
@@ -155,17 +149,67 @@
             "key_code": "right_option",
             "modifiers": {
               "optional": [
-                "shift",
-                "option",
-                "control",
-                "command",
-                "caps_lock"
+                "any"
               ]
             }
           },
           "to": [
             {
               "key_code": "right_command"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "non_us_backslash",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "neo2_mod_4",
+                "value": 1
+              }
+            }
+          ],
+          "to_after_key_up": [
+            {
+              "set_variable": {
+                "name": "neo2_mod_4",
+                "value": 0
+              }
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_command",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "neo2_mod_4",
+                "value": 1
+              }
+            }
+          ],
+          "to_after_key_up": [
+            {
+              "set_variable": {
+                "name": "neo2_mod_4",
+                "value": 0
+              }
             }
           ]
         }
@@ -179,18 +223,23 @@
           "from": {
             "key_code": "d",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
               "key_code": "down_arrow"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -199,18 +248,23 @@
           "from": {
             "key_code": "e",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
               "key_code": "up_arrow"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -219,18 +273,23 @@
           "from": {
             "key_code": "s",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
               "key_code": "left_arrow"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -239,18 +298,23 @@
           "from": {
             "key_code": "f",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
               "key_code": "right_arrow"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -259,18 +323,23 @@
           "from": {
             "key_code": "q",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
               "key_code": "page_up"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -279,18 +348,23 @@
           "from": {
             "key_code": "t",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
               "key_code": "page_down"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -299,18 +373,23 @@
           "from": {
             "key_code": "z",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
               "key_code": "escape"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -319,18 +398,23 @@
           "from": {
             "key_code": "w",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
               "key_code": "delete_or_backspace"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -339,18 +423,23 @@
           "from": {
             "key_code": "r",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
               "key_code": "delete_forward"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -359,18 +448,23 @@
           "from": {
             "key_code": "m",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
               "key_code": "keypad_1"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -379,18 +473,23 @@
           "from": {
             "key_code": "comma",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
               "key_code": "keypad_2"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -399,18 +498,23 @@
           "from": {
             "key_code": "period",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
               "key_code": "keypad_3"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -419,18 +523,23 @@
           "from": {
             "key_code": "j",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
               "key_code": "keypad_4"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -439,18 +548,23 @@
           "from": {
             "key_code": "k",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
               "key_code": "keypad_5"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -459,18 +573,23 @@
           "from": {
             "key_code": "l",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
               "key_code": "keypad_6"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -479,18 +598,23 @@
           "from": {
             "key_code": "u",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
               "key_code": "keypad_7"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -499,18 +623,23 @@
           "from": {
             "key_code": "i",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
               "key_code": "keypad_8"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -519,18 +648,23 @@
           "from": {
             "key_code": "o",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
               "key_code": "keypad_9"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -539,18 +673,23 @@
           "from": {
             "key_code": "spacebar",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
               "key_code": "keypad_0"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -559,18 +698,23 @@
           "from": {
             "key_code": "9",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
-              "key_code": "keypad_equal_sign"
+              "key_code": "keypad_slash"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -579,18 +723,23 @@
           "from": {
             "key_code": "0",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
-              "key_code": "keypad_slash"
+              "key_code": "keypad_asterisk"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -599,18 +748,23 @@
           "from": {
             "key_code": "hyphen",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
-              "key_code": "keypad_asterisk"
+              "key_code": "keypad_hyphen"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -619,18 +773,23 @@
           "from": {
             "key_code": "p",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
-              "key_code": "keypad_hyphen"
+              "key_code": "keypad_plus"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -639,18 +798,23 @@
           "from": {
             "key_code": "v",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
               "key_code": "return_or_enter"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -659,18 +823,23 @@
           "from": {
             "key_code": "quote",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
               "key_code": "period"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -679,18 +848,23 @@
           "from": {
             "key_code": "semicolon",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
               "key_code": "comma"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -699,18 +873,23 @@
           "from": {
             "key_code": "x",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
               "key_code": "tab"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -719,18 +898,23 @@
           "from": {
             "key_code": "8",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
           "to": [
             {
               "key_code": "tab"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
@@ -739,12 +923,10 @@
           "from": {
             "key_code": "n",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
@@ -755,6 +937,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -762,12 +951,10 @@
           "from": {
             "key_code": "slash",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
-                "caps_lock"
+                "caps_lock",
+                "command"
               ]
             }
           },
@@ -778,6 +965,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -785,9 +979,6 @@
           "from": {
             "key_code": "b",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
                 "caps_lock"
@@ -801,6 +992,13 @@
                 "left_command"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -808,9 +1006,6 @@
           "from": {
             "key_code": "c",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
                 "caps_lock"
@@ -824,6 +1019,13 @@
                 "left_command"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -831,9 +1033,6 @@
           "from": {
             "key_code": "a",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
                 "caps_lock"
@@ -847,6 +1046,13 @@
                 "left_command"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -854,9 +1060,6 @@
           "from": {
             "key_code": "g",
             "modifiers": {
-              "mandatory": [
-                "right_command"
-              ],
               "optional": [
                 "shift",
                 "caps_lock"
@@ -870,17 +1073,19 @@
                 "left_command"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
           "type": "basic",
           "from": {
-            "key_code": "non_us_backslash",
-            "modifiers": {
-              "mandatory": [
-                "right_command"
-              ]
-            }
+            "key_code": "non_us_backslash"
           },
           "to": [
             {
@@ -893,21 +1098,22 @@
             {
               "key_code": "non_us_backslash",
               "modifiers": [
-                "left_shift",
-                "caps_lock"
+                "left_shift"
               ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
         {
           "type": "basic",
           "from": {
-            "key_code": "1",
-            "modifiers": {
-              "mandatory": [
-                "right_command"
-              ]
-            }
+            "key_code": "1"
           },
           "to": [
             {
@@ -920,21 +1126,22 @@
             {
               "key_code": "1",
               "modifiers": [
-                "left_shift",
-                "caps_lock"
+                "left_shift"
               ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
         {
           "type": "basic",
           "from": {
-            "key_code": "2",
-            "modifiers": {
-              "mandatory": [
-                "right_command"
-              ]
-            }
+            "key_code": "2"
           },
           "to": [
             {
@@ -947,21 +1154,22 @@
             {
               "key_code": "2",
               "modifiers": [
-                "left_shift",
-                "caps_lock"
+                "left_shift"
               ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
         {
           "type": "basic",
           "from": {
-            "key_code": "3",
-            "modifiers": {
-              "mandatory": [
-                "right_command"
-              ]
-            }
+            "key_code": "3"
           },
           "to": [
             {
@@ -974,21 +1182,22 @@
             {
               "key_code": "3",
               "modifiers": [
-                "left_shift",
-                "caps_lock"
+                "left_shift"
               ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
         {
           "type": "basic",
           "from": {
-            "key_code": "4",
-            "modifiers": {
-              "mandatory": [
-                "right_command"
-              ]
-            }
+            "key_code": "4"
           },
           "to": [
             {
@@ -1001,21 +1210,22 @@
             {
               "key_code": "4",
               "modifiers": [
-                "left_shift",
-                "caps_lock"
+                "left_shift"
               ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
         {
           "type": "basic",
           "from": {
-            "key_code": "5",
-            "modifiers": {
-              "mandatory": [
-                "right_command"
-              ]
-            }
+            "key_code": "5"
           },
           "to": [
             {
@@ -1028,21 +1238,22 @@
             {
               "key_code": "5",
               "modifiers": [
-                "left_shift",
-                "caps_lock"
+                "left_shift"
               ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
         {
           "type": "basic",
           "from": {
-            "key_code": "6",
-            "modifiers": {
-              "mandatory": [
-                "right_command"
-              ]
-            }
+            "key_code": "6"
           },
           "to": [
             {
@@ -1055,21 +1266,22 @@
             {
               "key_code": "6",
               "modifiers": [
-                "left_shift",
-                "caps_lock"
+                "left_shift"
               ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
         {
           "type": "basic",
           "from": {
-            "key_code": "7",
-            "modifiers": {
-              "mandatory": [
-                "right_command"
-              ]
-            }
+            "key_code": "7"
           },
           "to": [
             {
@@ -1082,21 +1294,22 @@
             {
               "key_code": "7",
               "modifiers": [
-                "left_shift",
-                "caps_lock"
+                "left_shift"
               ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
         {
           "type": "basic",
           "from": {
-            "key_code": "hyphen",
-            "modifiers": {
-              "mandatory": [
-                "right_command"
-              ]
-            }
+            "key_code": "hyphen"
           },
           "to": [
             {
@@ -1109,21 +1322,22 @@
             {
               "key_code": "hyphen",
               "modifiers": [
-                "left_shift",
-                "caps_lock"
+                "left_shift"
               ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
         {
           "type": "basic",
           "from": {
-            "key_code": "equal_sign",
-            "modifiers": {
-              "mandatory": [
-                "right_command"
-              ]
-            }
+            "key_code": "equal_sign"
           },
           "to": [
             {
@@ -1136,21 +1350,22 @@
             {
               "key_code": "equal_sign",
               "modifiers": [
-                "left_shift",
-                "caps_lock"
+                "left_shift"
               ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
         {
           "type": "basic",
           "from": {
-            "key_code": "open_bracket",
-            "modifiers": {
-              "mandatory": [
-                "right_command"
-              ]
-            }
+            "key_code": "open_bracket"
           },
           "to": [
             {
@@ -1163,21 +1378,22 @@
             {
               "key_code": "open_bracket",
               "modifiers": [
-                "left_shift",
-                "caps_lock"
+                "left_shift"
               ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
         {
           "type": "basic",
           "from": {
-            "key_code": "close_bracket",
-            "modifiers": {
-              "mandatory": [
-                "right_command"
-              ]
-            }
+            "key_code": "close_bracket"
           },
           "to": [
             {
@@ -1190,21 +1406,22 @@
             {
               "key_code": "close_bracket",
               "modifiers": [
-                "left_shift",
-                "caps_lock"
+                "left_shift"
               ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
         {
           "type": "basic",
           "from": {
-            "key_code": "y",
-            "modifiers": {
-              "mandatory": [
-                "right_command"
-              ]
-            }
+            "key_code": "y"
           },
           "to": [
             {
@@ -1217,21 +1434,22 @@
             {
               "key_code": "y",
               "modifiers": [
-                "left_shift",
-                "caps_lock"
+                "left_shift"
               ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         },
         {
           "type": "basic",
           "from": {
-            "key_code": "h",
-            "modifiers": {
-              "mandatory": [
-                "right_command"
-              ]
-            }
+            "key_code": "h"
           },
           "to": [
             {
@@ -1244,9 +1462,15 @@
             {
               "key_code": "h",
               "modifiers": [
-                "left_shift",
-                "caps_lock"
+                "left_shift"
               ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         }
@@ -1261,7 +1485,6 @@
             "key_code": "non_us_backslash",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1281,6 +1504,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1289,7 +1519,6 @@
             "key_code": "1",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1309,6 +1538,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1317,7 +1553,6 @@
             "key_code": "2",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1337,6 +1572,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1345,7 +1587,6 @@
             "key_code": "3",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1365,6 +1606,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1373,7 +1621,6 @@
             "key_code": "4",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1393,6 +1640,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1401,7 +1655,6 @@
             "key_code": "5",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1421,6 +1674,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1429,7 +1689,6 @@
             "key_code": "6",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1449,6 +1708,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1457,7 +1723,6 @@
             "key_code": "7",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1477,6 +1742,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1485,7 +1757,6 @@
             "key_code": "8",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1505,6 +1776,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1513,7 +1791,6 @@
             "key_code": "9",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1533,6 +1810,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1541,7 +1825,6 @@
             "key_code": "0",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1561,6 +1844,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1569,7 +1859,6 @@
             "key_code": "hyphen",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1589,6 +1878,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1597,7 +1893,6 @@
             "key_code": "equal_sign",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1617,6 +1912,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1625,7 +1927,6 @@
             "key_code": "q",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1645,6 +1946,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1653,7 +1961,6 @@
             "key_code": "w",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1673,6 +1980,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1681,7 +1995,6 @@
             "key_code": "e",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1701,6 +2014,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1709,7 +2029,6 @@
             "key_code": "r",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1729,6 +2048,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1737,7 +2063,6 @@
             "key_code": "t",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1757,6 +2082,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1765,7 +2097,6 @@
             "key_code": "y",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1785,6 +2116,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1793,7 +2131,6 @@
             "key_code": "u",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1813,6 +2150,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1821,7 +2165,6 @@
             "key_code": "i",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1841,6 +2184,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1849,7 +2199,6 @@
             "key_code": "o",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1869,6 +2218,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1877,7 +2233,6 @@
             "key_code": "p",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1897,6 +2252,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1905,7 +2267,6 @@
             "key_code": "open_bracket",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1925,6 +2286,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1933,7 +2301,6 @@
             "key_code": "close_bracket",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1953,6 +2320,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1961,7 +2335,6 @@
             "key_code": "a",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -1981,6 +2354,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -1989,7 +2369,6 @@
             "key_code": "s",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -2009,6 +2388,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -2017,7 +2403,6 @@
             "key_code": "d",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -2037,6 +2422,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -2045,7 +2437,6 @@
             "key_code": "f",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -2065,6 +2456,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -2073,7 +2471,6 @@
             "key_code": "g",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -2093,6 +2490,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -2101,7 +2505,6 @@
             "key_code": "h",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -2121,6 +2524,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -2129,7 +2539,6 @@
             "key_code": "j",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -2149,6 +2558,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -2157,7 +2573,6 @@
             "key_code": "k",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -2177,6 +2592,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -2185,7 +2607,6 @@
             "key_code": "l",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -2205,6 +2626,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -2213,7 +2641,6 @@
             "key_code": "semicolon",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -2233,6 +2660,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -2241,7 +2675,6 @@
             "key_code": "quote",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -2261,6 +2694,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -2269,7 +2709,6 @@
             "key_code": "z",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -2289,6 +2728,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -2297,7 +2743,6 @@
             "key_code": "x",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -2317,6 +2762,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -2325,7 +2777,6 @@
             "key_code": "c",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -2345,6 +2796,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -2353,7 +2811,6 @@
             "key_code": "v",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -2373,6 +2830,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -2381,7 +2845,6 @@
             "key_code": "b",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -2401,6 +2864,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -2409,7 +2879,6 @@
             "key_code": "n",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -2429,6 +2898,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -2437,7 +2913,6 @@
             "key_code": "m",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -2457,6 +2932,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -2465,7 +2947,6 @@
             "key_code": "comma",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -2485,6 +2966,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -2493,7 +2981,6 @@
             "key_code": "period",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -2513,6 +3000,13 @@
                 "left_option"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
+            }
           ]
         },
         {
@@ -2521,7 +3015,6 @@
             "key_code": "slash",
             "modifiers": {
               "mandatory": [
-                "right_command",
                 "option"
               ]
             }
@@ -2540,6 +3033,13 @@
                 "left_shift",
                 "left_option"
               ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "neo2_mod_4",
+              "value": 1
             }
           ]
         }

--- a/src/json/neo2.json.erb
+++ b/src/json/neo2.json.erb
@@ -1,47 +1,41 @@
 {
     "title": "Neo2",
     "rules": [
+        <% def set_mod_4(b)
+            { "set_variable" => { "name" => "neo2_mod_4", "value" => b } }
+        end
+        if_mod_4 = { "type" => "variable_if", "name" => "neo2_mod_4", "value" => 1 }
+        def neo2_modifiers(mod_3_key, mod_4_key)
+            JSON.generate(
+                each_key(
+                    source_keys_list: [
+                        mod_3_key,
+                        "caps_lock",
+                        "right_option",
+                    ],
+                    dest_keys_list: [
+                        "right_option",
+                        "left_option",
+                        "right_command",
+                    ],
+                    from_optional_modifiers: ["any"]
+                ) + [mod_4_key, "right_command"].map { |from_key|
+                    {
+                        "type" => "basic",
+                        "from" => _from(from_key, [], ["any"]),
+                        "to" => [set_mod_4(1)],
+                        "to_after_key_up" => [set_mod_4(0)]
+                    }
+                }
+            )
+        end %>
         {
             "description": "Neo2 mod 3 and 4 keys (Apple keyboard)",
-            "manipulators": <%= each_key(
-                as_json: true,
-                source_keys_list: [
-                    "backslash",
-                    "caps_lock",
-                    "grave_accent_and_tilde",
-                    "right_option",
-                ],
-                dest_keys_list: [
-                    "right_option",
-                    "right_option",
-                    "right_command",
-                    "left_command",
-                ],
-                from_optional_modifiers: [
-                    "shift", "option", "control", "command", "caps_lock",
-                ]
-            ) %>
+            "manipulators": <%= neo2_modifiers("backslash", "grave_accent_and_tilde") %>
         },
         {
             "description": "Neo2 mod 3 and 4 keys (Windows keyboard)",
-            "manipulators": <%= each_key(
-                as_json: true,
-                source_keys_list: [
-                    "non_us_pound",
-                    "caps_lock",
-                    "non_us_backslash",
-                    "right_option",
-                ],
-                dest_keys_list: [
-                    "right_option",
-                    "right_option",
-                    "right_command",
-                    "right_command",
-                ],
-                from_optional_modifiers: [
-                    "shift", "option", "control", "command", "caps_lock",
-                ]
-            ) %>
+            "manipulators": <%= neo2_modifiers("non_us_pound", "non_us_backslash") %>
         },
         {
             "description": "Neo2 layer 4",
@@ -73,10 +67,10 @@
                 "i" => "keypad_8",
                 "o" => "keypad_9",
                 "spacebar" => "keypad_0",
-                "9" => "keypad_equal_sign",    # divide
-                "0" => "keypad_slash",         # multiply
-                "hyphen" => "keypad_asterisk", # subtract
-                "p" => "keypad_hyphen",        # add
+                "9" => "keypad_slash",
+                "0" => "keypad_asterisk",
+                "hyphen" => "keypad_hyphen",
+                "p" => "keypad_plus",
                 "v" => "return_or_enter",
                 "quote" => "period",
                 "semicolon" => "comma",
@@ -96,25 +90,25 @@
                 each_key(
                     source_keys_list: l4_mappings.keys,
                     dest_keys_list: l4_mappings.values,
-                    from_mandatory_modifiers: ["right_command"],
-                    from_optional_modifiers: ["shift", "caps_lock"]
+                    conditions: [if_mod_4],
+                    from_optional_modifiers: ["shift", "caps_lock", "command"]
                 ) + each_key(
                     source_keys_list: ["n", "slash"],
                     dest_keys_list: ["semicolon", "slash"],
-                    from_mandatory_modifiers: ["right_command"],
-                    from_optional_modifiers: ["shift", "caps_lock"],
+                    conditions: [if_mod_4],
+                    from_optional_modifiers: ["shift", "caps_lock", "command"],
                     to_modifiers: ["left_option"]
                 ) + each_key(
                     source_keys_list: ["b", "c", "a", "g"],
                     dest_keys_list: ["b", "w", "left_arrow", "right_arrow"],
-                    from_mandatory_modifiers: ["right_command"],
+                    conditions: [if_mod_4],
                     from_optional_modifiers: ["shift", "caps_lock"],
                     to_modifiers: ["left_command"]
                 ) + each_key(
                     source_keys_list: l4_dead_key_mappings,
                     dest_keys_list: l4_dead_key_mappings,
-                    from_mandatory_modifiers: ["right_command"],
-                    to_modifiers: ["left_shift", "caps_lock"],
+                    conditions: [if_mod_4],
+                    to_modifiers: ["left_shift"],
                     to_pre_events: [["z", ["left_option", "left_shift"]]]
                 )
             ) %>
@@ -137,7 +131,8 @@
                 each_key(
                     source_keys_list: l6_dead_key_mappings,
                     dest_keys_list: l6_dead_key_mappings,
-                    from_mandatory_modifiers: ["right_command", "option"],
+                    conditions: [if_mod_4],
+                    from_mandatory_modifiers: ["option"],
                     to_modifiers: ["left_shift", "left_option"],
                     to_pre_events: [["z", ["left_option", "left_shift"]]]
                 )


### PR DESCRIPTION
Mod4 is now implemented using variables instead of overloading
right_command, which allows for using cmd + mod4 shortcuts, and also
allows for more involved private modifications that need the
right_command flag to be unset.

Fixes capslock incorrectly being triggered in layer 4.

Fixes keypad numeric operators, see jgosmann/KE-complex_modifications#2.