### PR TITLE
PrintScreen to select area for screenshot

### DIFF
--- a/docs/json/pc_shortcuts.json
+++ b/docs/json/pc_shortcuts.json
@@ -1787,7 +1787,61 @@
       ]
     },
     {
-      "description": "PC-Style Screenshot(PrtSc for whole, Shift+PrtSc to select)",
+      "description": "PC-Style Screenshot (PrintScreen to select)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "print_screen",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "4",
+              "modifiers": [
+                "left_command",
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.microsoft\\.rdc$",
+                "^com\\.microsoft\\.rdc\\.mac$",
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.rdc\\.osx\\.beta$",
+                "^net\\.sf\\.cord$",
+                "^com\\.thinomenon\\.RemoteDesktopConnection$",
+                "^com\\.itap-mobile\\.qmote$",
+                "^com\\.nulana\\.remotixmac$",
+                "^com\\.p5sys\\.jump\\.mac\\.viewer$",
+                "^com\\.p5sys\\.jump\\.mac\\.viewer\\.web$",
+                "^com\\.teamviewer\\.TeamViewer$",
+                "^com\\.vmware\\.horizon$",
+                "^com\\.2X\\.Client\\.Mac$",
+                "^com\\.vmware\\.fusion$",
+                "^com\\.vmware\\.horizon$",
+                "^com\\.vmware\\.view$",
+                "^com\\.parallels\\.desktop$",
+                "^com\\.parallels\\.vm$",
+                "^com\\.parallels\\.desktop\\.console$",
+                "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
+                "^com\\.vmware\\.proxyApp\\.",
+                "^com\\.parallels\\.winapp\\."
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "PC-Style Screenshot (PrintScreen for whole, Shift+PrintScreen to select)",
       "manipulators": [
         {
           "type": "basic",
@@ -1893,7 +1947,7 @@
       ]
     },
     {
-      "description": "PC-Style Quit Application(Alt+F4 to Command+Q)",
+      "description": "PC-Style Quit Application (Alt+F4 to Command+Q)",
       "manipulators": [
         {
           "type": "basic",

--- a/src/json/pc_shortcuts.json.erb
+++ b/src/json/pc_shortcuts.json.erb
@@ -359,7 +359,20 @@
             ]
         },
         {
-            "description": "PC-Style Screenshot(PrtSc for whole, Shift+PrtSc to select)",
+            "description": "PC-Style Screenshot (PrintScreen to select)",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("print_screen", [], ["any"]) %>,
+                    "to": <%= to([["4", ["left_command", "left_shift"]]]) %>,
+                    "conditions": [
+                        <%= frontmost_application_unless(["remote_desktop", "virtual_machine"]) %>
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "PC-Style Screenshot (PrintScreen for whole, Shift+PrintScreen to select)",
             "manipulators": [
                 {
                     "type": "basic",
@@ -380,7 +393,7 @@
             ]
         },
         {
-            "description": "PC-Style Quit Application(Alt+F4 to Command+Q)",
+            "description": "PC-Style Quit Application (Alt+F4 to Command+Q)",
             "manipulators": [
                 {
                     "type": "basic",


### PR DESCRIPTION
In addition to the option for <kbd>PrintScreen</kbd> to take a screenshot of the whole screen, or <kbd>shift</kbd><kbd>PrintScreen</kbd> to take a screenshot of a selection, allow mapping <kbd>PrintScreen</kbd> directly to taking a screenshot of a selected area.