### PR TITLE
Command_R + Return to backslash

### DIFF
--- a/docs/extra_descriptions/cmd_return.json.html
+++ b/docs/extra_descriptions/cmd_return.json.html
@@ -1,0 +1,32 @@
+<style>
+.monospace {
+  font-family: monospace;
+}
+</style>
+
+<p>
+  This rule is handy when you are used to or would like to use
+  <a
+    href="https://support.apple.com/library/content/dam/edam/applecare/images/en_US/keyboards/english_notebook.png"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    the US English Layout
+  </a>
+  but have one of
+  <a
+    href="https://support.apple.com/library/content/dam/edam/applecare/images/en_US/keyboards/en_international_notebook.png"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    the layouts with the big Return key
+  </a>
+  .
+  Then the Backslash (\) key next to the Return (⏎) becomes really annoying.
+</p>
+<p>
+  You can remap the <span class="monospace">backslash (\)</span> key
+  to <span class="monospace">return_or_enter</span> with a <em>Simple Modification</em>
+  and then enable this <em>Complex Modification</em> to make your backslash and pipe keys accessible
+  when you press your right Command (⌘).
+</p>

--- a/docs/groups.json
+++ b/docs/groups.json
@@ -207,6 +207,10 @@
         },
         {
           "path": "json/half_qwertz_one_handed_layout.json"
+        },
+        {
+          "path": "json/cmd_return.json",
+          "extra_description_path": "extra_descriptions/cmd_return.json.html"
         }
       ]
     },

--- a/docs/json/cmd_return.json
+++ b/docs/json/cmd_return.json
@@ -1,0 +1,30 @@
+{
+  "title": "Command_R + Return to Backslash",
+  "rules": [
+    {
+      "description": "Command_R (⌘) + Return (⏎) to Backslash and Command_R (⌘) + Shift (⇧) + Return (⏎) to Pipe (|)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "return_or_enter",
+            "modifiers": {
+              "mandatory": [
+                "right_command"
+              ],
+              "optional": [
+                "left_shift",
+                "right_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "backslash"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/cmd_return.json.erb
+++ b/src/json/cmd_return.json.erb
@@ -1,0 +1,15 @@
+{
+    "title": "Command_R + Return to Backslash",
+    "rules": [
+        {
+            "description": "Command_R (⌘) + Return (⏎) to Backslash and Command_R (⌘) + Shift (⇧) + Return (⏎) to Pipe (|)",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("return_or_enter", ["right_command"], ["left_shift", "right_shift"]) %>,
+                    "to": <%= to([["backslash"]]) %>
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
#### `Command_R` (⌘) + `Return` (⏎) to `Backslash` (\\) and `Command_R` (⌘) + `Shift` (⇧) + `Return` (⏎) to Pipe (|)

This rule is handy when you are used to or would like to use [the US English Layout](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/keyboards/english_notebook.png) but have one of [the layouts with the big Return key](https://support.apple.com/library/content/dam/edam/applecare/images/en_US/keyboards/en_international_notebook.png).

Then the backslash key next to the Return becomes really annoying.

You can remap the `backslash (\)` key to `return_or_enter` with a _Simple Modification_ and then enable this _Complex Modification_ to make your backslash and pipe keys accessible when you press your right Command.