### PR TITLE
Add rules for using Fn keys for copy & paste

### DIFF
--- a/src/json/fn-copy-paste.json.erb
+++ b/src/json/fn-copy-paste.json.erb
@@ -1,0 +1,93 @@
+{
+  "title": "F13 to copy & F14 to paste",
+  "rules": [
+    {
+      "description": "F13 to Copy",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "f13"
+          },
+          "to": [
+            {
+              "key_code": "c",
+              "modifiers": [
+                "command"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "F14 to Paste",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "f14"
+          },
+          "to": [
+            {
+              "key_code": "v",
+              "modifiers": [
+                "command"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Shift-F14 to Paste and Match Style",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "f14",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "v",
+              "modifiers": [
+                "option",
+                "shift",
+                "command"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "F15 to Paste and Match Style",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "f15"
+          },
+          "to": [
+            {
+              "key_code": "v",
+              "modifiers": [
+                "option",
+                "shift",
+                "command"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
F13 to Copy
F14 to Paste
⇧F14 to Paste and Match Style
F15 to Paste and Match Style

These are especially useful if you're on a full-sized Apple keyboard
(like the iMac Pro keyboard) or if you mouse on the left so your left
hand isn't always in position to hit the ⌘ shortcuts.