### PR TITLE
Add additional Finder rules

### DIFF
--- a/docs/json/finder.json
+++ b/docs/json/finder.json
@@ -79,6 +79,30 @@
       ]
     },
     {
+      "description": "Use F2 as Rename",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "f2"
+          },
+          "to": [
+            {
+              "key_code": "return_or_enter"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com.apple.finder"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
       "description": "Use Delete as Move to Trash",
       "manipulators": [
         {
@@ -92,6 +116,61 @@
           "to": [
             {
               "key_code": "delete_or_backspace",
+              "modifiers": ["left_command"]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com.apple.finder"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Use Fn+Delete as Move to Trash",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "delete_forward",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_or_backspace",
+              "modifiers": ["left_command"]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com.apple.finder"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Use Backspace as Go to Previous Folder",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "delete_or_backspace"
+          },
+          "to": [
+            {
+              "key_code": "semicolon",
               "modifiers": ["left_command"]
             }
           ],


### PR DESCRIPTION
Adds the following rules to the Finder:

- Use F2 as Rename
- Use Fn+Delete as Move to Trash
- Use Backspace as Go to Previous Folder

Resolves #450