### PR TITLE
Update ijkl_arrows.json to allow using other modifiers

### DIFF
--- a/docs/json/ijkl_arrows.json
+++ b/docs/json/ijkl_arrows.json
@@ -324,6 +324,31 @@
           ]
         }
       ]
+    },
+    {
+      "description": "Change Ctrl + i to Cmd + i (italics shortcut)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "i",
+              "modifiers": "command"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/docs/json/ijkl_arrows.json
+++ b/docs/json/ijkl_arrows.json
@@ -1,16 +1,54 @@
 {
-  "title": "Change fn + i/j/k/l' to arrow keys",
+  "title": "Change Modifier key + i/j/k/l to arrow keys",
   "rules": [
     {
-      "description": "Change fn + i/j/k/l' to arrow keys",
+      "description": "Change Control + i/j/k/l to Arrows",
       "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "k",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "down_arrow"
+            }
+          ]
+        },
         {
           "type": "basic",
           "from": {
             "key_code": "i",
             "modifiers": {
               "mandatory": [
-                "fn"
+                "control"
               ],
               "optional": [
                 "any"
@@ -23,6 +61,111 @@
             }
           ]
         },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change Option + i/j/k/l to Arrows",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "k",
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "down_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change Fn + i/j/k/l to Arrows",
+      "manipulators": [
         {
           "type": "basic",
           "from": {
@@ -64,10 +207,110 @@
         {
           "type": "basic",
           "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
             "key_code": "l",
             "modifiers": {
               "mandatory": [
                 "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change Command + i/j/k/l to Arrows",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "k",
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "down_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "mandatory": [
+                "command"
               ],
               "optional": [
                 "any"

--- a/src/json/ijkl_arrows.json.erb
+++ b/src/json/ijkl_arrows.json.erb
@@ -1,84 +1,106 @@
 {
-    "title": "Change fn + i/j/k/l' to arrow keys",
+    "title": "Change Modifier key + i/j/k/l to arrow keys",
     "rules": [
         {
-            "description": "Change fn + i/j/k/l' to arrow keys",
+            "description": "Change Control + i/j/k/l to Arrows",
             "manipulators": [
                 {
                     "type": "basic",
-                    "from": {
-                        "key_code": "i",
-                        "modifiers": {
-                            "mandatory": [
-                                "fn"
-                            ],
-                            "optional": [
-                                "any"
-                            ]
-                        }
-                    },
-                    "to": [
-                        {
-                            "key_code": "up_arrow"
-                        }
-                    ]
+                    "from": <%= from("j", ['control'], ['any']) %>,
+                    "to": <%= to([["left_arrow"]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": {
-                        "key_code": "j",
-                        "modifiers": {
-                            "mandatory": [
-                                "fn"
-                            ],
-                            "optional": [
-                                "any"
-                            ]
-                        }
-                    },
-                    "to": [
-                        {
-                            "key_code": "left_arrow"
-                        }
-                    ]
+                    "from": <%= from("k", ['control'], ['any']) %>,
+                    "to": <%= to([["down_arrow"]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": {
-                        "key_code": "k",
-                        "modifiers": {
-                            "mandatory": [
-                                "fn"
-                            ],
-                            "optional": [
-                                "any"
-                            ]
-                        }
-                    },
-                    "to": [
-                        {
-                            "key_code": "down_arrow"
-                        }
-                    ]
+                    "from": <%= from("i", ['control'], ['any']) %>,
+                    "to": <%= to([["up_arrow"]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": {
-                        "key_code": "l",
-                        "modifiers": {
-                            "mandatory": [
-                                "fn"
-                            ],
-                            "optional": [
-                                "any"
-                            ]
-                        }
-                    },
-                    "to": [
-                        {
-                            "key_code": "right_arrow"
-                        }
-                    ]
+                    "from": <%= from("l", ['control'], ['any']) %>,
+                    "to": <%= to([["right_arrow"]]) %>
+                }
+            ]
+        },
+
+        {
+            "description": "Change Option + i/j/k/l to Arrows",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("j", ['option'], ['any']) %>,
+                    "to": <%= to([["left_arrow"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("k", ['option'], ['any']) %>,
+                    "to": <%= to([["down_arrow"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("i", ['option'], ['any']) %>,
+                    "to": <%= to([["up_arrow"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("l", ['option'], ['any']) %>,
+                    "to": <%= to([["right_arrow"]]) %>
+                }
+            ]
+        },
+
+        {
+            "description": "Change Fn + i/j/k/l to Arrows",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("j", ['fn'], ['any']) %>,
+                    "to": <%= to([["left_arrow"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("k", ['fn'], ['any']) %>,
+                    "to": <%= to([["down_arrow"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("i", ['fn'], ['any']) %>,
+                    "to": <%= to([["up_arrow"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("l", ['fn'], ['any']) %>,
+                    "to": <%= to([["right_arrow"]]) %>
+                }
+            ]
+        },
+
+        {
+            "description": "Change Command + i/j/k/l to Arrows",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("j", ['command'], ['any']) %>,
+                    "to": <%= to([["left_arrow"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("k", ['command'], ['any']) %>,
+                    "to": <%= to([["down_arrow"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("i", ['command'], ['any']) %>,
+                    "to": <%= to([["up_arrow"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("l", ['command'], ['any']) %>,
+                    "to": <%= to([["right_arrow"]]) %>
                 }
             ]
         }

--- a/src/json/ijkl_arrows.json.erb
+++ b/src/json/ijkl_arrows.json.erb
@@ -103,6 +103,18 @@
                     "to": <%= to([["right_arrow"]]) %>
                 }
             ]
+        },
+
+        {
+            "description": "Change Ctrl + i to Cmd + i (italics shortcut)",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("i", ['control'], ['any']) %>,
+                    "to": <%= to([["i", "command"]]) %>
+                }
+            ]
         }
+
     ]
 }


### PR DESCRIPTION
Currently `ijkl_arrows.json` allows converting `fn + i/j/k/l` to arrow keys.

This pull request extends this file to also allow setting a different modifier (`cmd`, `control` or `option`) + `i/j/k/l` as arrow keys.

I tested this by running:

```
$ cd ~/github/KE-complex_modifications/

$ make
bash scripts/update-json.sh
docs/json/ijkl_arrows.json
(cd docs && ruby ../scripts/make-distjs.rb > dist.json)

$ cp docs/json/ijkl_arrows.json ~/.config/karabiner/assets/complex_modifications
```

And then I enabled it from the UI:

<img width="1000" alt="karabiner-elements_preferences_and_ke-complex_modifications_ _-bash_ _80x24" src="https://user-images.githubusercontent.com/9726/50849313-8062f080-132b-11e9-9f91-ae3de5eb9bd7.png">
