### PR TITLE
Add modifications for Visual Studio Code

### DIFF
--- a/docs/extra_descriptions/vscode.json.html
+++ b/docs/extra_descriptions/vscode.json.html
@@ -1,0 +1,6 @@
+<p style="margin-top: 20px; font-weight: bold">
+Double-press Shift to Go To Anything
+</p>
+<p>
+  Enable the rule <em>"Change left_shift to cmd+k if pressed alone in VSCode"</em>, then edit your keyboard shortcuts in VSCode and bind the command <span style="font-family: monospace">workbench.action.quickOpen</span> to the chord ⌘K ⌘K.
+</p>

--- a/docs/groups.json
+++ b/docs/groups.json
@@ -179,6 +179,10 @@
           "path": "json/xcode.json"
         },
         {
+          "path": "json/vscode.json",
+          "extra_description_path": "extra_descriptions/vscode.json.html"
+        },
+        {
           "path": "json/safari.json"
         },
         {

--- a/docs/json/vscode.json
+++ b/docs/json/vscode.json
@@ -1,0 +1,95 @@
+{
+  "title": "Visual Studio Code",
+  "rules": [
+    {
+      "description": "Change left_shift to cmd+k if pressed alone in VSCode",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "bundle_identifiers": [
+                "com\\.microsoft\\.VSCode",
+                "com\\.microsoft\\.VSCodeInsiders"
+              ],
+              "type": "frontmost_application_if"
+            }
+          ],
+          "from": {
+            "key_code": "left_shift",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_shift"
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "k",
+              "modifiers": [
+                "left_command"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Change mouse button 4/5 to navigate back/forward in VSCode",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "bundle_identifiers": [
+                "com\\.microsoft\\.VSCode",
+                "com\\.microsoft\\.VSCodeInsiders"
+              ],
+              "type": "frontmost_application_if"
+            }
+          ],
+          "from": {
+            "pointing_button": "button4"
+          },
+          "to": [
+            {
+              "key_code": "hyphen",
+              "modifiers": [
+                "left_control"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "bundle_identifiers": [
+                "com\\.microsoft\\.VSCode",
+                "com\\.microsoft\\.VSCodeInsiders"
+              ],
+              "type": "frontmost_application_if"
+            }
+          ],
+          "from": {
+            "pointing_button": "button5"
+          },
+          "to": [
+            {
+              "key_code": "hyphen",
+              "modifiers": [
+                "left_control",
+                "left_shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- Adds proper back/forward navigation using mouse side buttons.
- Adds "Go to file" on double tap of shift key (like IntelliJ/Android Studio) - requires adding a keybinding in VSCode, see the extra descriptions.