### PR TITLE
Add Sublime Text to emacs_key_bindings_exception

### DIFF
--- a/docs/json/emacs_key_bindings.json
+++ b/docs/json/emacs_key_bindings.json
@@ -1,8 +1,8 @@
 {
-  "title": "Emacs key bindings (rev 11)",
+  "title": "Emacs key bindings (rev 12)",
   "rules": [
     {
-      "description": "Emacs key bindings [C-x key strokes] (rev 1)",
+      "description": "Emacs key bindings [C-x key strokes] (rev 2)",
       "manipulators": [
         {
           "type": "basic",
@@ -190,6 +190,7 @@
                 "^com\\.apple\\.x11$",
                 "^org\\.macosforge\\.xquartz\\.X11$",
                 "^org\\.macports\\.X11$",
+                "^com\\.sublimetext\\.",
                 "^com\\.microsoft\\.VSCode$"
               ]
             }
@@ -198,7 +199,7 @@
       ]
     },
     {
-      "description": "Emacs key bindings [control+keys] (rev 9)",
+      "description": "Emacs key bindings [control+keys] (rev 10)",
       "manipulators": [
         {
           "type": "basic",
@@ -261,6 +262,7 @@
                 "^com\\.apple\\.x11$",
                 "^org\\.macosforge\\.xquartz\\.X11$",
                 "^org\\.macports\\.X11$",
+                "^com\\.sublimetext\\.",
                 "^com\\.microsoft\\.VSCode$"
               ]
             }
@@ -327,6 +329,7 @@
                 "^com\\.apple\\.x11$",
                 "^org\\.macosforge\\.xquartz\\.X11$",
                 "^org\\.macports\\.X11$",
+                "^com\\.sublimetext\\.",
                 "^com\\.microsoft\\.VSCode$"
               ]
             }
@@ -393,6 +396,7 @@
                 "^com\\.apple\\.x11$",
                 "^org\\.macosforge\\.xquartz\\.X11$",
                 "^org\\.macports\\.X11$",
+                "^com\\.sublimetext\\.",
                 "^com\\.microsoft\\.VSCode$"
               ]
             }
@@ -536,6 +540,7 @@
                 "^com\\.apple\\.x11$",
                 "^org\\.macosforge\\.xquartz\\.X11$",
                 "^org\\.macports\\.X11$",
+                "^com\\.sublimetext\\.",
                 "^com\\.microsoft\\.VSCode$"
               ]
             }
@@ -603,6 +608,7 @@
                 "^com\\.apple\\.x11$",
                 "^org\\.macosforge\\.xquartz\\.X11$",
                 "^org\\.macports\\.X11$",
+                "^com\\.sublimetext\\.",
                 "^com\\.microsoft\\.VSCode$"
               ]
             }
@@ -670,6 +676,7 @@
                 "^com\\.apple\\.x11$",
                 "^org\\.macosforge\\.xquartz\\.X11$",
                 "^org\\.macports\\.X11$",
+                "^com\\.sublimetext\\.",
                 "^com\\.microsoft\\.VSCode$"
               ]
             }
@@ -737,6 +744,7 @@
                 "^com\\.apple\\.x11$",
                 "^org\\.macosforge\\.xquartz\\.X11$",
                 "^org\\.macports\\.X11$",
+                "^com\\.sublimetext\\.",
                 "^com\\.microsoft\\.VSCode$"
               ]
             }
@@ -803,6 +811,7 @@
                 "^com\\.apple\\.x11$",
                 "^org\\.macosforge\\.xquartz\\.X11$",
                 "^org\\.macports\\.X11$",
+                "^com\\.sublimetext\\.",
                 "^com\\.microsoft\\.VSCode$"
               ]
             }
@@ -933,7 +942,7 @@
       ]
     },
     {
-      "description": "Emacs key bindings [option+keys] (rev 4)",
+      "description": "Emacs key bindings [option+keys] (rev 5)",
       "manipulators": [
         {
           "type": "basic",
@@ -996,6 +1005,7 @@
                 "^com\\.apple\\.x11$",
                 "^org\\.macosforge\\.xquartz\\.X11$",
                 "^org\\.macports\\.X11$",
+                "^com\\.sublimetext\\.",
                 "^com\\.microsoft\\.VSCode$"
               ]
             }
@@ -1065,6 +1075,7 @@
                 "^com\\.apple\\.x11$",
                 "^org\\.macosforge\\.xquartz\\.X11$",
                 "^org\\.macports\\.X11$",
+                "^com\\.sublimetext\\.",
                 "^com\\.microsoft\\.VSCode$"
               ]
             }
