### PR TITLE
Add rules for AquaSKK workarounds.

### DIFF
--- a/docs/extra_descriptions/aquaskk.json.html
+++ b/docs/extra_descriptions/aquaskk.json.html
@@ -1,0 +1,11 @@
+<p style="margin-top: 20px; font-weight: bold">
+  Version 1.0
+</p>
+<p>Rules to fix problems using AquaSKK with JetBrains IDEs, Terminal, and iTerm2.</p>
+<p>More information:</p>
+	<ul>
+		<li><a href="https://github.com/codefirst/aquaskk">AquaSKK</a></li>
+		<li><a href="https://mzp.hatenablog.com/entry/2016/10/29/095435">The original article describing JetBrains workaround</a></li>
+		<li><a href="https://mzp.hatenablog.com/entry/2015/03/15/213219">The original article describing Terminal/iTerm2 workaround</a></li>
+		<li><a href="https://github.com/nxadm/KE-complex_modifications">Raise an issue on the fork.</a></li>
+	</ul>

--- a/docs/groups.json
+++ b/docs/groups.json
@@ -236,6 +236,9 @@
         },
         {
           "path": "json/alacritty.json"
+        },
+        {
+          "path": "json/aquaskk.json"
         }
       ]
     },

--- a/docs/json/aquaskk.json
+++ b/docs/json/aquaskk.json
@@ -1,0 +1,176 @@
+{
+  "title": "AquaSKK",
+  "rules": [
+    {
+      "description": "AquaSKK for JetBrains",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "mandatory": [
+                "left_shift",
+                "right_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "select_input_source": {
+                "language": "ja",
+                "input_source_id": "jp.sourceforge.inputmethod.aquaskk.FullWidthRoman",
+                "input_mode_id": "com.apple.inputmethod.Japanese.FullWidthRoman"
+              }
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.jetbrains\\."
+              ]
+            },
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "input_source_id": "^jp\\.sourceforge\\.inputmethod\\.aquaskk\\.(Hiragana|Katakana|HalfWidthKana)$"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "l"
+          },
+          "to": [
+            {
+              "select_input_source": {
+                "language": "en",
+                "input_source_id": "jp.sourceforge.inputmethod.aquaskk.Ascii",
+                "input_mode_id": "com.apple.inputmethod.Roman"
+              }
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.jetbrains\\."
+              ]
+            },
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "input_source_id": "^jp\\.sourceforge\\.inputmethod\\.aquaskk\\.(Hiragana|Katakana|HalfWidthKana)$"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "q",
+            "modifiers": {
+              "mandatory": [
+                "left_shift",
+                "right_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "select_input_source": {
+                "language": "ja",
+                "input_source_id": "jp.sourceforge.inputmethod.aquaskk.HalfWidthKana",
+                "input_mode_id": "com.apple.inputmethod.Japanese.HalfWidthKana"
+              }
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.jetbrains\\."
+              ]
+            },
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "input_source_id": "^jp\\.sourceforge\\.inputmethod\\.aquaskk\\.(Hiragana|Katakana|HalfWidthKana)$"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "q"
+          },
+          "to": [
+            {
+              "select_input_source": {
+                "language": "ja",
+                "input_source_id": "jp.sourceforge.inputmethod.aquaskk.Katakana",
+                "input_mode_id": "com.apple.inputmethod.Japanese.Katakana"
+              }
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.jetbrains\\."
+              ]
+            },
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "input_source_id": "^jp\\.sourceforge\\.inputmethod\\.aquaskk\\.(Hiragana|Katakana|HalfWidthKana)$"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "AquaSKK for Terminal/iTerm2",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "mandatory": [
+                "left_control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "japanese_kana"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.googlecode\\.iterm2",
+                "^com\\.apple\\.Terminal"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/aquaskk.json.erb
+++ b/src/json/aquaskk.json.erb
@@ -1,0 +1,124 @@
+{
+  "title": "AquaSKK",
+  "rules": [
+    {
+      "description": "AquaSKK for JetBrains",
+      <%
+        jetbrains = {
+          "type"=>"frontmost_application_if",
+          "bundle_identifiers"=>[
+            "^com\\.jetbrains\\."
+          ]
+        }
+        non_latin = {
+          "type"=>"input_source_if",
+          "input_sources"=>[
+            {
+              "input_source_id"=>"^jp\\.sourceforge\\.inputmethod\\.aquaskk\\.(Hiragana|Katakana|HalfWidthKana)$"
+            }
+          ]
+        }
+      %>
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "mandatory": ["left_shift", "right_shift"]
+            }
+          },
+          "to": [
+            {
+              "select_input_source": {
+                "language": "ja",
+                "input_source_id": "jp.sourceforge.inputmethod.aquaskk.FullWidthRoman",
+                "input_mode_id": "com.apple.inputmethod.Japanese.FullWidthRoman"
+              }
+            }
+          ],
+          "conditions": <%= JSON.generate([jetbrains, non_latin]) %>
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "l"
+          },
+          "to": [
+            {
+              "select_input_source": {
+                "language": "en",
+                "input_source_id": "jp.sourceforge.inputmethod.aquaskk.Ascii",
+                "input_mode_id": "com.apple.inputmethod.Roman"
+              }
+            }
+          ],
+          "conditions": <%= JSON.generate([jetbrains, non_latin]) %>
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "q",
+            "modifiers": {
+              "mandatory": ["left_shift", "right_shift"]
+            }
+          },
+          "to": [
+            {
+              "select_input_source": {
+                "language": "ja",
+                "input_source_id": "jp.sourceforge.inputmethod.aquaskk.HalfWidthKana",
+                "input_mode_id": "com.apple.inputmethod.Japanese.HalfWidthKana"
+              }
+            }
+          ],
+          "conditions": <%= JSON.generate([jetbrains, non_latin]) %>
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "q"
+          },
+          "to": [
+            {
+              "select_input_source": {
+                "language": "ja",
+                "input_source_id": "jp.sourceforge.inputmethod.aquaskk.Katakana",
+                "input_mode_id": "com.apple.inputmethod.Japanese.Katakana"
+              }
+            }
+          ],
+          "conditions": <%= JSON.generate([jetbrains, non_latin]) %>
+        }
+      ]
+    },
+    {
+      "description": "AquaSKK for Terminal/iTerm2",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "mandatory": ["left_control"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "japanese_kana"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.googlecode\\.iterm2",
+                "^com\\.apple\\.Terminal"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds application-specific rules.

[AquaSKK](https://github.com/codefirst/aquaskk) is a Japanese IME and it's not fully compatible with JetBrains IDEs and Terminal/iTerm2. The semi-official workarounds using Karabiner are known (https://mzp.hatenablog.com/entry/2016/10/29/095435, https://mzp.hatenablog.com/entry/2015/03/15/213219) but they're in the old `private.xml` format. This PR is the port of the known workarounds.