### PR TITLE
Add mapping for Finnish keyboard

### DIFF
--- a/docs/groups.json
+++ b/docs/groups.json
@@ -308,6 +308,9 @@
         },
         {
           "path": "json/norwegian_programming.json"
+        },
+        {
+          "path": "json/finnish_programming.json"
         }
       ]
     },

--- a/docs/json/finnish_programming.json
+++ b/docs/json/finnish_programming.json
@@ -1,0 +1,82 @@
+{
+  "title": "Finnish mapping for programming (|, {} and \\)",
+  "rules": [
+    {
+      "description": "Finnish {} keys",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "7",
+            "modifiers": {
+              "mandatory": ["right_option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "8",
+              "modifiers": ["right_option", "left_shift"],
+              "lazy": true
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "0",
+            "modifiers": {
+              "mandatory": ["right_option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "9",
+              "modifiers": ["right_option", "left_shift"],
+              "lazy": true
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Finnish | key",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "non_us_backslash",
+            "modifiers": {
+              "mandatory": ["right_option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "7",
+              "modifiers": ["right_option"]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Finnish \\ key",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "hyphen",
+            "modifiers": {
+              "mandatory": ["right_option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "7",
+              "modifiers": ["right_shift", "right_option"]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Finnish keyboard uses altgr modifier for several programming related keys.

Add the following rules:
- altgr + 7 -> {
- altgr + 0 -> }
- altgr + < -> |
- altgr + + -> \

On Finnish keyboard < was "non_us_backslash" and + sign was "hyphen"