### PR TITLE
F12 developer tools proposals

### DIFF
--- a/src/json/f12-to-dev-tools-networking-mac-ff.json.erb
+++ b/src/json/f12-to-dev-tools-networking-mac-ff.json.erb
@@ -1,5 +1,5 @@
 {
-  "title": "Use F12 to open Dev Tools Network Tab (Mac + Firefox)",
+  "title": "Use F12 to open Dev Tools",
   "rules": [
     {
       "description": "Use F12 to open Dev Tools Network Tab (Mac + Firefox)",
@@ -13,6 +13,19 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": ["^org\\.mozilla\\.firefox$"]
             }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Use F12 to open Dev Tools (all browsers)",
+      "manipulators": [
+         {
+          "type": "basic",
+          "from": <%= from("f12", [], []) %>,
+          "to": <%= to([["i", ["option", "left_command"]]]) %>,
+          "conditions": [
+            <%= frontmost_application_if(["browser"]) %>
           ]
         }
       ]

--- a/src/json/f12-to-dev-tools-networking-mac-ff.json.erb
+++ b/src/json/f12-to-dev-tools-networking-mac-ff.json.erb
@@ -7,7 +7,13 @@
          {
           "type": "basic",
           "from": <%= from("f12", [], ["caps_lock"]) %>,
-          "to": <%= to([["e", ["option", "left_command"]]]) %>
+          "to": <%= to([["e", ["option", "left_command"]]]) %>,
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": ["^org\\.mozilla\\.firefox$"]
+            }
+          ]
         }
       ]
     }

--- a/src/json/f12-to-dev-tools-networking-mac-ff.json.erb
+++ b/src/json/f12-to-dev-tools-networking-mac-ff.json.erb
@@ -6,23 +6,8 @@
       "manipulators": [
          {
           "type": "basic",
-          "from": {
-            "key_code": "f12",
-            "modifiers": {
-              "optional": [
-                "caps_lock"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "e",
-              "modifiers": [
-                "option",
-                "left_command"
-              ]
-            }
-          ]
+          "from": <%= from("f12", [], ["caps_lock"]) %>,
+          "to": <%= to([["e", ["option", "left_command"]]]) %>
         }
       ]
     }


### PR DESCRIPTION
Here is a proposal to modify the F12 developer tools keypress a little bit.

One important change I am proposing to the original version by @niij in #471 is to only have that rule take effect when Firefox is in the foreground. The reason is because it otherwise steals the F12 for other applications (notably Edge).

In ce9166f I am also suggesting we add a "generic" F12 mapping for all browsers. Chrome, Edge, Firefox and Safari all use Cmd-Opt-I to open the developer tools on the inspector tab, so this would work on all browsers as an alternative to the Firefox-specific option if you do not care about network tab.

Another option might be to combine these back together again so on Firefox it does Cmd-Opt-E and on Chrome/Safari it does Cmd-Opt-I. On Edge it doesn't matter because F12 works already.

Note: I did not `make rebuild` yet because this one might be different if #498 gets merged first.  