### PR TITLE
Add Microsoft Edge browser

### DIFF
--- a/docs/json/pc_shortcuts.json
+++ b/docs/json/pc_shortcuts.json
@@ -152,6 +152,7 @@
                 "^io\\.alacritty$",
                 "^net\\.kovidgoyal\\.kitty$",
                 "^org\\.mozilla\\.firefox$",
+                "^com\\.microsoft\\.Edge",
                 "^com\\.google\\.Chrome$",
                 "^com\\.apple\\.Safari$",
                 "^cz\\.or\\.repo\\.git-gui$",
@@ -183,6 +184,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^com\\.microsoft\\.Edge",
                 "^com\\.google\\.Chrome$",
                 "^com\\.apple\\.Safari$"
               ]
@@ -301,6 +303,7 @@
                 "^io\\.alacritty$",
                 "^net\\.kovidgoyal\\.kitty$",
                 "^org\\.mozilla\\.firefox$",
+                "^com\\.microsoft\\.Edge",
                 "^com\\.google\\.Chrome$",
                 "^com\\.apple\\.Safari$",
                 "^cz\\.or\\.repo\\.git-gui$",
@@ -332,6 +335,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^com\\.microsoft\\.Edge",
                 "^com\\.google\\.Chrome$",
                 "^com\\.apple\\.Safari$"
               ]
@@ -2175,6 +2179,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^com\\.microsoft\\.Edge",
                 "^com\\.google\\.Chrome$",
                 "^com\\.apple\\.Safari$"
               ]
@@ -2212,6 +2217,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^com\\.microsoft\\.Edge",
                 "^com\\.google\\.Chrome$",
                 "^com\\.apple\\.Safari$"
               ]
@@ -2244,6 +2250,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^com\\.microsoft\\.Edge",
                 "^com\\.google\\.Chrome$",
                 "^com\\.apple\\.Safari$"
               ]
@@ -2281,6 +2288,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^com\\.microsoft\\.Edge",
                 "^com\\.google\\.Chrome$",
                 "^com\\.apple\\.Safari$"
               ]
@@ -2313,6 +2321,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^com\\.microsoft\\.Edge",
                 "^com\\.google\\.Chrome$",
                 "^com\\.apple\\.Safari$"
               ]
@@ -2345,6 +2354,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^com\\.microsoft\\.Edge",
                 "^com\\.google\\.Chrome$",
                 "^com\\.apple\\.Safari$"
               ]
@@ -2377,6 +2387,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^com\\.microsoft\\.Edge",
                 "^com\\.google\\.Chrome$",
                 "^com\\.apple\\.Safari$"
               ]
@@ -2409,6 +2420,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^com\\.microsoft\\.Edge",
                 "^com\\.google\\.Chrome$",
                 "^com\\.apple\\.Safari$"
               ]
@@ -2441,6 +2453,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^com\\.microsoft\\.Edge",
                 "^com\\.google\\.Chrome$",
                 "^com\\.apple\\.Safari$"
               ]

--- a/docs/json/personal_tekezo.json
+++ b/docs/json/personal_tekezo.json
@@ -776,6 +776,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^com\\.microsoft\\.Edge",
                 "^com\\.google\\.Chrome$",
                 "^com\\.apple\\.Safari$"
               ]
@@ -809,6 +810,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^com\\.microsoft\\.Edge",
                 "^com\\.google\\.Chrome$",
                 "^com\\.apple\\.Safari$"
               ]
@@ -842,6 +844,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^com\\.microsoft\\.Edge",
                 "^com\\.google\\.Chrome$",
                 "^com\\.apple\\.Safari$"
               ]

--- a/docs/json/personal_yqrashawn.json
+++ b/docs/json/personal_yqrashawn.json
@@ -288,6 +288,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^com\\.microsoft\\.Edge",
                 "^com\\.google\\.Chrome$",
                 "^com\\.apple\\.Safari$"
               ]

--- a/src/lib/karabiner.rb
+++ b/src/lib/karabiner.rb
@@ -11,6 +11,7 @@ module Karabiner
 
     :browser => [
       '^org\.mozilla\.firefox$',
+      '^com\.microsoft\.Edge', # prefix
       '^com\.google\.Chrome$',
       '^com\.apple\.Safari$',
     ],


### PR DESCRIPTION
Adding Microsoft Edge to the list of browsers. See: https://blogs.windows.com/msedgedev/2019/05/20/microsoft-edge-macos-canary-preview/

Currently this identifies as `com.microsoft.Edge.Canary` but presumably once it gets into standard insider preview and general release it will retain the `com.microsoft.Edge` prefix.