### PR TITLE
Add default arguments to Karabiner.from_modifiers

### DIFF
--- a/src/json/caps_lock.json.rb
+++ b/src/json/caps_lock.json.rb
@@ -19,7 +19,7 @@ def main
             'type' => 'basic',
             'from' => {
               'key_code' => 'caps_lock',
-              'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+              'modifiers' => Karabiner.from_modifiers,
             },
             'to' => [
               {
@@ -45,7 +45,7 @@ def main
             'type' => 'basic',
             'from' => {
               'key_code' => 'caps_lock',
-              'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+              'modifiers' => Karabiner.from_modifiers,
             },
             'to' => [
               {
@@ -70,7 +70,7 @@ def main
             'type' => 'basic',
             'from' => {
               'key_code' => 'caps_lock',
-              'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+              'modifiers' => Karabiner.from_modifiers,
             },
             'to' => [
               {
@@ -107,7 +107,7 @@ def main
             'type' => 'basic',
             'from' => {
               'key_code' => 'caps_lock',
-              'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+              'modifiers' => Karabiner.from_modifiers,
             },
             'to' => [
               {
@@ -127,7 +127,7 @@ def main
             'type' => 'basic',
             'from' => {
               'key_code' => 'caps_lock',
-              'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+              'modifiers' => Karabiner.from_modifiers,
             },
             'to' => [
               {
@@ -149,7 +149,7 @@ def main
             'type' => 'basic',
             'from' => {
               'key_code' => 'caps_lock',
-              'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+              'modifiers' => Karabiner.from_modifiers,
             },
             'to' => [
               {
@@ -172,7 +172,7 @@ def main
             'type' => 'basic',
             'from' => {
               'key_code' => 'caps_lock',
-              'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+              'modifiers' => Karabiner.from_modifiers,
             },
             'to' => [
               {

--- a/src/json/emacs_key_bindings.json.rb
+++ b/src/json/emacs_key_bindings.json.rb
@@ -118,7 +118,7 @@ def c_x_key_strokes
         'type' => 'basic',
         'from' => {
           'any' => 'key_code',
-          'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+          'modifiers' => Karabiner.from_modifiers,
         },
         'conditions' => [Karabiner.variable_if('C-x', 1)],
       },

--- a/src/json/japanese.json.rb
+++ b/src/json/japanese.json.rb
@@ -19,7 +19,7 @@ def main
             'type' => 'basic',
             'from' => {
               'key_code' => 'left_command',
-              'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+              'modifiers' => Karabiner.from_modifiers,
             },
             'parameters' => {
               'basic.to_if_held_down_threshold_milliseconds' => 100,
@@ -45,7 +45,7 @@ def main
             'type' => 'basic',
             'from' => {
               'key_code' => 'right_command',
-              'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+              'modifiers' => Karabiner.from_modifiers,
             },
             'parameters' => {
               'basic.to_if_held_down_threshold_milliseconds' => 100,
@@ -86,7 +86,7 @@ def main
             ],
             'from' => {
               'key_code' => 'left_command',
-              'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+              'modifiers' => Karabiner.from_modifiers,
             },
             'to' => [
               {
@@ -114,7 +114,7 @@ def main
             ],
             'from' => {
               'key_code' => 'left_command',
-              'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+              'modifiers' => Karabiner.from_modifiers,
             },
             'to' => [
               {
@@ -142,7 +142,7 @@ def main
             ],
             'from' => {
               'key_code' => 'right_command',
-              'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+              'modifiers' => Karabiner.from_modifiers,
             },
             'to' => [
               {
@@ -170,7 +170,7 @@ def main
             ],
             'from' => {
               'key_code' => 'right_command',
-              'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+              'modifiers' => Karabiner.from_modifiers,
             },
             'to' => [
               {
@@ -203,7 +203,7 @@ def main
             ],
             'from' => {
               'key_code' => 'right_command',
-              'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+              'modifiers' => Karabiner.from_modifiers,
             },
             'to' => [
               {
@@ -231,7 +231,7 @@ def main
             ],
             'from' => {
               'key_code' => 'right_command',
-              'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+              'modifiers' => Karabiner.from_modifiers,
             },
             'to' => [
               {
@@ -254,7 +254,7 @@ def main
             'type' => 'basic',
             'from' => {
               'key_code' => 'japanese_eisuu',
-              'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+              'modifiers' => Karabiner.from_modifiers,
             },
             'to' => [
               {
@@ -271,7 +271,7 @@ def main
             'type' => 'basic',
             'from' => {
               'key_code' => 'japanese_kana',
-              'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+              'modifiers' => Karabiner.from_modifiers,
             },
             'to' => [
               {
@@ -465,7 +465,7 @@ def main
             'type' => 'basic',
             'from' => {
               'key_code' => 'left_control',
-              'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+              'modifiers' => Karabiner.from_modifiers,
             },
             'to' => [
               {
@@ -483,7 +483,7 @@ def main
             'type' => 'basic',
             'from' => {
               'key_code' => 'right_command',
-              'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+              'modifiers' => Karabiner.from_modifiers,
             },
             'to' => [
               {

--- a/src/json/mouse_keys_mode_v4.json.rb
+++ b/src/json/mouse_keys_mode_v4.json.rb
@@ -91,7 +91,7 @@ def generate_mouse_keys_mode(from_key_code, to, scroll_to, to_after_key_up)
       'type' => 'basic',
       'from' => {
         'key_code' => from_key_code,
-        'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+        'modifiers' => Karabiner.from_modifiers,
       },
       'to' => scroll_to,
       'conditions' => [
@@ -111,7 +111,7 @@ def generate_mouse_keys_mode(from_key_code, to, scroll_to, to_after_key_up)
     'type' => 'basic',
     'from' => {
       'key_code' => from_key_code,
-      'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+      'modifiers' => Karabiner.from_modifiers,
     },
     'to' => to,
     'conditions' => [Karabiner.variable_if('mouse_keys_mode_v4', 1)],
@@ -142,7 +142,7 @@ def generate_mouse_keys_mode(from_key_code, to, scroll_to, to_after_key_up)
           Karabiner.set_variable('mouse_keys_mode_v4_scroll', 0),
         ],
       },
-      'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+      'modifiers' => Karabiner.from_modifiers,
     },
     'to' => [
       Karabiner.set_variable('mouse_keys_mode_v4', 1),

--- a/src/json/personal_tekezo.json.rb
+++ b/src/json/personal_tekezo.json.rb
@@ -32,7 +32,7 @@ def main
             'type' => 'basic',
             'from' => {
               'key_code' => 'tab',
-              'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+              'modifiers' => Karabiner.from_modifiers,
             },
             'to' => [
               {
@@ -52,7 +52,7 @@ def main
             'type' => 'basic',
             'from' => {
               'key_code' => 'f18',
-              'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+              'modifiers' => Karabiner.from_modifiers,
             },
             'to' => [
               { 'key_code' => 'spacebar' },
@@ -102,7 +102,7 @@ def main
             'type' => 'basic',
             'from' => {
               'key_code' => 'right_command',
-              'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+              'modifiers' => Karabiner.from_modifiers,
             },
             'to' => [
               {
@@ -120,7 +120,7 @@ def main
             'type' => 'basic',
             'from' => {
               'key_code' => 'right_command',
-              'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+              'modifiers' => Karabiner.from_modifiers,
             },
             'to' => [
               {
@@ -136,7 +136,7 @@ def main
             'type' => 'basic',
             'from' => {
               'key_code' => 'left_command',
-              'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+              'modifiers' => Karabiner.from_modifiers,
             },
             'to' => [
               {
@@ -382,7 +382,7 @@ def app_terminal
       'type' => 'basic',
       'from' => {
         'key_code' => 'o',
-        'modifiers' => Karabiner.from_modifiers(['command'], ['any']),
+        'modifiers' => Karabiner.from_modifiers(['command']),
       },
       'conditions' => [
         Karabiner.frontmost_application_if(['terminal']),
@@ -392,7 +392,7 @@ def app_terminal
       'type' => 'basic',
       'from' => {
         'key_code' => 'f',
-        'modifiers' => Karabiner.from_modifiers(['command'], ['any']),
+        'modifiers' => Karabiner.from_modifiers(['command']),
       },
       'conditions' => [
         Karabiner.frontmost_application_if(['terminal']),

--- a/src/json/personal_tekezo_launcher_mode_v4.json.rb
+++ b/src/json/personal_tekezo_launcher_mode_v4.json.rb
@@ -58,7 +58,7 @@ def generate_launcher_mode(from_key_code, mandatory_modifiers, to)
     'type' => 'basic',
     'from' => {
       'key_code' => from_key_code,
-      'modifiers' => Karabiner.from_modifiers(mandatory_modifiers, ['any']),
+      'modifiers' => Karabiner.from_modifiers(mandatory_modifiers),
     },
     'to' => to,
     'conditions' => [Karabiner.variable_if('launcher_mode_v4', 1)],
@@ -82,7 +82,7 @@ def generate_launcher_mode(from_key_code, mandatory_modifiers, to)
           Karabiner.set_variable('launcher_mode_v4', 0),
         ],
       },
-      'modifiers' => Karabiner.from_modifiers(mandatory_modifiers, ['any']),
+      'modifiers' => Karabiner.from_modifiers(mandatory_modifiers),
     },
     'to' => [
       Karabiner.set_variable('launcher_mode_v4', 1),

--- a/src/json/personal_tekezo_simple_vi_mode.json.rb
+++ b/src/json/personal_tekezo_simple_vi_mode.json.rb
@@ -36,7 +36,7 @@ def generate_simple_vi_mode(from_key_code, to_key_code)
       'type' => 'basic',
       'from' => {
         'key_code' => from_key_code,
-        'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+        'modifiers' => Karabiner.from_modifiers,
       },
       'to' => [
         {
@@ -65,7 +65,7 @@ def generate_simple_vi_mode(from_key_code, to_key_code)
             Karabiner.set_variable('simple_vi_mode', 0),
           ],
         },
-        'modifiers' => Karabiner.from_modifiers(nil, ['any']),
+        'modifiers' => Karabiner.from_modifiers,
       },
       'to' => [
         Karabiner.set_variable('simple_vi_mode', 1),

--- a/src/json/swiss_pc_shortcuts.json.rb
+++ b/src/json/swiss_pc_shortcuts.json.rb
@@ -20,7 +20,7 @@ def main
           {
             'from' => {
               'key_code' => 'grave_accent_and_tilde',
-              'modifiers' => Karabiner.from_modifiers(['right_option'], ['any']),
+              'modifiers' => Karabiner.from_modifiers(['right_option']),
             },
             'to' => [
               {
@@ -41,7 +41,7 @@ def main
           {
             'from' => {
               'key_code' => 'hyphen',
-              'modifiers' => Karabiner.from_modifiers(['right_option'], ['any']),
+              'modifiers' => Karabiner.from_modifiers(['right_option']),
             },
             'to' => [
               {
@@ -62,7 +62,7 @@ def main
           {
             'from' => {
               'key_code' => 'open_bracket',
-              'modifiers' => Karabiner.from_modifiers(['right_option'], ['any']),
+              'modifiers' => Karabiner.from_modifiers(['right_option']),
             },
             'to' => [
               {
@@ -83,7 +83,7 @@ def main
           {
             'from' => {
               'key_code' => 'close_bracket',
-              'modifiers' => Karabiner.from_modifiers(['right_option'], ['any']),
+              'modifiers' => Karabiner.from_modifiers(['right_option']),
             },
             'to' => [
               {
@@ -104,7 +104,7 @@ def main
           {
             'from' => {
               'key_code' => '2',
-              'modifiers' => Karabiner.from_modifiers(['right_option'], ['any']),
+              'modifiers' => Karabiner.from_modifiers(['right_option']),
             },
             'to' => [
               {
@@ -125,7 +125,7 @@ def main
           {
             'from' => {
               'key_code' => 'quote',
-              'modifiers' => Karabiner.from_modifiers(['right_option'], ['any']),
+              'modifiers' => Karabiner.from_modifiers(['right_option']),
             },
             'to' => [
               {
@@ -146,7 +146,7 @@ def main
           {
             'from' => {
               'key_code' => 'non_us_pound',
-              'modifiers' => Karabiner.from_modifiers(['right_option'], ['any']),
+              'modifiers' => Karabiner.from_modifiers(['right_option']),
             },
             'to' => [
               {
@@ -167,7 +167,7 @@ def main
           {
             'from' => {
               'key_code' => 'equal_sign',
-              'modifiers' => Karabiner.from_modifiers(['right_option'], ['any']),
+              'modifiers' => Karabiner.from_modifiers(['right_option']),
             },
             'to' => [
               {

--- a/src/lib/karabiner.rb
+++ b/src/lib/karabiner.rb
@@ -148,7 +148,7 @@ module Karabiner
     'xcode' => BUNDLE_IDENTIFERS[:xcode],
   }.freeze
 
-  def self.from_modifiers(mandatory_modifiers, optional_modifiers)
+  def self.from_modifiers(mandatory_modifiers = nil, optional_modifiers = ['any'])
     modifiers = {}
     modifiers['mandatory'] = mandatory_modifiers unless mandatory_modifiers.nil?
     modifiers['optional'] = optional_modifiers unless optional_modifiers.nil?


### PR DESCRIPTION
`Karabiner.from_modifiers` is frequently called with `nil` and
`['any']` as the mandatory and optional modifiers, respectively.
Specifying a mandatory modifier and `['any']` as optional is also a
common use case. Thus, it seems reasonable to add `nil` and `['any']` as
default arguments for this method.

Running `make` produces no changes in the `docs/json` directory.