### PR TITLE
Add workaround_broken_sw2tabesc.json

### DIFF
--- a/docs/groups.json
+++ b/docs/groups.json
@@ -567,6 +567,9 @@
         },
         {
           "path": "json/switch_en_cn_ja_katakana.json"
+        },
+        {
+          "path": "json/workaround_broken_sw2tabesc.json"
         }
       ]
     }

--- a/docs/json/workaround_broken_sw2tabesc.json
+++ b/docs/json/workaround_broken_sw2tabesc.json
@@ -1,0 +1,215 @@
+{
+  "title": "Workaround broken s,w,2,tab,esc,< by fn+neighbour on Apple internal kbd only",
+  "rules": [
+    {
+      "description": "Change fn + d to s",
+      "manipulators": [
+        {
+         "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 589
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "d",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "s"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change fn + e to w",
+      "manipulators": [
+        {
+         "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 589
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "e",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "w"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change fn + 3 to 2",
+      "manipulators": [
+        {
+         "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 589
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "3",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change fn + q to Tab",
+      "manipulators": [
+        {
+         "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 589
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "q",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "tab"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change fn + 1 to Esc",
+      "manipulators": [
+        {
+         "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 589
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "1",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "escape"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change fn + y to <",
+      "manipulators": [
+        {
+         "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 589
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "z",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This complex ruleset defines fn+d -> s , fn+e -> w
and so on, in order to work around my broken Macbook Air
keyboard which doesn't react on keys s,w,2,tab,esc,<
any more. By pressing fn+each desired key's right
neighbour, I can now reach all keys again which works
surprisingly well.

Restricted to operat on the Mac internal keyboard only,
and provided as an example in case somebody has a similar
problem.