### PR TITLE
Section sign (§) to Escape

### DIFF
--- a/docs/groups.json
+++ b/docs/groups.json
@@ -46,6 +46,9 @@
         {
           "path": "json/accute_accent_deadkey_azerty.json",
           "extra_description_path": "extra_descriptions/accute_accent_deadkey_azerty.json.html"
+        },
+        {
+          "path": "json/section_sign_to_escape.json"
         }
       ]
     },

--- a/docs/json/section_sign_to_escape.json
+++ b/docs/json/section_sign_to_escape.json
@@ -1,0 +1,42 @@
+{
+  "title": "Section sign (§) to Escape",
+  "rules": [
+    {
+      "description": "Section sign (§) to Escape and fn + Section sign (§) to Section sign (§). Useful on Mac with Touch Bar, where is no physical Escape key.",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "non_us_backslash",
+            "modifiers": {
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "escape"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "non_us_backslash",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "non_us_backslash"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Useful on Mac with Touch Bar, where is no physical Escape key.