### PR TITLE
add Swedish Umlaut rule

### DIFF
--- a/src/json/swedish_umlaut.json.erb
+++ b/src/json/swedish_umlaut.json.erb
@@ -1,0 +1,31 @@
+{
+    "title": "Swedish Umlaut",
+    "rules": [
+        {
+            "description": "Change option + q/o to ä/ö",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("q", ["option"], ["caps_lock"]) %>,
+                    "to": <%= to([["u", ["left_option"]], ["a"], ["vk_none"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("q", ["option", "shift"], []) %>,
+                    "to": <%= to([["u", ["left_option"]], ["a", ["left_shift"]], ["vk_none"]]) %>
+                },
+
+                {
+                    "type": "basic",
+                    "from": <%= from("o", ["option"], ["caps_lock"]) %>,
+                    "to": <%= to([["u", ["left_option"]], ["o"], ["vk_none"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("o", ["option", "shift"], []) %>,
+                    "to": <%= to([["u", ["left_option"]], ["o", ["left_shift"]], ["vk_none"]]) %>
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Similar to the German Umlaut rule, but this one adds ä and ö (å already exists, which is alt + a)

Really helps as a Swede using the international English layout, as I can now type å, ä and ö without switching keyboard layout 😍 