### PR TITLE
Numeric Keypad Mode: Add alternative layout.

### DIFF
--- a/docs/extra_descriptions/numeric_keypad.json.html
+++ b/docs/extra_descriptions/numeric_keypad.json.html
@@ -20,7 +20,7 @@
     <td>1 / 2 / 3 / Enter</td>
   </tr>
   <tr>
-    <td>Trigger Key + Space / right_option</td>
+    <td>Trigger Key + Space or right_command / right_option</td>
     <td>0 / Period (.)</td>
   </tr>
 </table>
@@ -43,6 +43,7 @@
 <ul>
   <li>Hold down the trigger key (Tab) then press one of the keys to use a numeric key</li>
   <li>Press and releasing tab acts as a normal tab key</li>
+  <li>You can choose if you want spacebar or right_command to be mapped to 0.</li>
   <li>Optionally map right_control (in case you remapped your right_option) to numeric_period</li>
   <li>Optionally map left_command to spacebar (so you can type spaced numbers without lifting trigger key)</li>
 </ul>

--- a/src/json/numeric_keypad.json.erb
+++ b/src/json/numeric_keypad.json.erb
@@ -1,6 +1,7 @@
 {
     "title": "Numeric Keypad",
     <%
+        # standard key mapping where space is 0
         remap_source_keys = [
             "7","8","9","0",
             "u","i","o","p",
@@ -24,10 +25,28 @@
         manipulators.each do |m|
             manipulators_str += ", #{JSON.generate(m)}"
         end
+
+        # alternative key mapping where right_command is 0
+        alt_remap_source_keys = [
+            "7","8","9","0",
+            "u","i","o","p",
+            "j","k","l","semicolon",
+            "m","comma","period","slash",
+            "right_command","right_option"
+        ]
+        alt_manipulators = each_key(
+            source_keys_list: alt_remap_source_keys,
+            dest_keys_list: remap_dest_keys,
+            conditions: [{ "type"=>"variable_if", "name"=>"numeric_keypad_mode", "value"=>1 }]
+        )
+        alt_manipulators_str = ""
+        alt_manipulators.each do |m|
+            alt_manipulators_str += ", #{JSON.generate(m)}"
+        end
     %>
     "rules": [
         {
-            "description": "Numeric Keypad Mode [Tab as trigger key]",
+            "description": "Numeric Keypad Mode [Tab as trigger key, spacebar as 0]",
             "manipulators": [
                 {
                     "type": "basic",
@@ -41,6 +60,23 @@
                     ]
                 }
                 <%= manipulators_str %>
+            ]
+        },
+        {
+            "description": "Numeric Keypad Mode [Tab as trigger key, right_command as 0]",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("tab", [], []) %>,
+                    "to": [
+                        { "set_variable": { "name": "numeric_keypad_mode", "value": 1 } }
+                    ],
+                    "to_if_alone": <%= to([["tab"]]) %>,
+                    "to_after_key_up": [
+                        { "set_variable": { "name": "numeric_keypad_mode", "value": 0 } }
+                    ]
+                }
+                <%= alt_manipulators_str %>
             ]
         },
         {


### PR DESCRIPTION
This adds an option to use right_command as zero in order to preserve the spacebar for actual spaces.

I'm not sure if this is the optimal layout for having a zero key while preserving the spacebar. Open to suggestions.