### PR TITLE
erb2json: add kitty to terminal_bundle_identifiers

### DIFF
--- a/scripts/erb2json.rb
+++ b/scripts/erb2json.rb
@@ -141,6 +141,7 @@ def frontmost_application(type, app_aliases)
     '^co\.zeit\.hyperterm$',
     '^co\.zeit\.hyper$',
     '^io\.alacritty$',
+    '^net\.kovidgoyal\.kitty$',
   ]
 
   vi_bundle_identifiers = [


### PR DESCRIPTION
As the subject line says, this is just adding [kitty](https://github.com/kovidgoyal/kitty) to the list of known terminals.