### PR TITLE
Remap AZERTY "ù" key to "´" deadkey

### DIFF
--- a/docs/extra_descriptions/accute_accent_deadkey_azerty.json.html
+++ b/docs/extra_descriptions/accute_accent_deadkey_azerty.json.html
@@ -1,0 +1,11 @@
+<p style="margin-top: 20px; font-weight: bold">
+  Version 1.0
+</p>
+<p>Typing an accute accented letter in AZERTT requires the Alt+Shift+1+letter combinaion.
+This slows down typing considerably compared to the AltGr method in Linux and Windows.
+This setup converts the "ù" key to a "´" deadkey to you can use it to type accents.
+</p>
+<p>More information:</p>
+	<ul>
+	 	<li><a href="https://github.com/nxadm/KE-complex_modifications">Raise an issue on the fork.</a></li>
+	</ul>

--- a/docs/groups.json
+++ b/docs/groups.json
@@ -42,6 +42,10 @@
         },
         {
           "path": "json/wolfXu.json"
+        },
+        {
+          "path": "json/accute_accent_deadkey_azerty.json",
+          "extra_description_path": "extra_descriptions/accute_accent_deadkey_azerty.json.html"
         }
       ]
     },
@@ -256,6 +260,10 @@
         {
           "path": "json/cmd_return.json",
           "extra_description_path": "extra_descriptions/cmd_return.json.html"
+        },
+        {
+          "path": "json/accute_accent_deadkey_azerty.json",
+          "extra_description_path": "extra_descriptions/accute_accent_deadkey_azerty.json.html"
         }
       ]
     },

--- a/docs/json/accute_accent_deadkey_azerty.json
+++ b/docs/json/accute_accent_deadkey_azerty.json
@@ -1,0 +1,30 @@
+{
+    "title": "Convert ù to an accute accent (´) dead key (AZERTY)",
+    "rules": [
+        {
+            "manipulators": [
+                {
+                    "description": "ù to deadkey ´ while leaving % accessible.",
+                    "from": {
+                        "key_code": "quote",
+                        "modifiers": {
+                            "optional": [
+                                "none"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "1",
+                            "modifiers": [
+                                "left_shift",
+                                "left_option"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        }
+    ]
+}

--- a/docs/json/accute_accent_deadkey_azerty.json
+++ b/docs/json/accute_accent_deadkey_azerty.json
@@ -2,9 +2,9 @@
     "title": "Convert ù to an accute accent (´) dead key (AZERTY)",
     "rules": [
         {
+            "description": "ù to deadkey ´ while leaving % accessible.",
             "manipulators": [
                 {
-                    "description": "ù to deadkey ´ while leaving % accessible.",
                     "from": {
                         "key_code": "quote",
                         "modifiers": {


### PR DESCRIPTION
Instead of using the azerty shortcut Alt+Shift+& for the ´ modifier, this scheme changes "ù" to the "´" deadkey (which is situated next to "´").