### PR TITLE
Modifications for swapping Command and Ctrl, for Windows keyboards

### DIFF
--- a/docs/groups.json
+++ b/docs/groups.json
@@ -5,6 +5,9 @@
       "id": "modifier-keys",
       "files": [
         {
+          "path": "json/command_ctrl_for_windows_keyboard.json"
+        }
+        {
           "path": "json/caps_and_return_to_ctrl.json"
         },
         {

--- a/docs/json/command_ctrl_for_windows_keyboard.json
+++ b/docs/json/command_ctrl_for_windows_keyboard.json
@@ -1,0 +1,198 @@
+{
+  "title": "Swap Ctrl key with Command key, with PC-style Alt+Tab and Alt+Backtick mapped to Option+Tab and Option+Backtick",
+  "rules": [
+    {
+      "description": "Swap Command with Ctrl",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_command",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_control"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_control",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_command"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_shift",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_shift",
+              "lazy": true
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_command",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_control"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_control",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_command"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_shift",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_shift",
+              "lazy": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Option+Tab to Command+Tab",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "tab",
+            "modifiers": {
+              "mandatory": [
+                "left_option"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "tab",
+              "modifiers": "command"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "tab",
+            "modifiers": {
+              "mandatory": [
+                "right_option"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "tab",
+              "modifiers": "command"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Option+Backtick to Command+Backtick",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "grave_accent_and_tilde",
+            "modifiers": {
+              "mandatory": [
+                "left_option"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": "command"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "grave_accent_and_tilde",
+            "modifiers": {
+              "mandatory": [
+                "right_option"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": "command"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/command_ctrl_for_windows_keyboard.json.erb
+++ b/src/json/command_ctrl_for_windows_keyboard.json.erb
@@ -1,0 +1,70 @@
+{
+    "title": "Swap Ctrl key with Command key, with PC-style Alt+Tab and Alt+Backtick mapped to Option+Tab and Option+Backtick",
+    "rules": [
+        {
+            "description": "Swap Command with Ctrl",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("left_command", [], ["any"]) %>,
+                    "to": <%= to([["left_control"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("left_control", [], ["any"]) %>,
+                    "to": <%= to([["left_command"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("left_shift", [], ["any"]) %>,
+                    "to": [{"key_code": "left_shift", "lazy": true}]
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("right_command", [], ["any"]) %>,
+                    "to": <%= to([["right_control"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("right_control", [], ["any"]) %>,
+                    "to": <%= to([["right_command"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("right_shift", [], ["any"]) %>,
+                    "to": [{"key_code": "right_shift", "lazy": true}]
+                }
+            ]
+        },
+        {
+            "description": "Option+Tab to Command+Tab",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("tab", ["left_option"], ["any"]) %>,
+                    "to": <%= to([["tab", "command"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("tab", ["right_option"], ["any"]) %>,
+                    "to": <%= to([["tab", "command"]]) %>
+                }
+            ]
+        },
+        {
+            "description": "Option+Backtick to Command+Backtick",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("grave_accent_and_tilde", ["left_option"], ["any"]) %>,
+                    "to": <%= to([["grave_accent_and_tilde", "command"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("grave_accent_and_tilde", ["right_option"], ["any"]) %>,
+                    "to": <%= to([["grave_accent_and_tilde", "command"]]) %>
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
These modifications make using a Windows keyboard on a Mac more tolerable:

- Swap <kbd>command</kbd> (the Windows key) and <kbd>ctrl</kbd>
- Map <kbd>alt</kbd><kbd>tab</kbd> to <kbd>command</kbd><kbd>tab</kbd>
- Map <kbd>alt</kbd><kbd>shift</kbd><kbd>tab</kbd> to <kbd>command</kbd><kbd>shift</kbd><kbd>tab</kbd>
- Map <kbd>alt</kbd><kbd>&#96;</kbd> to <kbd>command</kbd><kbd>&#96;</kbd>
- Map <kbd>alt</kbd><kbd>shift</kbd><kbd>&#96;</kbd> to <kbd>command</kbd><kbd>shift</kbd><kbd>&#96;</kbd>

When plugging a Windows keyboard into a Mac, by default <kbd>command</kbd> is mapped to the Windows key, which is a rarely-used key and therefore usually small. These modifications make the keyboard’s <kbd>ctrl</kbd> key behave like the Mac’s <kbd>command</kbd> key, and the Windows key behaves like a Mac’s <kbd>ctrl</kbd> (rarely used in Mac).

Because a Mac keyboard’s <kbd>command</kbd> key is where a Windows keyboard’s <kbd>alt</kbd> key is, Mac adopted Windows’ keyboard shortcut for switching applications as  <kbd>command</kbd><kbd>tab</kbd>. But per the above, <kbd>command</kbd> is now accessed via the <kbd>ctrl</kbd> key, hit by your pinky. To preserve the familiar shortcut hit by your thumb, <kbd>alt</kbd><kbd>tab</kbd> is mapped to <kbd>command</kbd><kbd>tab</kbd>. Ditto for <kbd>alt</kbd><kbd>shift</kbd><kbd>tab</kbd>, <kbd>alt</kbd><kbd>&#96;</kbd> and <kbd>alt</kbd><kbd>shift</kbd><kbd>&#96;</kbd>.

These modifications also fix the issue mentioned in https://github.com/tekezo/Karabiner-Elements/issues/1143, https://github.com/tekezo/Karabiner-Elements/issues/1285, https://github.com/tekezo/Karabiner-Elements/issues/1063, https://github.com/tekezo/Karabiner/issues/161 and https://github.com/tekezo/Karabiner-Elements/issues/281#issuecomment-354429291 where <kbd>shift</kbd> wasn’t working properly in the application/window switcher. (This is a bug in #116 IMO.)