### PR TITLE
Vim pedal for modes

### DIFF
--- a/src/json/vi_pedal_mode.json
+++ b/src/json/vi_pedal_mode.json
@@ -1,0 +1,27 @@
+{
+    "title": "Footpedal down hits `i` for edit mode, and returns to command mode on release",
+    "rules": [
+        {
+            "manipulators": [
+                {
+                    "description": "Right footpedal to edit mode, back to command mode on release",
+                    "from": {
+                        "key_code": "keypad_enter"
+                    },
+                    "to": [
+                        {
+                            "key_code": "i",
+                            "repeat": false
+                        }
+                    ],
+                    "to_after_key_up": [
+                        {
+                            "key_code": "escape"
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This allows you to depress a pedal to enter edit mode, and then release it to return to command mode