### PR TITLE
Numeric Keypad Mode: Add option to use the left command as spacebar

### DIFF
--- a/docs/extra_descriptions/numeric_keypad.json.html
+++ b/docs/extra_descriptions/numeric_keypad.json.html
@@ -26,17 +26,21 @@
 </table>
 
 <p style="margin-top: 20px; font-weight: bold">
-  Optional Numeric Period (.) mappings
+  Additional optional mappings
 </p>
 
 <table class="table">
   <tr>
     <td>Trigger Key + right_option</td>
-    <td>.</td>
+    <td>Period (.)</td>
   </tr>
   <tr>
     <td>Trigger Key + right_control</td>
-    <td>.</td>
+    <td>Period (.)</td>
+  </tr>
+  <tr>
+    <td>Trigger Key + left_command</td>
+    <td>Space</td>
   </tr>
 </table>
 
@@ -44,4 +48,5 @@
   <li>Hold down the trigger key (Tab) then press one of the keys to use a numeric key</li>
   <li>Press and releasing tab acts as a normal tab key</li>
   <li>Optionally map right_option or right_control (in case you remapped your right_option) to numeric_period</li>
+  <li>Optionally map left_command to spacebar (so you can type spaced numbers without lifting trigger key)</li>
 </ul>

--- a/src/json/numeric_keypad.json.erb
+++ b/src/json/numeric_keypad.json.erb
@@ -45,6 +45,19 @@
             ]
         },
         {
+            "description": "Numeric Keypad Mode Trigger + left_command to spacebar",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("left_command", [], []) %>,
+                    "to": <%= to([["spacebar"]]) %>,
+                    "conditions": [
+                        { "type": "variable_if", "name": "numeric_keypad_mode", "value": 1 }
+                    ]
+                }
+            ]
+        },
+        {
             "description": "Numeric Keypad Mode Trigger + right_option to keypad_period",
             "manipulators": [
                 {


### PR DESCRIPTION
The use case is when you want to type many space separated numbers like phone numbers without lifting and re-pressing the tab key.