@@ -1134,6 +1145,7 @@
                 "^com\\.apple\\.x11$",
                 "^org\\.macosforge\\.xquartz\\.X11$",
                 "^org\\.macports\\.X11$",
+                "^com\\.sublimetext\\.",
                 "^com\\.microsoft\\.VSCode$"
               ]
             }
@@ -1202,6 +1214,7 @@
                 "^com\\.apple\\.x11$",
                 "^org\\.macosforge\\.xquartz\\.X11$",
                 "^org\\.macports\\.X11$",
+                "^com\\.sublimetext\\.",
                 "^com\\.microsoft\\.VSCode$"
               ]
             }
@@ -1210,7 +1223,7 @@
       ]
     },
     {
-      "description": "Bash style Emacs key bindings (rev 1)",
+      "description": "Bash style Emacs key bindings (rev 2)",
       "manipulators": [
         {
           "type": "basic",
@@ -1275,6 +1288,7 @@
                 "^com\\.apple\\.x11$",
                 "^org\\.macosforge\\.xquartz\\.X11$",
                 "^org\\.macports\\.X11$",
+                "^com\\.sublimetext\\.",
                 "^com\\.microsoft\\.VSCode$"
               ]
             }
@@ -1348,6 +1362,7 @@
                 "^com\\.apple\\.x11$",
                 "^org\\.macosforge\\.xquartz\\.X11$",
                 "^org\\.macports\\.X11$",
+                "^com\\.sublimetext\\.",
                 "^com\\.microsoft\\.VSCode$"
               ]
             }
@@ -1356,7 +1371,7 @@
       ]
     },
     {
-      "description": "For Visual Studio Code: Emacs key bindings [control+keys] (rev 9)",
+      "description": "For Visual Studio Code: Emacs key bindings [control+keys] (rev 10)",
       "manipulators": [
         {
           "type": "basic",
@@ -1893,7 +1908,7 @@
       ]
     },
     {
-      "description": "For Visual Studio Code: Emacs key bindings [option+keys] (rev 4)",
+      "description": "For Visual Studio Code: Emacs key bindings [option+keys] (rev 5)",
       "manipulators": [
         {
           "type": "basic",
@@ -2018,7 +2033,7 @@
       ]
     },
     {
-      "description": "For Visual Studio Code: Bash style Emacs key bindings (rev 1)",
+      "description": "For Visual Studio Code: Bash style Emacs key bindings (rev 2)",
       "manipulators": [
         {
           "type": "basic",

--- a/src/json/emacs_key_bindings.json.rb
+++ b/src/json/emacs_key_bindings.json.rb
@@ -9,12 +9,12 @@ require 'json'
 require_relative '../lib/karabiner.rb'
 
 def main
-  control_keys_rev = 'rev 9'
-  option_keys_rev = 'rev 4'
-  bash_style_rev = 'rev 1'
+  control_keys_rev = 'rev 10'
+  option_keys_rev = 'rev 5'
+  bash_style_rev = 'rev 2'
 
   puts JSON.pretty_generate(
-    'title' => 'Emacs key bindings (rev 11)',
+    'title' => 'Emacs key bindings (rev 12)',
     'rules' => [
       # generic
       c_x_key_strokes,
@@ -62,7 +62,7 @@ end
 
 def c_x_key_strokes
   {
-    'description' => 'Emacs key bindings [C-x key strokes] (rev 1)',
+    'description' => 'Emacs key bindings [C-x key strokes] (rev 2)',
     'manipulators' => [
       # C-x C-c (quit)
       {

--- a/src/lib/karabiner.rb
+++ b/src/lib/karabiner.rb
@@ -78,6 +78,10 @@ module Karabiner
       '^com\.parallels\.winapp\.', # prefix
     ],
 
+    :sublime_text => [
+      '^com\.sublimetext\.' # prefix
+    ],
+
     :visual_studio_code => [
       '^com\.microsoft\.VSCode$',
     ],
@@ -106,6 +110,7 @@ module Karabiner
                                       BUNDLE_IDENTIFERS[:vi] +
                                       BUNDLE_IDENTIFERS[:virtual_machine] +
                                       BUNDLE_IDENTIFERS[:x11] +
+                                      BUNDLE_IDENTIFERS[:sublime_text] +
                                       BUNDLE_IDENTIFERS[:visual_studio_code],
     'finder' => BUNDLE_IDENTIFERS[:finder],
     'microsoft_office' => BUNDLE_IDENTIFERS[:microsoft_office],


### PR DESCRIPTION
Sublime Text 3 is similar to VS Code. It has its own Emacs emulation plugin called Emacs Pro Essentials.
Without excluding this app, there is some glitches (C-x C-f will be remapped to C-x right-arrow).
Thanks!