### PR TITLE
Added 'Disable Ctrl Click' Modification

### DIFF
--- a/docs/groups.json
+++ b/docs/groups.json
@@ -387,6 +387,9 @@
         },
         {
         	"path": "json/sleep-monitor.json"
+        },
+        {
+            "path": "json/control_lclick_to_lclick.json"
         }
       ]
     },

--- a/docs/json/control_lclick_to_lclick.json
+++ b/docs/json/control_lclick_to_lclick.json
@@ -10,19 +10,19 @@
             "pointing_button": "button1",
             "modifiers": {
               "mandatory": [
-                "left_control"
+                  "left_control"
               ],
               "optional": [
-                "any"
+                  "any"
               ]
             }
           },
           "to": [
             {
-              "pointing_button": "button1"
+                "pointing_button": "button1"
             },
             {
-                "key_code": "left_control",
+                "key_code": "left_control"
             }
           ]
         }

--- a/docs/json/control_lclick_to_lclick.json
+++ b/docs/json/control_lclick_to_lclick.json
@@ -1,0 +1,26 @@
+{
+  "title": "Disable Ctrl Click",
+  "rules": [
+    {
+      "description": "Ctrl + Left Click to Left Click",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "pointing_button": "button1",
+            "modifiers": {
+              "mandatory": [
+                "left_control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "pointing_button": "button1"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/json/control_lclick_to_lclick.json
+++ b/docs/json/control_lclick_to_lclick.json
@@ -11,6 +11,9 @@
             "modifiers": {
               "mandatory": [
                 "left_control"
+              ],
+              "optional": [
+                "any"
               ]
             }
           },

--- a/docs/json/control_lclick_to_lclick.json
+++ b/docs/json/control_lclick_to_lclick.json
@@ -13,7 +13,7 @@
                   "left_control"
               ],
               "optional": [
-                  "any"
+                  "caps_lock"
               ]
             }
           },

--- a/docs/json/control_lclick_to_lclick.json
+++ b/docs/json/control_lclick_to_lclick.json
@@ -17,6 +17,9 @@
           "to": [
             {
               "pointing_button": "button1"
+            },
+            {
+                "key_code": "left_control",
             }
           ]
         }


### PR DESCRIPTION
Sets `Ctrl + Left Click` to `Left Click`, effectively disabling MacOS's Ctrl-Click feature.