### PR TITLE
Screen saver hotkeys (that can lock screen)

### DIFF
--- a/docs/json/screen_saver.json
+++ b/docs/json/screen_saver.json
@@ -1,0 +1,43 @@
+{
+  "title": "Screen Saver (can Lock Screen)",
+  "rules": [
+    {
+      "description": "Option+L to start Screen Saver",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "mandatory": ["option"]
+            }
+          },
+          "to": [
+            {
+              "shell_command": "open -a ScreenSaverEngine.app"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Control+Command+Delete to start Screen Saver",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "delete_forward",
+            "modifiers": {
+              "mandatory": ["control", "command"]
+            }
+          },
+          "to": [
+            {
+              "shell_command": "open -a ScreenSaverEngine.app"
+            }
+          ]
+        }
+      ]
+    }    
+  ]
+}


### PR DESCRIPTION
Two options to launch screen saver:
1. Option + L
2. Control + Command + Delete

Note: macOS can be further configured to immediately lock the screen:
System Preferences > Security & Privacy > Require password: immediately
![os-x-require-password-immediately](https://user-images.githubusercontent.com/1231423/40159795-a5b8f612-595f-11e8-8ff2-602765e5e706.jpg)
