### PR TITLE
Lock screen hotkeys on macOS High Sierra 10.13+

### DIFF
--- a/docs/json/lock_screen.json
+++ b/docs/json/lock_screen.json
@@ -1,0 +1,45 @@
+{
+  "title": "Lock Screen",
+  "rules": [
+    {
+      "description": "Option+L to Lock Screen (macOS 10.13+)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "mandatory": ["option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "q",
+              "modifiers": ["left_control", "left_command"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Control+Command+Delete to Lock Screen (macOS 10.13+)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "delete_forward",
+            "modifiers": {
+              "mandatory": ["control", "command"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "q",
+              "modifiers": ["left_control", "left_command"]
+            }
+          ]
+        }
+      ]
+    }    
+  ]
+}


### PR DESCRIPTION
Two options to lock screen on macOS High Sierra 10.13+:
1. Option + L
2. Control + Command + Delete

Related to #363 