### PR TITLE
Update "Equals+Del" rule to use new "simultaneous" feature

### DIFF
--- a/docs/json/equals_del_to_forward_del.json
+++ b/docs/json/equals_del_to_forward_del.json
@@ -2,50 +2,28 @@
   "title": "Equals + Delete to Forward Delete",
   "rules": [
     {
-      "description": "= + Del to Forward Del",
+      "description": "Simultaneously press Equals + Del to get a ForwardDel",
       "manipulators": [
         {
           "type": "basic",
           "from": {
-            "key_code": "equal_sign"
-          },
-          "to": [
-            {
-              "set_variable": {
-                "name": "equals_for_forward_delete",
-                "value": 1
+            "simultaneous": [
+              {
+                "key_code": "equal_sign"
+              },
+              {
+                "key_code": "delete_or_backspace"
               }
+            ],
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
             }
-          ],
-          "to_if_alone": [
-            {
-              "key_code": "equal_sign"
-            }
-          ],
-          "to_after_key_up": [
-            {
-              "set_variable": {
-                "name": "equals_for_forward_delete",
-                "value": 0
-              }
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "delete_or_backspace"
           },
           "to": [
             {
               "key_code": "delete_forward"
-            }
-          ],
-          "conditions": [
-            {
-              "type": "variable_if",
-              "name": "equals_for_forward_delete",
-              "value": 1
             }
           ]
         }


### PR DESCRIPTION
The older version of this modification, which I added in #281, had some issues when modifiers were pressed. This new version uses the new "simultaneous key presses" to work as expected. 

The code is actually the one in the [documentation](https://pqrs.org/osx/karabiner/json.html#typical-complex_modifications-examples-simultaneous-equal-delete-to-forward-delete), but I didn't see it in the list of complex modification that could be added directly from the "Preferences", therefore I'm updating my old code to use this new one so anyone can import it in an easier manner (let me know if I missed some place).