### PR TITLE
app-specific convert hangouts mic/video mute to zoom.us

### DIFF
--- a/docs/groups.json
+++ b/docs/groups.json
@@ -125,6 +125,9 @@
       "id": "application-specific",
       "files": [
         {
+          "path": "json/convert_hangouts_mutes_to_zoom_us.json"
+        },
+        {
           "path": "json/swap_alt_cmd_in_autodesk_maya.json"
         },
         {

--- a/docs/json/convert_hangouts_mutes_to_zoom_us.json
+++ b/docs/json/convert_hangouts_mutes_to_zoom_us.json
@@ -1,0 +1,71 @@
+{
+  "title": "Convert hangouts Mic/Video Mutes to Zoom.us",
+  "rules": [
+    {
+        "description": "Convert hangouts mic mute to Zoom.us mic mute",
+        "manipulators": [
+            {
+                "conditions": [
+                    {
+                        "bundle_identifiers": [
+                            "us.zoom.xos"
+                        ],
+                        "type": "frontmost_application_if"
+                    }
+                ],
+                "from": {
+                    "key_code": "d",
+                    "modifiers": {
+                        "mandatory": [
+                            "left_command"
+                        ]
+                    }
+                },
+                "to": [
+                    {
+                        "key_code": "a",
+                        "modifiers": [
+                            "left_command",
+                            "left_shift"
+                        ]
+                    }
+                ],
+                "type": "basic"
+            }
+        ]
+    },
+    {
+        "description": "Convert hangouts video mute to Zoom.us video mute",
+        "manipulators": [
+            {
+                "conditions": [
+                    {
+                        "bundle_identifiers": [
+                            "us.zoom.xos"
+                        ],
+                        "type": "frontmost_application_if"
+                    }
+                ],
+                "from": {
+                    "key_code": "e",
+                    "modifiers": {
+                        "mandatory": [
+                            "left_command"
+                        ]
+                    }
+                },
+                "to": [
+                    {
+                        "key_code": "v",
+                        "modifiers": [
+                            "left_command",
+                            "left_shift"
+                        ]
+                    }
+                ],
+                "type": "basic"
+            }
+        ]
+    }
+]
+}


### PR DESCRIPTION
I've been using Hangouts for over 6 years now, but my org is moving to Zoom. there's a lot of muscle memory built up, and this helps with that.

While Zoom.us is the frontmost app:
convert cmd-d to cmd-shift-a
convert cmd-e to cmd-shift-v