### PR TITLE
feat: Add workaround for auto-jumping or faulty keys

### DIFF
--- a/docs/extra_descriptions/personal_rakeshtembhurne_jumping_key_workaround.json.html
+++ b/docs/extra_descriptions/personal_rakeshtembhurne_jumping_key_workaround.json.html
@@ -1,0 +1,23 @@
+<p>
+  Personal Rules by
+  <a href="https://github.com/rakeshtembhurne">@rakeshtembhurne</a>. Disables
+  auto jumping keys which are typed-in automatically anytime causing unwanted
+  typed characters or behavior.
+</p>
+<p>
+  For me key `left_option` started turning on anytime, causing weird symbols to
+  appear while writing. Also it is in pressed down state always, causing every
+  other key to behave differently. Sometimes I could not even log in as correct
+  password is not being typed. Similar things happened with number 9 key. It
+  started auto typing automatically.
+</p>
+<p>
+  This configuration is settings for disabling 'left_option' key and '9' key
+  (which is also a '(' when used with shift key). With these configs applied,
+  normal behavior of key 9 will be disabled and they will only work when they
+  are pressed with 'fn' button.
+</p>
+<p>
+  So, fn + 9 will be 9, and fn + shift + 9 will be '('. Disabled keys will be
+  left_option, 9 and shift + 9 which is '('.
+</p>

--- a/docs/groups.json
+++ b/docs/groups.json
@@ -511,6 +511,10 @@
       "id": "personal-settings",
       "files": [
         {
+          "path": "json/personal_rakeshtembhurne_jumping_key_workaround.json",
+          "extra_description_path": "extra_descriptions/personal_rakeshtembhurne_jumping_key_workaround.json.html"
+        },
+        {
           "path": "json/personal_tekezo.json",
           "extra_description_path": "extra_descriptions/personal_tekezo.json.html"
         },

--- a/docs/json/personal_rakeshtembhurne_jumping_key_workaround.json
+++ b/docs/json/personal_rakeshtembhurne_jumping_key_workaround.json
@@ -1,0 +1,50 @@
+{
+  "title": "Personal rules (@rakeshtembhurne) - Workaround for auto-jumping or non functioning keys",
+  "rules": [
+    {
+      "description": "Disable left_option key",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_option"
+          }
+        }
+      ]
+    },
+    {
+      "description": "Disable key 9 and shift + 9 which is (",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "9",
+            "modifiers": {
+              "optional": ["shift"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "Change fn + 9 to 9 and fn + shift + 9 to (",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "9",
+            "modifiers": {
+              "mandatory": ["fn"]
+            }
+          },
+          "to": [
+            {
+              "halt": true,
+              "key_code": "9"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
These are personal rules. Disables faulty auto-jumping keys `left_option` and `9`. Adds new combo replacements for the characters `9` and `(`. 