### PR TITLE
Added rule to allow activation of the standard fn keys

### DIFF
--- a/docs/groups.json
+++ b/docs/groups.json
@@ -352,6 +352,9 @@
         },
         {
           "path": "json/command_r_and_shift_r_to_command_tab.json"
+        },
+        {
+          "path": "json/standard_function_keys_on_fn.json"
         }
       ]
     },

--- a/docs/json/standard_function_keys_on_fn.json
+++ b/docs/json/standard_function_keys_on_fn.json
@@ -1,0 +1,197 @@
+{
+  "title": "Standard function keys using the fn key",
+  "rules": [
+    {
+      "description" : "Standard function keys using fn key - allows adding this feature just for specific profiles.",
+      "manipulators" : [
+        {
+          "type" : "basic",
+          "to" : [
+            {
+              "key_code" : "display_brightness_decrement"
+            }
+          ],
+          "from" : {
+            "key_code" : "f1",
+            "modifiers" : {
+              "mandatory" : [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          }
+        },
+        {
+          "type" : "basic",
+          "to" : [
+            {
+              "key_code" : "display_brightness_increment"
+            }
+          ],
+          "from" : {
+            "key_code" : "f2",
+            "modifiers" : {
+              "mandatory" : [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          }
+        },
+        {
+          "type" : "basic",
+          "to" : [
+            {
+              "key_code" : "mission_control"
+            }
+          ],
+          "from" : {
+            "key_code" : "f3",
+            "modifiers" : {
+              "mandatory" : [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          }
+        },
+        {
+          "type" : "basic",
+          "to" : [
+            {
+              "key_code" : "launchpad"
+            }
+          ],
+          "from" : {
+            "key_code" : "f4",
+            "modifiers" : {
+              "mandatory" : [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          }
+        },
+        {
+          "type" : "basic",
+          "to" : [
+            {
+              "key_code" : "rewind"
+            }
+          ],
+          "from" : {
+            "key_code" : "f7",
+            "modifiers" : {
+              "mandatory" : [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          }
+        },
+        {
+          "type" : "basic",
+          "to" : [
+            {
+              "key_code" : "play_or_pause"
+            }
+          ],
+          "from" : {
+            "key_code" : "f8",
+            "modifiers" : {
+              "mandatory" : [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          }
+        },
+        {
+          "type" : "basic",
+          "to" : [
+            {
+              "key_code" : "fastforward"
+            }
+          ],
+          "from" : {
+            "key_code" : "f9",
+            "modifiers" : {
+              "mandatory" : [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          }
+        },
+        {
+          "type" : "basic",
+          "to" : [
+            {
+              "key_code" : "mute"
+            }
+          ],
+          "from" : {
+            "key_code" : "f10",
+            "modifiers" : {
+              "mandatory" : [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          }
+        },
+        {
+          "type" : "basic",
+          "to" : [
+            {
+              "key_code" : "volume_decrement"
+            }
+          ],
+          "from" : {
+            "key_code" : "f11",
+            "modifiers" : {
+              "mandatory" : [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          }
+        },
+        {
+          "type" : "basic",
+          "to" : [
+            {
+              "key_code" : "volume_increment"
+            }
+          ],
+          "from" : {
+            "key_code" : "f12",
+            "modifiers" : {
+              "mandatory" : [
+                "fn"
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This allows activation of standard function keys with fn button
on per profile basis. For now it is not possible, because the
activation of F1, F2... buttons is a global settings. So settings
the F1, F2 and so on buttons to F1, F2... and using this rule the
inversion of the behaviour is possible on per profile basis.