### PR TITLE
Add backslash-yen swapping for JIS keyboards

### DIFF
--- a/docs/groups.json
+++ b/docs/groups.json
@@ -244,6 +244,9 @@
           "path": "json/swap_yen_and_backslash.json"
         },
         {
+          "path": "json/swap_yen_and_backslash_jis.json"
+        },
+        {
           "path": "json/swiss_pc_shortcuts.json",
           "extra_description_path": "extra_descriptions/swiss_pc_shortcuts.json.html"
         },

--- a/docs/json/swap_yen_and_backslash_jis.json
+++ b/docs/json/swap_yen_and_backslash_jis.json
@@ -1,0 +1,45 @@
+{
+  "title": "Swap ¥ and \\ always on JIS Keyboards",
+  "rules": [
+    {
+      "description": "Change ¥ to Alt+¥",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "international3"
+          },
+          "to": [
+            {
+              "key_code": "international3",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Change Alt+¥ to ¥",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "international3",
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "international3"
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/swap_yen_and_backslash_jis.json.erb
+++ b/src/json/swap_yen_and_backslash_jis.json.erb
@@ -1,0 +1,45 @@
+{
+    "title": "Swap ¥ and \\ always on JIS Keyboards",
+    "rules": [
+        {
+            "description": "Change ¥ to Alt+¥",
+            "manipulators": [
+                {
+                    "from": {
+                        "key_code": "international3"
+                    },
+                    "to": [
+                        {
+                            "key_code": "international3",
+                            "modifiers": [
+                                "option"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "Change Alt+¥ to ¥",
+            "manipulators": [
+                {
+                    "from": {
+                        "key_code": "international3",
+                        "modifiers": {
+                            "mandatory": [
+                                "option"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "international3"
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
I can't modify JIS keyboard's **¥** key using Karabiner-Element with existing rule set "Swap ¥ and \ for Japanese Romaji input on US Keyboard".

Please add the rule for also JIS keyboards. Differ from US keyboards, **¥** is mapped to the virtual key code "international3" for JIS keyboard.

See details why/how we do:
- https://qiita.com/tanakahisateru/items/d8a67ad89c07baf8c0da
- https://qiita.com/kunit/items/f6ec7e159d93002bfc48
