### PR TITLE
Create F12 shortcut to open up Dev Tools Network

### DIFF
--- a/src/json/f12-to-dev-tools-networking-mac-ff.json.erb
+++ b/src/json/f12-to-dev-tools-networking-mac-ff.json.erb
@@ -1,0 +1,30 @@
+{
+  "title": "Use F12 to open Dev Tools Network Tab (Mac + Firefox)",
+  "rules": [
+    {
+      "description": "Use F12 to open Dev Tools Network Tab (Mac + Firefox)",
+      "manipulators": [
+         {
+          "type": "basic",
+          "from": {
+            "key_code": "f12",
+            "modifiers": {
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "e",
+              "modifiers": [
+                "option",
+                "left_command"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
only for Mac/Firefox