### PR TITLE
Seperate left and right rules to swap command and control in virtual machine

### DIFF
--- a/docs/json/virtual_machine.json
+++ b/docs/json/virtual_machine.json
@@ -2,7 +2,7 @@
   "title": "Virtual Machine",
   "rules": [
     {
-      "description": "Swap command and control in virtual machine/remote desktop",
+      "description": "Swap left command and control in virtual machine/remote desktop",
       "manipulators": [
         {
           "type": "basic",
@@ -52,7 +52,7 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "right_control",
+            "key_code": "left_command",
             "modifiers": {
               "optional": [
                 "any"
@@ -61,7 +61,7 @@
           },
           "to": [
             {
-              "key_code": "right_command"
+              "key_code": "left_control"
             }
           ],
           "conditions": [
@@ -93,11 +93,16 @@
               ]
             }
           ]
-        },
+        }
+      ]
+    },
+    {
+      "description": "Swap right command and control in virtual machine/remote desktop",
+      "manipulators": [
         {
           "type": "basic",
           "from": {
-            "key_code": "left_command",
+            "key_code": "right_control",
             "modifiers": {
               "optional": [
                 "any"
@@ -106,7 +111,7 @@
           },
           "to": [
             {
-              "key_code": "left_control"
+              "key_code": "right_command"
             }
           ],
           "conditions": [

--- a/src/json/virtual_machine.json.erb
+++ b/src/json/virtual_machine.json.erb
@@ -6,10 +6,20 @@
     "title": "Virtual Machine",
     "rules": [
         {
-            "description": "Swap command and control in virtual machine/remote desktop",
+            "description": "Swap left command and control in virtual machine/remote desktop",
             "manipulators": <%= each_key(
-                source_keys_list: ['left_control', 'right_control', 'left_command', 'right_command'],
-                dest_keys_list: ['left_command', 'right_command', 'left_control', 'right_control'],
+                source_keys_list: ['left_control', 'left_command'],
+                dest_keys_list: ['left_command', 'left_control'],
+                from_optional_modifiers: ['any'],
+                conditions: virtual_conditions,
+                as_json: true
+            ) %>
+        },
+        {
+            "description": "Swap right command and control in virtual machine/remote desktop",
+            "manipulators": <%= each_key(
+                source_keys_list: ['right_control', 'right_command'],
+                dest_keys_list: ['right_command', 'right_control'],
                 from_optional_modifiers: ['any'],
                 conditions: virtual_conditions,
                 as_json: true


### PR DESCRIPTION
No `right control` on macbook's keyboard, and `right command` is usually set as the host key. Swapping the left only is good enough.
