### PR TITLE
Adding Sleep Monitor Rule for Keyboards without Eject 

### DIFF
--- a/docs/groups.json
+++ b/docs/groups.json
@@ -361,6 +361,9 @@
         },
         {
           "path": "json/rotate_left_modifiers.json"
+        },
+        {
+        	"path": "json/sleep-monitor.json"
         }
       ]
     },

--- a/docs/json/sleep-monitor.json
+++ b/docs/json/sleep-monitor.json
@@ -1,0 +1,32 @@
+{
+  "title": "Add Sleep Monitor for Keyboard without Eject",
+  "rules": [
+    {
+        "description": "Ctrl+Cmd+Shift+Esc to Sleep Monitor",
+        "manipulators": [
+        {
+          "from": {
+            "key_code": "escape",
+            "modifiers": {
+              "mandatory": [
+                "control",
+                "command",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "eject",
+              "modifiers": [
+                "left_control",
+                "left_shift"
+            ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I've created a modification rule for keyboards without an eject button. Currently Mac's sleep monitor shortcut requires eject button on the keyboard, so this rule adds another way to trigger the shortcut without an eject key.

Let me know if I missed anything. Thanks in advance!