### PR TITLE
Make pc-style Home/End work in git-gui and Jetbrains IDEs

### DIFF
--- a/docs/json/pc_shortcuts.json
+++ b/docs/json/pc_shortcuts.json
@@ -152,7 +152,9 @@
                 "^net\\.kovidgoyal\\.kitty$",
                 "^org\\.mozilla\\.firefox$",
                 "^com\\.google\\.Chrome$",
-                "^com\\.apple\\.Safari$"
+                "^com\\.apple\\.Safari$",
+                "^cz\\.or\\.repo\\.git-gui$",
+                "^com\\.jetbrains\\."
               ]
             }
           ]
@@ -238,7 +240,9 @@
                 "^co\\.zeit\\.hyperterm$",
                 "^co\\.zeit\\.hyper$",
                 "^io\\.alacritty$",
-                "^net\\.kovidgoyal\\.kitty$"
+                "^net\\.kovidgoyal\\.kitty$",
+                "^cz\\.or\\.repo\\.git-gui$",
+                "^com\\.jetbrains\\."
               ]
             }
           ]
@@ -295,7 +299,9 @@
                 "^net\\.kovidgoyal\\.kitty$",
                 "^org\\.mozilla\\.firefox$",
                 "^com\\.google\\.Chrome$",
-                "^com\\.apple\\.Safari$"
+                "^com\\.apple\\.Safari$",
+                "^cz\\.or\\.repo\\.git-gui$",
+                "^com\\.jetbrains\\."
               ]
             }
           ]
@@ -381,7 +387,9 @@
                 "^co\\.zeit\\.hyperterm$",
                 "^co\\.zeit\\.hyper$",
                 "^io\\.alacritty$",
-                "^net\\.kovidgoyal\\.kitty$"
+                "^net\\.kovidgoyal\\.kitty$",
+                "^cz\\.or\\.repo\\.git-gui$",
+                "^com\\.jetbrains\\."
               ]
             }
           ]

--- a/src/json/pc_shortcuts.json.erb
+++ b/src/json/pc_shortcuts.json.erb
@@ -49,7 +49,7 @@
                     "from": <%= from("home", [], ["shift"]) %>,
                     "to": <%= to([["left_arrow", ["left_command"]]]) %>,
                     "conditions": [
-                        <%= frontmost_application_unless(["remote_desktop", "virtual_machine", "terminal", "browser"]) %>
+                        <%= frontmost_application_unless(["remote_desktop", "virtual_machine", "terminal", "browser", "git_gui", "jetbrains_ide"]) %>
                     ]
                 },
                 {
@@ -65,7 +65,7 @@
                     "from": <%= from("home", ["control"], ["shift"]) %>,
                     "to": <%= to([["up_arrow", ["left_command"]]]) %>,
                     "conditions": [
-                        <%= frontmost_application_unless(["remote_desktop", "virtual_machine", "terminal"]) %>
+                        <%= frontmost_application_unless(["remote_desktop", "virtual_machine", "terminal", "git_gui", "jetbrains_ide"]) %>
                     ]
                 },
                 {
@@ -73,7 +73,7 @@
                     "from": <%= from("end", [], ["shift"]) %>,
                     "to": <%= to([["right_arrow", ["left_command"]]]) %>,
                     "conditions": [
-                        <%= frontmost_application_unless(["remote_desktop", "virtual_machine", "terminal", "browser"]) %>
+                        <%= frontmost_application_unless(["remote_desktop", "virtual_machine", "terminal", "browser", "git_gui", "jetbrains_ide"]) %>
                     ]
                 },
                 {
@@ -89,7 +89,7 @@
                     "from": <%= from("end", ["control"], ["shift"]) %>,
                     "to": <%= to([["down_arrow", ["left_command"]]]) %>,
                     "conditions": [
-                        <%= frontmost_application_unless(["remote_desktop", "virtual_machine", "terminal"]) %>
+                        <%= frontmost_application_unless(["remote_desktop", "virtual_machine", "terminal", "git_gui", "jetbrains_ide"]) %>
                     ]
                 }
             ]

--- a/src/lib/karabiner.rb
+++ b/src/lib/karabiner.rb
@@ -30,6 +30,14 @@ module Karabiner
       '^com\.apple\.finder$',
     ],
 
+    :git_gui => [
+      '^cz\.or\.repo\.git-gui$',
+    ],
+
+    :jetbrains_ide => [
+      '^com\.jetbrains\.'  # prefix
+    ],
+
     :microsoft_office => [
       '^com\.microsoft\.Excel$',
       '^com\.microsoft\.Powerpoint$',
@@ -113,6 +121,8 @@ module Karabiner
                                       BUNDLE_IDENTIFERS[:sublime_text] +
                                       BUNDLE_IDENTIFERS[:visual_studio_code],
     'finder' => BUNDLE_IDENTIFERS[:finder],
+    'git_gui' => BUNDLE_IDENTIFERS[:git_gui],
+    'jetbrains_ide' => BUNDLE_IDENTIFERS[:jetbrains_ide],
     'microsoft_office' => BUNDLE_IDENTIFERS[:microsoft_office],
     'remote_desktop' => BUNDLE_IDENTIFERS[:remote_desktop],
     'terminal' => BUNDLE_IDENTIFERS[:terminal],


### PR DESCRIPTION
In git-gui home/end is handled and cmd+arrow only moves by 1 character.
Jetbrains IDEs contain an embedded terminal which doesn't like cmd+arrow.