### PR TITLE
Add modifier keys and VNC applications to virtual_machine

### DIFF
--- a/docs/json/virtual_machine.json
+++ b/docs/json/virtual_machine.json
@@ -45,7 +45,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -91,7 +95,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -142,7 +150,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -188,7 +200,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -201,7 +217,15 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "f1"
+            "key_code": "f1",
+            "modifiers": {
+              "optional": [
+                "command",
+                "control",
+                "option",
+                "shift"
+              ]
+            }
           },
           "to": [
             {
@@ -237,7 +261,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -245,7 +273,15 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "f2"
+            "key_code": "f2",
+            "modifiers": {
+              "optional": [
+                "command",
+                "control",
+                "option",
+                "shift"
+              ]
+            }
           },
           "to": [
             {
@@ -281,7 +317,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -289,7 +329,15 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "f3"
+            "key_code": "f3",
+            "modifiers": {
+              "optional": [
+                "command",
+                "control",
+                "option",
+                "shift"
+              ]
+            }
           },
           "to": [
             {
@@ -325,7 +373,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -333,7 +385,15 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "f4"
+            "key_code": "f4",
+            "modifiers": {
+              "optional": [
+                "command",
+                "control",
+                "option",
+                "shift"
+              ]
+            }
           },
           "to": [
             {
@@ -369,7 +429,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -377,7 +441,15 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "f5"
+            "key_code": "f5",
+            "modifiers": {
+              "optional": [
+                "command",
+                "control",
+                "option",
+                "shift"
+              ]
+            }
           },
           "to": [
             {
@@ -413,7 +485,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -421,7 +497,15 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "f6"
+            "key_code": "f6",
+            "modifiers": {
+              "optional": [
+                "command",
+                "control",
+                "option",
+                "shift"
+              ]
+            }
           },
           "to": [
             {
@@ -457,7 +541,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -465,7 +553,15 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "f7"
+            "key_code": "f7",
+            "modifiers": {
+              "optional": [
+                "command",
+                "control",
+                "option",
+                "shift"
+              ]
+            }
           },
           "to": [
             {
@@ -501,7 +597,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -509,7 +609,15 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "f8"
+            "key_code": "f8",
+            "modifiers": {
+              "optional": [
+                "command",
+                "control",
+                "option",
+                "shift"
+              ]
+            }
           },
           "to": [
             {
@@ -545,7 +653,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -553,7 +665,15 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "f9"
+            "key_code": "f9",
+            "modifiers": {
+              "optional": [
+                "command",
+                "control",
+                "option",
+                "shift"
+              ]
+            }
           },
           "to": [
             {
@@ -589,7 +709,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -597,7 +721,15 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "f10"
+            "key_code": "f10",
+            "modifiers": {
+              "optional": [
+                "command",
+                "control",
+                "option",
+                "shift"
+              ]
+            }
           },
           "to": [
             {
@@ -633,7 +765,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -641,7 +777,15 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "f11"
+            "key_code": "f11",
+            "modifiers": {
+              "optional": [
+                "command",
+                "control",
+                "option",
+                "shift"
+              ]
+            }
           },
           "to": [
             {
@@ -677,7 +821,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -685,7 +833,15 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "f12"
+            "key_code": "f12",
+            "modifiers": {
+              "optional": [
+                "command",
+                "control",
+                "option",
+                "shift"
+              ]
+            }
           },
           "to": [
             {
@@ -721,7 +877,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -738,6 +898,12 @@
             "modifiers": {
               "mandatory": [
                 "fn"
+              ],
+              "optional": [
+                "command",
+                "control",
+                "option",
+                "shift"
               ]
             }
           },
@@ -772,7 +938,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -784,6 +954,12 @@
             "modifiers": {
               "mandatory": [
                 "fn"
+              ],
+              "optional": [
+                "command",
+                "control",
+                "option",
+                "shift"
               ]
             }
           },
@@ -818,7 +994,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -830,6 +1010,12 @@
             "modifiers": {
               "mandatory": [
                 "fn"
+              ],
+              "optional": [
+                "command",
+                "control",
+                "option",
+                "shift"
               ]
             }
           },
@@ -864,7 +1050,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -876,6 +1066,12 @@
             "modifiers": {
               "mandatory": [
                 "fn"
+              ],
+              "optional": [
+                "command",
+                "control",
+                "option",
+                "shift"
               ]
             }
           },
@@ -910,7 +1106,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -922,6 +1122,12 @@
             "modifiers": {
               "mandatory": [
                 "fn"
+              ],
+              "optional": [
+                "command",
+                "control",
+                "option",
+                "shift"
               ]
             }
           },
@@ -956,7 +1162,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -968,6 +1178,12 @@
             "modifiers": {
               "mandatory": [
                 "fn"
+              ],
+              "optional": [
+                "command",
+                "control",
+                "option",
+                "shift"
               ]
             }
           },
@@ -1002,7 +1218,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -1014,6 +1234,12 @@
             "modifiers": {
               "mandatory": [
                 "fn"
+              ],
+              "optional": [
+                "command",
+                "control",
+                "option",
+                "shift"
               ]
             }
           },
@@ -1048,7 +1274,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -1060,6 +1290,12 @@
             "modifiers": {
               "mandatory": [
                 "fn"
+              ],
+              "optional": [
+                "command",
+                "control",
+                "option",
+                "shift"
               ]
             }
           },
@@ -1094,7 +1330,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -1106,6 +1346,12 @@
             "modifiers": {
               "mandatory": [
                 "fn"
+              ],
+              "optional": [
+                "command",
+                "control",
+                "option",
+                "shift"
               ]
             }
           },
@@ -1140,7 +1386,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -1152,6 +1402,12 @@
             "modifiers": {
               "mandatory": [
                 "fn"
+              ],
+              "optional": [
+                "command",
+                "control",
+                "option",
+                "shift"
               ]
             }
           },
@@ -1186,7 +1442,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -1198,6 +1458,12 @@
             "modifiers": {
               "mandatory": [
                 "fn"
+              ],
+              "optional": [
+                "command",
+                "control",
+                "option",
+                "shift"
               ]
             }
           },
@@ -1232,7 +1498,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]
@@ -1244,6 +1514,12 @@
             "modifiers": {
               "mandatory": [
                 "fn"
+              ],
+              "optional": [
+                "command",
+                "control",
+                "option",
+                "shift"
               ]
             }
           },
