### PR TITLE
Change Won (₩) to grave accent (`) in Korean layout

### DIFF
--- a/docs/groups.json
+++ b/docs/groups.json
@@ -262,6 +262,9 @@
           "path": "json/korean_pc.json"
         },
         {
+          "path": "json/korean_won_to_backtick.json"
+        },
+        {
           "path": "json/russian.json"
         }
       ]

--- a/docs/json/korean_won_to_backtick.json
+++ b/docs/json/korean_won_to_backtick.json
@@ -1,0 +1,39 @@
+{
+  "title": "For Korean",
+  "rules": [
+    {
+      "description": "Change Won (₩) to grave accent (`) in Korean layout.",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ko"
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "grave_accent_and_tilde",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR remaps the dead key for the Won symbol to the grave accent in the Korean layout.
Should be useful for Korean developers.

(Work done with @shurain)