### PR TITLE
added rotate_left_modifiers

### DIFF
--- a/docs/groups.json
+++ b/docs/groups.json
@@ -358,6 +358,9 @@
         },
         {
           "path": "json/disable_cmd_f1_screen_mirroring.json"
+        },
+        {
+          "path": "json/rotate_left_modifiers.json"
         }
       ]
     },

--- a/docs/json/rotate_left_modifiers.json
+++ b/docs/json/rotate_left_modifiers.json
@@ -1,0 +1,250 @@
+{
+  "title": "Rotate left modifiers",
+  "rules": [
+    {
+      "description": "Map left ctrl to command, command to option, option to control unless in iTerm2 or Remote Desktop",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_command",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_option",
+              "lazy": true
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                  "^com\\.apple\\.Terminal$",
+                  "^com\\.googlecode\\.iterm2$",
+                  "com\\.microsoft\\.rdc\\.mac"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_control",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_command",
+              "lazy": true
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                  "^com\\.apple\\.Terminal$",
+                  "^com\\.googlecode\\.iterm2$",
+                  "com\\.microsoft\\.rdc\\.mac"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_option",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_control",
+              "lazy": true
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                  "^com\\.apple\\.Terminal$",
+                  "^com\\.googlecode\\.iterm2$",
+                  "com\\.microsoft\\.rdc\\.mac"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Swap left option and command in iTerm2 and Remote Desktop",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_option",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_command",
+              "lazy": true
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                  "^com\\.apple\\.Terminal$",
+                  "^com\\.googlecode\\.iterm2$",
+                  "com\\.microsoft\\.rdc\\.mac"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_command",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_option",
+              "lazy": true
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                  "^com\\.apple\\.Terminal$",
+                  "^com\\.googlecode\\.iterm2$",
+                  "com\\.microsoft\\.rdc\\.mac"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Map left option+tab to command+tab",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "tab",
+            "modifiers": {
+              "mandatory": [
+                "left_option"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "tab",
+              "modifiers": [
+                "left_command"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Lazy left modifiers (allows option+shift+tab to shift apps backwards). Enable this last!",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_shift",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_shift",
+              "lazy": true
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_command",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_command",
+              "lazy": true
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_control",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_control",
+              "lazy": true
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_option",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_option",
+              "lazy": true
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This rotates left ctrl to command, command to option, option to control; resulting in physical key mapping similar to Windows/Linux; supporting application switching with option+tab.