### PR TITLE
Add "Ctrl+[を押したときに、escキーと英数キーを送信する" (Send Escape and Eisuu when Ctrl+…

### DIFF
--- a/docs/json/japanese.json
+++ b/docs/json/japanese.json
@@ -183,6 +183,66 @@
       ]
     },
     {
+      "description": "Ctrl+[を押したときに、escキーと英数キーを送信する",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "open_bracket",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "escape"
+            },
+            {
+              "key_code": "japanese_eisuu"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": [
+                "ansi",
+                "iso"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "close_bracket",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "escape"
+            },
+            {
+              "key_code": "japanese_eisuu"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": [
+                "jis"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
       "description": "英数・かなキーをtoggle方式にする",
       "manipulators": [
         {

--- a/src/json/japanese.json.erb
+++ b/src/json/japanese.json.erb
@@ -96,6 +96,38 @@
             ]
         },
         {
+            "description": "Ctrl+[を押したときに、escキーと英数キーを送信する",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("open_bracket", ["control"], []) %>,
+                    "to": <%= to([["escape"], ["japanese_eisuu"]]) %>,
+                    "conditions": [
+                        {
+                            "type": "keyboard_type_if",
+                            "keyboard_types": [
+                                "ansi",
+                                "iso"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("close_bracket", ["control"], []) %>,
+                    "to": <%= to([["escape"], ["japanese_eisuu"]]) %>,
+                    "conditions": [
+                        {
+                            "type": "keyboard_type_if",
+                            "keyboard_types": [
+                                "jis"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "description": "英数・かなキーをtoggle方式にする",
             "manipulators": [
                 {


### PR DESCRIPTION
This PR will extend the vim-like `Ctrl+[` -> `Escape AND Eisuu` behavior to outside of vim, say when browsing the web or using other text editors.
AFAIK there is currently no way to achieve this with existing modification rules.