### PR TITLE
Numeric Keypad Mode: Remove redundant optional key mapping

### DIFF
--- a/docs/extra_descriptions/numeric_keypad.json.html
+++ b/docs/extra_descriptions/numeric_keypad.json.html
@@ -20,7 +20,7 @@
     <td>1 / 2 / 3 / Enter</td>
   </tr>
   <tr>
-    <td>Trigger Key + Space / r_option</td>
+    <td>Trigger Key + Space / right_option</td>
     <td>0 / Period (.)</td>
   </tr>
 </table>

--- a/docs/extra_descriptions/numeric_keypad.json.html
+++ b/docs/extra_descriptions/numeric_keypad.json.html
@@ -20,8 +20,8 @@
     <td>1 / 2 / 3 / Enter</td>
   </tr>
   <tr>
-    <td>Trigger Key + Space</td>
-    <td>0</td>
+    <td>Trigger Key + Space / r_option</td>
+    <td>0 / Period (.)</td>
   </tr>
 </table>
 
@@ -30,10 +30,6 @@
 </p>
 
 <table class="table">
-  <tr>
-    <td>Trigger Key + right_option</td>
-    <td>Period (.)</td>
-  </tr>
   <tr>
     <td>Trigger Key + right_control</td>
     <td>Period (.)</td>
@@ -47,6 +43,6 @@
 <ul>
   <li>Hold down the trigger key (Tab) then press one of the keys to use a numeric key</li>
   <li>Press and releasing tab acts as a normal tab key</li>
-  <li>Optionally map right_option or right_control (in case you remapped your right_option) to numeric_period</li>
+  <li>Optionally map right_control (in case you remapped your right_option) to numeric_period</li>
   <li>Optionally map left_command to spacebar (so you can type spaced numbers without lifting trigger key)</li>
 </ul>

--- a/src/json/numeric_keypad.json.erb
+++ b/src/json/numeric_keypad.json.erb
@@ -58,19 +58,6 @@
             ]
         },
         {
-            "description": "Numeric Keypad Mode Trigger + right_option to keypad_period",
-            "manipulators": [
-                {
-                    "type": "basic",
-                    "from": <%= from("right_option", [], []) %>,
-                    "to": <%= to([["keypad_period"]]) %>,
-                    "conditions": [
-                        { "type": "variable_if", "name": "numeric_keypad_mode", "value": 1 }
-                    ]
-                }
-            ]
-        },
-        {
             "description": "Numeric Keypad Mode Trigger + right_control to keypad_period",
             "manipulators": [
                 {


### PR DESCRIPTION
Right option was being mapped to period by default so there was no point offering the optional key mapping.