### PR TITLE
Ctrl+6 to Ctrl+Shift+6 for vim buffer switching

### DIFF
--- a/docs/groups.json
+++ b/docs/groups.json
@@ -60,6 +60,9 @@
           "path": "json/vim_style_escape.json"
         },
         {
+          "path": "json/vim_buffer_switch.json"
+        },
+        {
           "path": "json/vi_mode_arrow.json"
         },
         {

--- a/docs/json/vim_buffer_switch.json
+++ b/docs/json/vim_buffer_switch.json
@@ -1,0 +1,23 @@
+{
+  "title": "Vim Ctrl+6 to Ctrl+Shift+6 for buffer switching",
+  "rules": [
+    {
+      "description": "Map ctrl + 6 to ctrl + shift + 6",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "6",
+            "modifiers": {
+              "mandatory": ["control"]
+            }
+          },
+          "to": [{
+              "key_code": "6",
+              "modifiers": ["left_control", "left_shift"]
+            }]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I haven't found the existing code, so wrote my own based on other examples. The key mapping is intended to be used in vim to switch between the previous/next buffers. Ctrl+6 doesn't not work in MacOS directly. Luckily vim supports Ctrl+Shift+6 combination to have the same function as Ctrl+6.