### PR TITLE
caps_lock to cmd+ctrl+opt+shift, caps_lock when pressed alone

### DIFF
--- a/src/json/caps_lock.json.rb
+++ b/src/json/caps_lock.json.rb
@@ -31,7 +31,7 @@ def main
             ],
             'to_if_alone' => [
               {
-                "hold_down_milliseconds": 100,
+                'hold_down_milliseconds' => 100,
                 'key_code' => 'caps_lock',
               },
             ],

--- a/src/json/caps_lock.json.rb
+++ b/src/json/caps_lock.json.rb
@@ -13,7 +13,7 @@ def main
     'title' => 'Change caps_lock key (rev 4)',
     'rules' => [
       {
-        'description' => 'Change caps_lock key to command+control+option+shift. (Post caps_lock when pressed alone)',
+        'description' => 'Change caps_lock key to command+control+option+shift if pressed with other keys',
         'manipulators' => [
           {
             'type' => 'basic',

--- a/src/json/caps_lock.json.rb
+++ b/src/json/caps_lock.json.rb
@@ -10,8 +10,34 @@ require_relative '../lib/karabiner.rb'
 
 def main
   puts JSON.pretty_generate(
-    'title' => 'Change caps_lock key (rev 3)',
+    'title' => 'Change caps_lock key (rev 4)',
     'rules' => [
+      {
+        'description' => 'Change caps_lock key to command+control+option+shift. (Post caps_lock when pressed alone)',
+        'manipulators' => [
+          {
+            'type' => 'basic',
+            'from' => {
+              'key_code' => 'caps_lock',
+              'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+            },
+            'to' => [
+              {
+                'key_code' => 'left_shift',
+                'modifiers' => %w[
+                  left_command left_control left_option
+                ],
+              },
+            ],
+            'to_if_alone' => [
+              {
+                "hold_down_milliseconds": 100,
+                'key_code' => 'caps_lock',
+              },
+            ],
+          },
+        ],
+      },
       {
         'description' => 'Change caps_lock key to command+control+option+shift. (Post escape key when pressed alone)',
         'manipulators' => [


### PR DESCRIPTION
This rule allows caps_lock to be used as cmd+ctrl+opt+shift when pressed in combination with any other key, but to still work as normal caps_lock when pressed alone.

Because this stays closer to standard keyboard behaviour than any other version of the "caps_lock to cmd+ctrl+opt+shift" rules, it is especially suitable for new users. Therefore, I have placed this rule first in the list in order to make it easier for new users to find it.