### PR TITLE
Add rule: exchange single and double quote

### DIFF
--- a/docs/groups.json
+++ b/docs/groups.json
@@ -297,6 +297,9 @@
           "path": "json/exchange_semicolon_and_colon.json"
         },
         {
+          "path": "json/exchange_single_and_double_quote.json"
+        },
+        {
           "path": "json/swap-paren-and-sqbrackets.json"
         },
         {

--- a/docs/json/exchange_single_and_double_quote.json
+++ b/docs/json/exchange_single_and_double_quote.json
@@ -1,0 +1,48 @@
+{
+  "title": "Exchange single and double quote",
+  "rules": [
+    {
+      "description": "Exchange single and double quote",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "quote",
+            "modifiers": {
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "quote",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "quote",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "quote"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/exchange_single_and_double_quote.json.erb
+++ b/src/json/exchange_single_and_double_quote.json.erb
@@ -1,0 +1,13 @@
+{
+    "title": "Exchange single and double quote",
+    "rules": [
+        {
+            "description": "Exchange single and double quote",
+            "manipulators": [
+                { "type": "basic", "from": <%= from("quote", [], ["caps_lock"]) %>, "to": <%= to([["quote", ["left_shift"]]]) %> },
+
+                { "type": "basic", "from": <%= from("quote", ["shift"], ["caps_lock"]) %>, "to": <%= to([["quote"]]) %> }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This adds a rule of exchange quote (single and double), which is very useful for US keyboard layout.

- `'` (single quote) and `"` (double quote) is same key in US layout (such as semicolon and colon).
- For people who type often "double" than "single" in programming, I think this rule is very useful.

![image](https://user-images.githubusercontent.com/473530/42611899-5daeff92-85d3-11e8-8a99-b8359f92d96a.png)

Thanks.