### PR TITLE
A German Programming Mapping

### DIFF
--- a/docs/extra_descriptions/german_programming.json.html
+++ b/docs/extra_descriptions/german_programming.json.html
@@ -1,0 +1,42 @@
+<p style="margin-top: 20px; font-weight: bold">
+  Mapped Keys
+</p>
+
+<table class="table">
+  <tr>
+    <th>From</th>
+    <th>To</th>
+  </tr>
+  <tr>
+    <td>Control+ö</td>
+    <td>{</td>
+  </tr>
+  <tr>
+    <td>Control+ä</td>
+    <td>}</td>
+  </tr>
+  <tr>
+    <td>Left Command+ö</td>
+    <td>[</td>
+  </tr>
+  <tr>
+    <td>Left Command+#</td>
+    <td>]</td>
+  </tr>
+  <tr>
+    <td>Control++</td>
+    <td>~</td>
+  </tr>
+  <tr>
+    <td>Control+-</td>
+    <td>/</td>
+  </tr>
+  <tr>
+    <td>Right Option+ß</td>
+    <td>\</td>
+  </tr>
+  <tr>
+    <td>Right Option+<</td>
+    <td>|</td>
+  </tr>
+</table>

--- a/docs/groups.json
+++ b/docs/groups.json
@@ -212,6 +212,10 @@
           "path": "json/german_umlaut.json"
         },
         {
+          "path": "json/german_programming.json",
+          "extra_description_path": "extra_descriptions/german_programming.json.html"
+        },
+        {
           "path": "json/czech_pc_shortcuts.json"
         },
         {

--- a/docs/json/german_programming.json
+++ b/docs/json/german_programming.json
@@ -1,0 +1,138 @@
+{
+  "title": "German mapping for programming (/, \\, |, {}, [], ~)",
+  "rules": [
+    {
+      "description": "German mapping for programming (/, \\, |, {}, [], ~)",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "semicolon",
+            "modifiers": {
+              "mandatory": [ "left_command" ],
+              "optional":  [ "any" ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "5",
+              "modifiers": { "mandatory": "left_option" }
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "quote",
+            "modifiers": {
+              "mandatory": [ "left_command" ],
+              "optional":  [ "any" ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "6",
+              "modifiers": { "mandatory": "left_option" }
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "semicolon",
+            "modifiers": {
+              "mandatory": [ "left_control" ],
+              "optional":  [ "any" ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "8",
+              "modifiers": { "mandatory": "left_option" }
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "quote",
+            "modifiers": {
+              "mandatory": [ "left_control" ],
+              "optional":  [ "any" ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "9",
+              "modifiers": { "mandatory": "left_option" }
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "close_bracket",
+            "modifiers": {
+              "mandatory": [ "left_control" ],
+              "optional":  [ "any" ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "n",
+              "modifiers": { "mandatory": "left_option" }
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "slash",
+            "modifiers": {
+              "mandatory": [ "left_control" ],
+              "optional":  [ "any" ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "7",
+              "modifiers": { "mandatory": "shift" }
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "hyphen",
+            "modifiers": {
+              "mandatory": [ "right_option" ],
+              "optional":  [ "any" ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "7",
+              "modifiers": ["left_shift", "left_option"]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "grave_accent_and_tilde",
+            "modifiers": {
+              "mandatory": [ "right_option" ],
+              "optional":  [ "any" ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "7",
+              "modifiers": ["left_option"]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Common programming characters like {} and [] are mapped horribly
on a German keyboard. Hope this helps some folks.

I think this used to be available in the old Karabiner.