### PR TITLE
Added missing Num Lock condition to keypad_7 key manipulation

### DIFF
--- a/docs/json/numpad.json
+++ b/docs/json/numpad.json
@@ -65,6 +65,13 @@
               "key_code": "home"
             }
           ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "Num Lock",
+              "value": 1
+            }
+          ],
           "type": "basic"
         },
         {


### PR DESCRIPTION
The absence of the Num Lock condition restricts `keypad_7` to the `home` keycode regardless of whether Num Lock is enabled or disabled.