### PR TITLE
fix bugs in change_grave_accent_to_escape complex modification

### DIFF
--- a/docs/json/change_grave_accent_to_escape.json
+++ b/docs/json/change_grave_accent_to_escape.json
@@ -9,7 +9,7 @@
           "from": {
             "key_code": "grave_accent_and_tilde",
             "modifiers": {
-              "optional": [
+              "mandatory": [
                 "left_command"
               ]
             }
@@ -21,11 +21,6 @@
                 "left_command"
               ]
             }
-          ],
-          "to_if_alone": [
-            {
-              "key_code": "escape"
-            }
           ]
         },
         {
@@ -33,8 +28,8 @@
           "from": {
             "key_code": "grave_accent_and_tilde",
             "modifiers": {
-              "optional": [
-                "left_control"
+              "mandatory": [
+                "right_command"
               ]
             }
           },
@@ -42,7 +37,7 @@
             {
               "key_code": "grave_accent_and_tilde",
               "modifiers": [
-                "left_control"
+                "right_command"
               ]
             }
           ]
@@ -52,14 +47,66 @@
           "from": {
             "key_code": "grave_accent_and_tilde",
             "modifiers": {
-              "optional": [
+              "mandatory": [
                 "left_option"
               ]
             }
           },
           "to": [
             {
-              "key_code": "grave_accent_and_tilde"
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "left_option"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "grave_accent_and_tilde",
+            "modifiers": {
+              "mandatory": [
+                "right_option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "grave_accent_and_tilde",
+            "modifiers": {
+              "mandatory": [
+                "left_control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "left_control"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "grave_accent_and_tilde"
+          },
+          "to": [
+            {
+              "key_code": "escape"
             }
           ]
         }

--- a/src/json/change_grave_accent_to_escape.json.erb
+++ b/src/json/change_grave_accent_to_escape.json.erb
@@ -6,21 +6,36 @@
             "manipulators": [
                 {
                     "type": "basic",
-                    "from": <%= from("grave_accent_and_tilde", [], ["left_command"]) %>,
-                    "to": <%= to([["grave_accent_and_tilde", ["left_command"]]]) %>,
-                    "to_if_alone": <%= to([["escape"]]) %>
+                    "from": <%= from("grave_accent_and_tilde", ["left_command"], []) %>,
+                    "to": <%= to([["grave_accent_and_tilde", ["left_command"]]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("grave_accent_and_tilde", [], ["left_control"]) %>,
+                    "from": <%= from("grave_accent_and_tilde", ["right_command"], []) %>,
+                    "to": <%= to([["grave_accent_and_tilde", ["right_command"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("grave_accent_and_tilde", ["left_option"], []) %>,
+                    "to": <%= to([["grave_accent_and_tilde", ["left_option"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("grave_accent_and_tilde", ["right_option"], []) %>,
+                    "to": <%= to([["grave_accent_and_tilde", ["right_option"]]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("grave_accent_and_tilde", ["left_control"], []) %>,
                     "to": <%= to([["grave_accent_and_tilde", ["left_control"]]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("grave_accent_and_tilde", [], ["left_option"]) %>,
-                    "to": <%= to([["grave_accent_and_tilde"]]) %>
+                    "from": <%= from("grave_accent_and_tilde", [], []) %>,
+                    "to": <%= to([["escape"]]) %>
                 }
             ]
         }
     ]
 }
+


### PR DESCRIPTION
### Summary

* Fixes bug where `grave_accent` alone would also trigger `Command-grave_accent`
* Adds support for right command, right option

### Detail

* This was done by not using the `to_if_alone` option, and instead re-ordering the other modifications so Escape came last