### PR TITLE
Numeric Keypad Mode: Add Caps Lock and Escape as trigger keys

### DIFF
--- a/docs/extra_descriptions/numeric_keypad.json.html
+++ b/docs/extra_descriptions/numeric_keypad.json.html
@@ -41,9 +41,10 @@
 </table>
 
 <ul>
-  <li>Hold down the trigger key (Tab) then press one of the keys to use a numeric key</li>
-  <li>Press and releasing tab acts as a normal tab key</li>
-  <li>You can choose if you want spacebar or right_command to be mapped to 0.</li>
+  <li>Choose a trigger key from: Tab, Escape, Caps Lock</li>
+  <li>Choose a layout: Either spacebar or right_command to be mapped to 0.</li>
+  <li>Hold down the trigger key then press one of the keys to use a numeric key</li>
+  <li>Press and releasing the trigger acts as a normal key press</li>
   <li>Optionally map right_control (in case you remapped your right_option) to numeric_period</li>
   <li>Optionally map left_command to spacebar (so you can type spaced numbers without lifting trigger key)</li>
 </ul>

--- a/docs/extra_descriptions/numeric_keypad.json.html
+++ b/docs/extra_descriptions/numeric_keypad.json.html
@@ -42,7 +42,7 @@
 
 <ul>
   <li>Choose a trigger key from: Tab, Escape, Caps Lock</li>
-  <li>Choose a layout: Either spacebar or right_command to be mapped to 0.</li>
+  <li>Choose a layout: Either spacebar or right_command to be mapped to 0</li>
   <li>Hold down the trigger key then press one of the keys to use a numeric key</li>
   <li>Press and releasing the trigger acts as a normal key press</li>
   <li>Optionally map right_control (in case you remapped your right_option) to numeric_period</li>

--- a/src/json/numeric_keypad.json.erb
+++ b/src/json/numeric_keypad.json.erb
@@ -23,8 +23,9 @@
         )
         manipulators_str = ""
         manipulators.each do |m|
-            manipulators_str += ", #{JSON.generate(m)}"
+            manipulators_str += "#{JSON.generate(m)}, "
         end
+        manipulators_str.chomp!(", ")
 
         # alternative key mapping where right_command is 0
         alt_remap_source_keys = [
@@ -41,12 +42,13 @@
         )
         alt_manipulators_str = ""
         alt_manipulators.each do |m|
-            alt_manipulators_str += ", #{JSON.generate(m)}"
+            alt_manipulators_str += "#{JSON.generate(m)}, "
         end
+        alt_manipulators_str.chomp!(", ")
     %>
     "rules": [
         {
-            "description": "Numeric Keypad Mode [Tab as trigger key, spacebar as 0]",
+            "description": "Numeric Keypad Trigger [Tab as trigger key]",
             "manipulators": [
                 {
                     "type": "basic",
@@ -59,25 +61,47 @@
                         { "set_variable": { "name": "numeric_keypad_mode", "value": 0 } }
                     ]
                 }
-                <%= manipulators_str %>
             ]
         },
         {
-            "description": "Numeric Keypad Mode [Tab as trigger key, right_command as 0]",
+            "description": "Numeric Keypad Trigger [Caps Lock as trigger key]",
             "manipulators": [
                 {
                     "type": "basic",
-                    "from": <%= from("tab", [], []) %>,
+                    "from": <%= from("caps_lock", [], []) %>,
                     "to": [
                         { "set_variable": { "name": "numeric_keypad_mode", "value": 1 } }
                     ],
-                    "to_if_alone": <%= to([["tab"]]) %>,
+                    "to_if_alone": <%= to([["caps_lock"]]) %>,
                     "to_after_key_up": [
                         { "set_variable": { "name": "numeric_keypad_mode", "value": 0 } }
                     ]
                 }
-                <%= alt_manipulators_str %>
             ]
+        },
+        {
+            "description": "Numeric Keypad Trigger [Escape as trigger key]",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("escape", [], []) %>,
+                    "to": [
+                        { "set_variable": { "name": "numeric_keypad_mode", "value": 1 } }
+                    ],
+                    "to_if_alone": <%= to([["escape"]]) %>,
+                    "to_after_key_up": [
+                        { "set_variable": { "name": "numeric_keypad_mode", "value": 0 } }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "Numeric Keypad Mode [space_bar as 0]",
+            "manipulators": [<%= manipulators_str %>]
+        },
+        {
+            "description": "Numeric Keypad Mode [right_command as 0]",
+            "manipulators": [<%= alt_manipulators_str %>]
         },
         {
             "description": "Numeric Keypad Mode [Optional] Trigger + right_control to keypad_period",

--- a/src/json/numeric_keypad.json.erb
+++ b/src/json/numeric_keypad.json.erb
@@ -96,7 +96,7 @@
             ]
         },
         {
-            "description": "Numeric Keypad Mode [space_bar as 0]",
+            "description": "Numeric Keypad Mode [spacebar as 0]",
             "manipulators": [<%= manipulators_str %>]
         },
         {


### PR DESCRIPTION
Add option to use different keys as trigger keys.

## Use case
When entering data into a spreadsheet, the Tab key is often used to navigate to the next cell horizontally. Currently if you wanted to enter numbers in several cells, you would have to press and release Tab over and over (as the trigger, and then as Tab for going to the next cell). If a different key is used as a trigger you don't suffer from this issue.

Caps Lock is a good key for a trigger however it is often bound to something else (such as escape for Vim users). So add both Caps Lock and Escape as options for trigger keys.

## Concerns
This current implementation requires users to enable two separate modifications, one for selecting the trigger key, and another for selecting the number pad layout (either right_command or spacebar as the key for 0). I've tried making this clear in the extra_descriptions but I don't know if this is too complicated for users who would rather only need to enable one thing as was the case previously.