### PR TITLE
Assign `right_command` to `japanese_kana` in jis_to_ascii

### DIFF
--- a/docs/json/jis_to_ascii.json
+++ b/docs/json/jis_to_ascii.json
@@ -45,6 +45,27 @@
               "key_code": "japanese_kana"
             }
           ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_command",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_command"
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "japanese_kana"
+            }
+          ]
         }
       ]
     },

--- a/src/json/jis_to_ascii.json.erb
+++ b/src/json/jis_to_ascii.json.erb
@@ -15,6 +15,12 @@
           "from": <%= from("japanese_kana", [], ["any"]) %>,
           "to": <%= to([["right_command"]]) %>,
           "to_if_alone": <%= to([["japanese_kana"]]) %>
+        },
+        {
+          "type": "basic",
+          "from": <%= from("right_command", [], ["any"]) %>,
+          "to": <%= to([["right_command"]]) %>,
+          "to_if_alone": <%= to([["japanese_kana"]]) %>
         }
       ]
     },


### PR DESCRIPTION
Assigns `right_command` to `japanese_kana` in jis_to_ascii keymap.