### PR TITLE
Add rule: Change fn + grave_accent_and_tilde to esc

### DIFF
--- a/docs/groups.json
+++ b/docs/groups.json
@@ -352,6 +352,9 @@
         },
         {
           "path": "json/command_r_and_shift_r_to_command_tab.json"
+        },
+        {
+          "path": "json/fn_grave_accent.json"
         }
       ]
     },

--- a/docs/json/fn_grave_accent.json
+++ b/docs/json/fn_grave_accent.json
@@ -1,0 +1,26 @@
+{
+  "title": "Change fn + grave_accent_and_tilde to esc",
+  "rules": [
+    {
+      "description": "Change fn + grave_accent_and_tilde to esc",
+      "manipulators": [
+        {
+         "type": "basic",
+          "from": {
+            "key_code": "grave_accent_and_tilde",
+            "modifiers": {
+                "mandatory": [
+                  "fn"
+                ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "escape"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This rule doesn't change default behavior of grave_accent_and_tilde but adds hardware esc variant with fn key.