### PR TITLE
Add rule: use option+1/2/3/4 to switch languages (English, Chinese, Japanese)

### DIFF
--- a/docs/groups.json
+++ b/docs/groups.json
@@ -491,6 +491,9 @@
         },
         {
           "path": "json/save_pinky_fingers.json"
+        },
+        {
+          "path": "json/switch_en_cn_ja_katakana.json"
         }
       ]
     }

--- a/docs/json/switch_en_cn_ja_katakana.json
+++ b/docs/json/switch_en_cn_ja_katakana.json
@@ -1,0 +1,94 @@
+{
+	"title": "switch English, Chinese, Japanese",
+	"rules": [
+		{
+			"description": "Use option+1/2/3/4 to switch language to English, Chinese, Japanese(Hirakana), Japanese(Katakana), respectively.",
+			"manipulators": [
+				{
+					"from": {
+						"key_code": "1",
+						"modifiers": {
+							"mandatory": [
+								"option"
+							],
+							"optional": [
+								"any"
+							]
+						}
+					},
+					"to": [
+						{
+							"select_input_source": {
+								"language": "en"
+							}
+						}
+					],
+					"type": "basic"
+				},
+				{
+					"from": {
+						"key_code": "2",
+						"modifiers": {
+							"mandatory": [
+								"option"
+							],
+							"optional": [
+								"any"
+							]
+						}
+					},
+					"to": [
+						{
+							"select_input_source": {
+								"language": "zh-Hans"
+							}
+						}
+					],
+					"type": "basic"
+				},
+				{
+					"from": {
+						"key_code": "3",
+						"modifiers": {
+							"mandatory": [
+								"option"
+							],
+							"optional": [
+								"any"
+							]
+						}
+					},
+					"to": [
+						{
+							"select_input_source": {
+								"input_mode_id": "com.apple.inputmethod.Japanese"
+							}
+						}
+					],
+					"type": "basic"
+				},
+				{
+					"from": {
+						"key_code": "4",
+						"modifiers": {
+							"mandatory": [
+								"option"
+							],
+							"optional": [
+								"any"
+							]
+						}
+					},
+					"to": [
+						{
+							"select_input_source": {
+								"input_mode_id": "com.apple.inputmethod.Japanese.Katakana"
+							}
+						}
+					],
+					"type": "basic"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
This adds a rule for switching languages by

- option + 1 for English
- option + 2 for Chinese
- option + 3 for Japanese, Hirakana
- option + 4 for Japanese, Katakana

It is very useful for English + Chinese + Japanese users (switching in a role is inconvenient especially for people constantly using more than two languages.
It should work fine for any Chinese/Japanese input method.
Thanks.

PS: excuse me if I put it in the wrong place but I'm not sure whether it should be Personal Settings or Miscellaneous.