### PR TITLE
Add rule: Figma Shortcut

### DIFF
--- a/docs/extra_descriptions/figma-shortcut.json.html
+++ b/docs/extra_descriptions/figma-shortcut.json.html
@@ -1,0 +1,2 @@
+<br>
+<p>Figma version of Sketch shortcut created by <a href="https://tankxu.com">@tankxu</a>.</p>

--- a/docs/groups.json
+++ b/docs/groups.json
@@ -228,6 +228,10 @@
           "extra_description_path": "extra_descriptions/sketch-shortcut.json.html"
         },
         {
+          "path": "json/figma-shortcut.json",
+          "extra_description_path": "extra_descriptions/figma-shortcut.json.html"
+        },
+        {
           "path": "json/option_tab.json"
         },
         {

--- a/docs/json/figma-shortcut.json
+++ b/docs/json/figma-shortcut.json
@@ -1,0 +1,44 @@
+{
+  "title": "Figma Shortcut",
+  "rules": [
+    {
+      "description": "Post spacebar to Command+Shift+Ctrl if not press alone in Figma app.",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "spacebar",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_control",
+              "modifiers": [
+                "left_shift",
+                "left_command"
+              ],
+              "lazy": true
+            }
+          ],
+          "to_if_alone": [
+              {
+                "key_code": "spacebar"
+              }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.figma\\.Desktop$"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### feature
- Post spacebar to Command+Shift+Ctrl if not press alone in Figma app.

This Shortcut operates the same  as the [Sketch Shortcut](https://github.com/pqrs-org/KE-complex_modifications/blob/master/docs/json/sketch-shortcut.json).