@@ -1278,7 +1554,11 @@
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
-                "^com\\.parallels\\.winapp\\."
+                "^com\\.parallels\\.winapp\\.",
+                "^com\\.geekspiff\\.chickenofthevnc$",
+                "^net\\.sourceforge\\.chicken$",
+                "^de\\.jinx\\.JollysFastVNC\\.",
+                "^com\\.realvnc\\.vncviewer\\."
               ]
             }
           ]

--- a/src/json/virtual_machine.json.erb
+++ b/src/json/virtual_machine.json.erb
@@ -1,6 +1,6 @@
 <%
     function_keys = Array(1..12).map {|x| 'f'+x.to_s}
-    virtual_conditions = [JSON.parse(frontmost_application_if(['remote_desktop', 'virtual_machine']))]
+    virtual_conditions = [JSON.parse(frontmost_application_if(['remote_desktop', 'virtual_machine', 'vnc']))]
 %>
 {
     "title": "Virtual Machine",
@@ -30,6 +30,7 @@
             "manipulators": <%= each_key(
                 source_keys_list: function_keys,
                 dest_keys_list: function_keys,
+                from_optional_modifiers: ['command', 'control', 'option', 'shift'],
                 to_modifiers: ['fn'],
                 conditions: virtual_conditions,
                 as_json: true
@@ -41,6 +42,7 @@
                 source_keys_list: function_keys,
                 dest_keys_list: function_keys,
                 from_mandatory_modifiers: ['fn'],
+                from_optional_modifiers: ['command', 'control', 'option', 'shift'],
                 conditions: virtual_conditions,
                 as_json: true
             ) %>

--- a/src/lib/karabiner.rb
+++ b/src/lib/karabiner.rb
@@ -99,6 +99,13 @@ module Karabiner
       '^com\.microsoft\.VSCode$',
     ],
 
+    :vnc => [
+      '^com\.geekspiff\.chickenofthevnc$',
+      '^net\.sourceforge\.chicken$',
+      '^de\.jinx\.JollysFastVNC\.', # prefix
+      '^com\.realvnc\.vncviewer\.', # prefix
+    ],
+
     :x11 => [
       '^org\.x\.X11$',
       '^com\.apple\.x11$',
@@ -135,6 +142,7 @@ module Karabiner
     'vi' => BUNDLE_IDENTIFERS[:vi],
     'virtual_machine' => BUNDLE_IDENTIFERS[:virtual_machine],
     'visual_studio_code' => BUNDLE_IDENTIFERS[:visual_studio_code],
+    'vnc' => BUNDLE_IDENTIFERS[:vnc],
     'xcode' => BUNDLE_IDENTIFERS[:xcode],
   }.freeze
 


### PR DESCRIPTION
Two modifications to virtual_machine:

- Allow modifier keys for function keys, so Alt-F4 works as expected.
- Add VNC to the list of applications. The list of bundle identifiers comes from appdef.xml of the old Karabiner.