### PR TITLE
Add helpful rules for the Matias Ergo Pro Keyboard + personal rules

### DIFF
--- a/docs/groups.json
+++ b/docs/groups.json
@@ -506,6 +506,9 @@
       "id": "device-specific",
       "files": [
         {
+          "path": "json/matias_ergo_pro.json"
+        },
+        {
           "path": "json/typematrix_bepo_cut_copy_paste_fn_shortcuts.json"
         },
         {
@@ -566,6 +569,9 @@
         },
         {
           "path": "json/personal_tkrworks.json"
+        },
+        {
+          "path": "json/personal_mingaldrichgan.json"
         },
         {
           "path": "json/backtick_z_slash_as_ctrl.json"

--- a/docs/json/matias_ergo_pro.json
+++ b/docs/json/matias_ergo_pro.json
@@ -1,0 +1,19169 @@
+{
+  "title": "Matias Ergo Pro Keyboard",
+  "maintainers": [
+    "mingaldrichgan"
+  ],
+  "rules": [
+    {
+      "description": "Matias Ergo Pro Keyboard: Change right_control to b if pressed alone, or while typing",
+      "manipulators": [
+        {
+          "description": "Set variable if 0 is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "0",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "0"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if 1 is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "1",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "1"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if 2 is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "2",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "2"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if 3 is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "3",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "3"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if 4 is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "4",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "4"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if 5 is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "5",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "5"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if 6 is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "6",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "6"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if 7 is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "7",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "7"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if 8 is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "8",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "8"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if 9 is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "9",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "9"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if a is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "a"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if b is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "b",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "b"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if c is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "c",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "c"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if d is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "d",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "d"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if e is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "e",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "e"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if f is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "f",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if g is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "g",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "g"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if h is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "h",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "h"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if i is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "i"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if j is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "j"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if k is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "k",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "k"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if l is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "l"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if m is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "m",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "m"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if n is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "n",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "n"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if o is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "o",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "o"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if p is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "p",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "p"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if q is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "q",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "q"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if r is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "r",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "r"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if s is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "s",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "s"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if t is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "t",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "t"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if u is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "u",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "u"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if v is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "v",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "v"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if w is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "w",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "w"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if x is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "x",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "x"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if y is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "y",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "y"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if z is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "z",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "z"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if grave_accent_and_tilde is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "grave_accent_and_tilde",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "grave_accent_and_tilde"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if hyphen is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "hyphen",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "hyphen"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if equal_sign is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "equal_sign",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "equal_sign"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if delete_or_backspace is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "delete_or_backspace",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "delete_or_backspace"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if tab is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "tab",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "tab"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if open_bracket is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "open_bracket",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "open_bracket"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if close_bracket is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "close_bracket",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "close_bracket"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if backslash is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "backslash",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "backslash"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if semicolon is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "semicolon",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "semicolon"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if quote is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "quote",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "quote"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if return_or_enter is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "return_or_enter",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "return_or_enter"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if comma is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "comma",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "comma"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if period is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "period",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "period"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if slash is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "slash",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "slash"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if spacebar is pressed",
+          "type": "basic",
+          "from": {
+            "key_code": "spacebar",
+            "modifiers": {
+              "optional": [
+                "caps_lock",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change right_control to b if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "right_control",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "b"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_right_control_as_b",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change right_control to b if pressed alone and not held down",
+          "type": "basic",
+          "from": {
+            "key_code": "right_control",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_control",
+              "lazy": true
+            }
+          ],
+          "to_if_alone": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_right_control_as_b",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "b"
+            }
+          ],
+          "to_if_held_down": [
+            {
+              "key_code": "right_control"
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "matias_ergo_pro.use_right_control_as_b",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "conditions": [
+            {
+              "description": "Matias Ergo Pro Keyboard",
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591
+                }
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_right_control_as_b",
+              "value": 1
+            }
+          ],
+          "parameters": {
+            "basic.to_if_alone_timeout_milliseconds": 500,
+            "basic.to_if_held_down_threshold_milliseconds": 500
+          }
+        }
+      ]
+    },
+    {
+      "description": "Matias Ergo Pro Keyboard: Change navigation keys to right_option if pressed with another key",
+      "manipulators": [
+        {
+          "description": "Set variable if home + end are pressed simultaneously",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "end"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if home + page_up are pressed simultaneously",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "page_up"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if home + page_down are pressed simultaneously",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "page_down"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if end + page_up are pressed simultaneously",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "page_up"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if end + page_down are pressed simultaneously",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "page_down"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if page_up + page_down are pressed simultaneously",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "page_down"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with f1",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "f1"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f1",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with f2",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "f2"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f2",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with f3",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "f3"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f3",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with f4",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "f4"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f4",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with f5",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "f5"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f5",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with f6",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "f6"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f6",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with f7",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "f7"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f7",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with f8",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "f8"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f8",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with f9",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "f9"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f9",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with f10",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "f10"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f10",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with f11",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "f11"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f11",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with f12",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "f12"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f12",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with escape",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "escape"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "escape",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with delete_forward",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "delete_forward"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "delete_forward",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with 0",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "0"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "0",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with 1",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "1"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "1",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with 2",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "2"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "2",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with 3",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "3"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "3",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with 4",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "4"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "4",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with 5",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "5"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "5",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with 6",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "6"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "6",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with 7",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "7"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "7",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with 8",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "8"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "8",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with 9",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "9"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "9",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with a",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "a"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "a",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with b",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "b"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "b",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with c",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "c"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "c",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with d",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "d"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "d",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with e",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "e"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "e",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with f",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "f"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with g",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "g"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "g",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with h",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "h"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "h",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with i",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "i"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "i",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with j",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "j"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "j",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with k",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "k"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "k",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with l",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "l"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "l",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with m",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "m"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "m",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with n",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "n"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "n",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with o",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "o"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "o",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with p",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "p"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "p",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with q",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "q"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "q",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with r",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "r"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "r",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with s",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "s"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "s",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with t",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "t"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "t",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with u",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "u"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "u",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with v",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "v"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "v",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with w",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "w"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "w",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with x",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "x"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "x",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with y",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "y"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "y",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with z",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "z"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "z",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with grave_accent_and_tilde",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "grave_accent_and_tilde"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with hyphen",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "hyphen"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "hyphen",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with equal_sign",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "equal_sign"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "equal_sign",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with delete_or_backspace",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "delete_or_backspace"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "delete_or_backspace",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with tab",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "tab"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "tab",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with open_bracket",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "open_bracket"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "open_bracket",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with close_bracket",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "close_bracket"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "close_bracket",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with backslash",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "backslash"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "backslash",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with semicolon",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "semicolon",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with quote",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "quote"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "quote",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with return_or_enter",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "return_or_enter"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "return_or_enter",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with comma",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "comma"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "comma",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with period",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "period"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "period",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with slash",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "slash"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "slash",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with spacebar",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "spacebar"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "spacebar",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with right_command",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "right_command"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "right_command",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with right_shift",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "right_shift"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "right_shift",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with left_arrow",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "left_arrow"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "left_arrow",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with right_arrow",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "right_arrow"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "right_arrow",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with up_arrow",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "up_arrow"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "up_arrow",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change home to right_option if pressed with down_arrow",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "home"
+              },
+              {
+                "key_code": "down_arrow"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "down_arrow",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with f1",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "f1"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f1",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with f2",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "f2"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f2",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with f3",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "f3"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f3",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with f4",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "f4"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f4",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with f5",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "f5"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f5",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with f6",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "f6"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f6",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with f7",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "f7"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f7",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with f8",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "f8"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f8",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with f9",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "f9"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f9",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with f10",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "f10"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f10",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with f11",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "f11"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f11",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with f12",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "f12"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f12",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with escape",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "escape"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "escape",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with delete_forward",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "delete_forward"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "delete_forward",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with 0",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "0"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "0",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with 1",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "1"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "1",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with 2",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "2"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "2",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with 3",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "3"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "3",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with 4",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "4"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "4",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with 5",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "5"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "5",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with 6",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "6"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "6",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with 7",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "7"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "7",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with 8",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "8"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "8",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with 9",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "9"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "9",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with a",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "a"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "a",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with b",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "b"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "b",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with c",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "c"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "c",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with d",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "d"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "d",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with e",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "e"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "e",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with f",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "f"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with g",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "g"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "g",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with h",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "h"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "h",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with i",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "i"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "i",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with j",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "j"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "j",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with k",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "k"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "k",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with l",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "l"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "l",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with m",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "m"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "m",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with n",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "n"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "n",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with o",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "o"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "o",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with p",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "p"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "p",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with q",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "q"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "q",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with r",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "r"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "r",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with s",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "s"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "s",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with t",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "t"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "t",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with u",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "u"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "u",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with v",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "v"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "v",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with w",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "w"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "w",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with x",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "x"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "x",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with y",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "y"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "y",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with z",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "z"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "z",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with grave_accent_and_tilde",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "grave_accent_and_tilde"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with hyphen",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "hyphen"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "hyphen",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with equal_sign",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "equal_sign"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "equal_sign",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with delete_or_backspace",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "delete_or_backspace"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "delete_or_backspace",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with tab",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "tab"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "tab",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with open_bracket",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "open_bracket"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "open_bracket",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with close_bracket",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "close_bracket"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "close_bracket",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with backslash",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "backslash"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "backslash",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with semicolon",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "semicolon",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with quote",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "quote"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "quote",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with return_or_enter",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "return_or_enter"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "return_or_enter",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with comma",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "comma"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "comma",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with period",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "period"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "period",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with slash",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "slash"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "slash",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with spacebar",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "spacebar"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "spacebar",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with right_command",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "right_command"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "right_command",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with right_shift",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "right_shift"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "right_shift",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with left_arrow",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "left_arrow"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "left_arrow",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with right_arrow",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "right_arrow"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "right_arrow",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with up_arrow",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "up_arrow"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "up_arrow",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change end to right_option if pressed with down_arrow",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "end"
+              },
+              {
+                "key_code": "down_arrow"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "down_arrow",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with f1",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "f1"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f1",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with f2",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "f2"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f2",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with f3",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "f3"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f3",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with f4",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "f4"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f4",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with f5",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "f5"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f5",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with f6",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "f6"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f6",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with f7",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "f7"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f7",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with f8",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "f8"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f8",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with f9",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "f9"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f9",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with f10",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "f10"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f10",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with f11",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "f11"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f11",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with f12",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "f12"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f12",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with escape",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "escape"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "escape",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with delete_forward",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "delete_forward"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "delete_forward",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with 0",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "0"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "0",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with 1",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "1"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "1",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with 2",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "2"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "2",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with 3",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "3"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "3",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with 4",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "4"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "4",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with 5",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "5"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "5",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with 6",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "6"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "6",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with 7",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "7"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "7",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with 8",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "8"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "8",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with 9",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "9"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "9",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with a",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "a"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "a",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with b",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "b"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "b",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with c",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "c"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "c",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with d",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "d"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "d",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with e",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "e"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "e",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with f",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "f"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with g",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "g"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "g",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with h",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "h"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "h",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with i",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "i"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "i",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with j",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "j"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "j",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with k",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "k"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "k",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with l",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "l"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "l",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with m",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "m"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "m",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with n",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "n"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "n",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with o",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "o"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "o",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with p",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "p"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "p",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with q",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "q"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "q",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with r",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "r"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "r",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with s",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "s"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "s",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with t",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "t"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "t",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with u",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "u"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "u",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with v",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "v"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "v",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with w",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "w"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "w",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with x",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "x"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "x",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with y",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "y"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "y",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with z",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "z"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "z",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with grave_accent_and_tilde",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "grave_accent_and_tilde"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with hyphen",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "hyphen"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "hyphen",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with equal_sign",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "equal_sign"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "equal_sign",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with delete_or_backspace",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "delete_or_backspace"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "delete_or_backspace",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with tab",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "tab"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "tab",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with open_bracket",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "open_bracket"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "open_bracket",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with close_bracket",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "close_bracket"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "close_bracket",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with backslash",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "backslash"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "backslash",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with semicolon",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "semicolon",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with quote",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "quote"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "quote",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with return_or_enter",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "return_or_enter"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "return_or_enter",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with comma",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "comma"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "comma",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with period",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "period"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "period",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with slash",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "slash"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "slash",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with spacebar",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "spacebar"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "spacebar",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with right_command",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "right_command"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "right_command",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with right_shift",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "right_shift"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "right_shift",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with left_arrow",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "left_arrow"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "left_arrow",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with right_arrow",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "right_arrow"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "right_arrow",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with up_arrow",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "up_arrow"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "up_arrow",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_up to right_option if pressed with down_arrow",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_up"
+              },
+              {
+                "key_code": "down_arrow"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "down_arrow",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with f1",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "f1"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f1",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with f2",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "f2"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f2",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with f3",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "f3"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f3",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with f4",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "f4"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f4",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with f5",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "f5"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f5",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with f6",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "f6"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f6",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with f7",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "f7"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f7",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with f8",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "f8"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f8",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with f9",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "f9"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f9",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with f10",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "f10"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f10",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with f11",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "f11"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f11",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with f12",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "f12"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f12",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with escape",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "escape"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "escape",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with delete_forward",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "delete_forward"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "delete_forward",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with 0",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "0"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "0",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with 1",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "1"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "1",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with 2",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "2"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "2",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with 3",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "3"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "3",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with 4",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "4"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "4",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with 5",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "5"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "5",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with 6",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "6"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "6",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with 7",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "7"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "7",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with 8",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "8"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "8",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with 9",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "9"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "9",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with a",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "a"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "a",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with b",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "b"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "b",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with c",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "c"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "c",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with d",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "d"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "d",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with e",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "e"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "e",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with f",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "f"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with g",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "g"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "g",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with h",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "h"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "h",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with i",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "i"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "i",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with j",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "j"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "j",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with k",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "k"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "k",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with l",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "l"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "l",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with m",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "m"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "m",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with n",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "n"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "n",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with o",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "o"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "o",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with p",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "p"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "p",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with q",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "q"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "q",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with r",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "r"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "r",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with s",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "s"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "s",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with t",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "t"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "t",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with u",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "u"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "u",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with v",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "v"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "v",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with w",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "w"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "w",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with x",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "x"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "x",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with y",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "y"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "y",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with z",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "z"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "z",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with grave_accent_and_tilde",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "grave_accent_and_tilde"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with hyphen",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "hyphen"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "hyphen",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with equal_sign",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "equal_sign"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "equal_sign",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with delete_or_backspace",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "delete_or_backspace"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "delete_or_backspace",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with tab",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "tab"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "tab",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with open_bracket",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "open_bracket"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "open_bracket",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with close_bracket",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "close_bracket"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "close_bracket",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with backslash",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "backslash"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "backslash",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with semicolon",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "semicolon",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with quote",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "quote"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "quote",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with return_or_enter",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "return_or_enter"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "return_or_enter",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with comma",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "comma"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "comma",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with period",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "period"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "period",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with slash",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "slash"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "slash",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with spacebar",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "spacebar"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "spacebar",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with right_command",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "right_command"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "right_command",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with right_shift",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "right_shift"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "right_shift",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with left_arrow",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "left_arrow"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "left_arrow",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with right_arrow",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "right_arrow"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "right_arrow",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with up_arrow",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "up_arrow"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "up_arrow",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change page_down to right_option if pressed with down_arrow",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "page_down"
+              },
+              {
+                "key_code": "down_arrow"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "down_arrow",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify f1 with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "f1",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f1",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify f2 with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "f2",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f2",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify f3 with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "f3",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f3",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify f4 with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "f4",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f4",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify f5 with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "f5",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f5",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify f6 with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "f6",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f6",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify f7 with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "f7",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f7",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify f8 with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "f8",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f8",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify f9 with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "f9",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f9",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify f10 with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "f10",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f10",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify f11 with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "f11",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f11",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify f12 with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "f12",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f12",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify escape with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "escape",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "escape",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify delete_forward with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "delete_forward",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_forward",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify 0 with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "0",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "0",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify 1 with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "1",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "1",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify 2 with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "2",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "2",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify 3 with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "3",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "3",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify 4 with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "4",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "4",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify 5 with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "5",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "5",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify 6 with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "6",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "6",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify 7 with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "7",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "7",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify 8 with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "8",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "8",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify 9 with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "9",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "9",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify a with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "a",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify b with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "b",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "b",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify c with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "c",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "c",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify d with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "d",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "d",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify e with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "e",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "e",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify f with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "f",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify g with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "g",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "g",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify h with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "h",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "h",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify i with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "i",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify j with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify k with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "k",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify l with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "l",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify m with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "m",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "m",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify n with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "n",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "n",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify o with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "o",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "o",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify p with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "p",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "p",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify q with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "q",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "q",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify r with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "r",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "r",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify s with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "s",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "s",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify t with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "t",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "t",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify u with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "u",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "u",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify v with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "v",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "v",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify w with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "w",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "w",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify x with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "x",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "x",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify y with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "y",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "y",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify z with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "z",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "z",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify grave_accent_and_tilde with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "grave_accent_and_tilde",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify hyphen with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "hyphen",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "hyphen",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify equal_sign with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "equal_sign",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "equal_sign",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify delete_or_backspace with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "delete_or_backspace",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_or_backspace",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify tab with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "tab",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "tab",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify open_bracket with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "open_bracket",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "open_bracket",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify close_bracket with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "close_bracket",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "close_bracket",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify backslash with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "backslash",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "backslash",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify semicolon with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "semicolon",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "semicolon",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify quote with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "quote",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "quote",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify return_or_enter with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "return_or_enter",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "return_or_enter",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify comma with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "comma",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "comma",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify period with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "period",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "period",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify slash with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "slash",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "slash",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify spacebar with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "spacebar",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "spacebar",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify home with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "home",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "home",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify end with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "end",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "end",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify page_up with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "page_up",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "page_up",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify page_down with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "page_down",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "page_down",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify left_arrow with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "left_arrow",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify right_arrow with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "right_arrow",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify up_arrow with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "up_arrow",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify down_arrow with right_option if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "down_arrow",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "down_arrow",
+              "modifiers": [
+                "right_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "matias_ergo_pro.use_nav_keys_as_right_option",
+              "value": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/json/personal_mingaldrichgan.json
+++ b/docs/json/personal_mingaldrichgan.json
@@ -1,0 +1,3284 @@
+{
+  "title": "Personal rules (@mingaldrichgan)",
+  "maintainers": [
+    "mingaldrichgan"
+  ],
+  "rules": [
+    {
+      "description": "Change escape/grave_accent_and_tilde/hyphen/equal_sign to fn if pressed with f-keys or delete",
+      "manipulators": [
+        {
+          "description": "Set variable if escape + grave_accent_and_tilde are pressed simultaneously",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "escape"
+              },
+              {
+                "key_code": "grave_accent_and_tilde"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if escape + hyphen are pressed simultaneously",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "escape"
+              },
+              {
+                "key_code": "hyphen"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if escape + equal_sign are pressed simultaneously",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "escape"
+              },
+              {
+                "key_code": "equal_sign"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if grave_accent_and_tilde + hyphen are pressed simultaneously",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "grave_accent_and_tilde"
+              },
+              {
+                "key_code": "hyphen"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if grave_accent_and_tilde + equal_sign are pressed simultaneously",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "grave_accent_and_tilde"
+              },
+              {
+                "key_code": "equal_sign"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Set variable if hyphen + equal_sign are pressed simultaneously",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "hyphen"
+              },
+              {
+                "key_code": "equal_sign"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change escape to fn if pressed with f1",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "escape"
+              },
+              {
+                "key_code": "f1"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f1",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change escape to fn if pressed with f2",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "escape"
+              },
+              {
+                "key_code": "f2"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f2",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change escape to fn if pressed with f3",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "escape"
+              },
+              {
+                "key_code": "f3"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f3",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change escape to fn if pressed with f4",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "escape"
+              },
+              {
+                "key_code": "f4"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f4",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change escape to fn if pressed with f5",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "escape"
+              },
+              {
+                "key_code": "f5"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f5",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change escape to fn if pressed with f6",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "escape"
+              },
+              {
+                "key_code": "f6"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f6",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change escape to fn if pressed with f7",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "escape"
+              },
+              {
+                "key_code": "f7"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f7",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change escape to fn if pressed with f8",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "escape"
+              },
+              {
+                "key_code": "f8"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f8",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change escape to fn if pressed with f9",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "escape"
+              },
+              {
+                "key_code": "f9"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f9",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change escape to fn if pressed with f10",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "escape"
+              },
+              {
+                "key_code": "f10"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f10",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change escape to fn if pressed with f11",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "escape"
+              },
+              {
+                "key_code": "f11"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f11",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change escape to fn if pressed with f12",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "escape"
+              },
+              {
+                "key_code": "f12"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f12",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change escape to fn if pressed with delete_or_backspace",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "escape"
+              },
+              {
+                "key_code": "delete_or_backspace"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "delete_or_backspace",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change grave_accent_and_tilde to fn if pressed with f1",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "grave_accent_and_tilde"
+              },
+              {
+                "key_code": "f1"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f1",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change grave_accent_and_tilde to fn if pressed with f2",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "grave_accent_and_tilde"
+              },
+              {
+                "key_code": "f2"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f2",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change grave_accent_and_tilde to fn if pressed with f3",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "grave_accent_and_tilde"
+              },
+              {
+                "key_code": "f3"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f3",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change grave_accent_and_tilde to fn if pressed with f4",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "grave_accent_and_tilde"
+              },
+              {
+                "key_code": "f4"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f4",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change grave_accent_and_tilde to fn if pressed with f5",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "grave_accent_and_tilde"
+              },
+              {
+                "key_code": "f5"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f5",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change grave_accent_and_tilde to fn if pressed with f6",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "grave_accent_and_tilde"
+              },
+              {
+                "key_code": "f6"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f6",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change grave_accent_and_tilde to fn if pressed with f7",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "grave_accent_and_tilde"
+              },
+              {
+                "key_code": "f7"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f7",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change grave_accent_and_tilde to fn if pressed with f8",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "grave_accent_and_tilde"
+              },
+              {
+                "key_code": "f8"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f8",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change grave_accent_and_tilde to fn if pressed with f9",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "grave_accent_and_tilde"
+              },
+              {
+                "key_code": "f9"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f9",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change grave_accent_and_tilde to fn if pressed with f10",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "grave_accent_and_tilde"
+              },
+              {
+                "key_code": "f10"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f10",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change grave_accent_and_tilde to fn if pressed with f11",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "grave_accent_and_tilde"
+              },
+              {
+                "key_code": "f11"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f11",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change grave_accent_and_tilde to fn if pressed with f12",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "grave_accent_and_tilde"
+              },
+              {
+                "key_code": "f12"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f12",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change grave_accent_and_tilde to fn if pressed with delete_or_backspace",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "grave_accent_and_tilde"
+              },
+              {
+                "key_code": "delete_or_backspace"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "delete_or_backspace",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change hyphen to fn if pressed with f1",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "hyphen"
+              },
+              {
+                "key_code": "f1"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f1",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change hyphen to fn if pressed with f2",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "hyphen"
+              },
+              {
+                "key_code": "f2"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f2",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change hyphen to fn if pressed with f3",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "hyphen"
+              },
+              {
+                "key_code": "f3"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f3",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change hyphen to fn if pressed with f4",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "hyphen"
+              },
+              {
+                "key_code": "f4"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f4",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change hyphen to fn if pressed with f5",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "hyphen"
+              },
+              {
+                "key_code": "f5"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f5",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change hyphen to fn if pressed with f6",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "hyphen"
+              },
+              {
+                "key_code": "f6"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f6",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change hyphen to fn if pressed with f7",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "hyphen"
+              },
+              {
+                "key_code": "f7"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f7",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change hyphen to fn if pressed with f8",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "hyphen"
+              },
+              {
+                "key_code": "f8"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f8",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change hyphen to fn if pressed with f9",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "hyphen"
+              },
+              {
+                "key_code": "f9"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f9",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change hyphen to fn if pressed with f10",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "hyphen"
+              },
+              {
+                "key_code": "f10"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f10",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change hyphen to fn if pressed with f11",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "hyphen"
+              },
+              {
+                "key_code": "f11"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f11",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change hyphen to fn if pressed with f12",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "hyphen"
+              },
+              {
+                "key_code": "f12"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f12",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change hyphen to fn if pressed with delete_or_backspace",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "hyphen"
+              },
+              {
+                "key_code": "delete_or_backspace"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "delete_or_backspace",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change equal_sign to fn if pressed with f1",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "equal_sign"
+              },
+              {
+                "key_code": "f1"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f1",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change equal_sign to fn if pressed with f2",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "equal_sign"
+              },
+              {
+                "key_code": "f2"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f2",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change equal_sign to fn if pressed with f3",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "equal_sign"
+              },
+              {
+                "key_code": "f3"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f3",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change equal_sign to fn if pressed with f4",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "equal_sign"
+              },
+              {
+                "key_code": "f4"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f4",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change equal_sign to fn if pressed with f5",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "equal_sign"
+              },
+              {
+                "key_code": "f5"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f5",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change equal_sign to fn if pressed with f6",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "equal_sign"
+              },
+              {
+                "key_code": "f6"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f6",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change equal_sign to fn if pressed with f7",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "equal_sign"
+              },
+              {
+                "key_code": "f7"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f7",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change equal_sign to fn if pressed with f8",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "equal_sign"
+              },
+              {
+                "key_code": "f8"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f8",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change equal_sign to fn if pressed with f9",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "equal_sign"
+              },
+              {
+                "key_code": "f9"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f9",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change equal_sign to fn if pressed with f10",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "equal_sign"
+              },
+              {
+                "key_code": "f10"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f10",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change equal_sign to fn if pressed with f11",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "equal_sign"
+              },
+              {
+                "key_code": "f11"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f11",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change equal_sign to fn if pressed with f12",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "equal_sign"
+              },
+              {
+                "key_code": "f12"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "f12",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Change equal_sign to fn if pressed with delete_or_backspace",
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            },
+            "simultaneous": [
+              {
+                "key_code": "equal_sign"
+              },
+              {
+                "key_code": "delete_or_backspace"
+              }
+            ],
+            "simultaneous_options": {
+              "to_after_key_up": [
+                {
+                  "set_variable": {
+                    "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                    "value": 0
+                  }
+                }
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "personal_mingaldrichgan.use_symbols_as_fn",
+                "value": 1
+              }
+            },
+            {
+              "key_code": "delete_or_backspace",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify f1 with fn if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "f1",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f1",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify f2 with fn if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "f2",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f2",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify f3 with fn if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "f3",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f3",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify f4 with fn if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "f4",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f4",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify f5 with fn if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "f5",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f5",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify f6 with fn if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "f6",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f6",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify f7 with fn if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "f7",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f7",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify f8 with fn if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "f8",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f8",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify f9 with fn if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "f9",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f9",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify f10 with fn if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "f10",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f10",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify f11 with fn if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "f11",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f11",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify f12 with fn if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "f12",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f12",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Modify delete_or_backspace with fn if variable is set",
+          "type": "basic",
+          "from": {
+            "key_code": "delete_or_backspace",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_or_backspace",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "personal_mingaldrichgan.use_symbols_as_fn",
+              "value": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Sibelius: Nums keypad workarounds",
+      "manipulators": [
+        {
+          "description": "Change 5 to f5 if modified by shift",
+          "type": "basic",
+          "from": {
+            "key_code": "5",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f5",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.avid\\.sibelius$"
+              ]
+            }
+          ]
+        },
+        {
+          "description": "Change return_or_enter to keypad_enter",
+          "type": "basic",
+          "from": {
+            "key_code": "return_or_enter"
+          },
+          "to": [
+            {
+              "key_code": "keypad_enter"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.avid\\.sibelius$"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/matias_ergo_pro.json.rb
+++ b/src/json/matias_ergo_pro.json.rb
@@ -1,0 +1,101 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+require_relative '../lib/karabiner.rb'
+require_relative '../lib/key_codes.rb'
+require_relative '../lib/variable.rb'
+
+def main
+  puts JSON.pretty_generate(
+    'title' => Device::NAME,
+    'maintainers' => ['mingaldrichgan'],
+    'rules' => Rules.constants.map(&Rules.method(:const_get)).map(&:rule)
+  )
+end
+
+module Device
+  NAME = 'Matias Ergo Pro Keyboard'
+
+  CONDITION = {
+    'description' => NAME,
+    'type' => 'device_if',
+    'identifiers' => [{ 'vendor_id' => 1452, 'product_id' => 591 }],
+  }.freeze
+
+  TOP_ROW = (KeyCodes.f(1..12) + %w[escape delete_forward]).freeze
+  TYPING_KEYS = (KeyCodes::ALPHANUMERIC_ROWS + ['spacebar']).freeze
+end
+
+module Rules
+  module NavKeys
+    TO_KEY = 'right_option'
+    VAR = Variable.new("use_nav_keys_as_#{TO_KEY}").freeze
+
+    NAV_KEYS = %w[home end page_up page_down].freeze
+    NAV_MODIFIERS = %w[right_command right_shift].freeze
+
+    def self.rule
+      {
+        'description' => "#{Device::NAME}: Change navigation keys to #{TO_KEY} if pressed with another key",
+        'manipulators' => VAR.remap_to_modifiers(
+          NAV_KEYS,
+          to_modifiers: [TO_KEY],
+          modifiable: Device::TOP_ROW + Device::TYPING_KEYS + NAV_KEYS + NAV_MODIFIERS + KeyCodes::ARROWS
+        ),
+      }
+    end
+  end # module NavKeys
+
+  module RightControl
+    FROM_KEY = 'right_control'
+    TO_KEY = 'b'
+    VAR = Variable.new("use_#{FROM_KEY}_as_#{TO_KEY}").freeze
+
+    TYPING_MODIFIERS = Karabiner.from_modifiers(nil, %w[caps_lock shift]).freeze
+
+    def self.rule
+      {
+        'description' => "#{Device::NAME}: Change #{FROM_KEY} to #{TO_KEY} if pressed alone, or while typing",
+        'manipulators' => (
+          Device::TYPING_KEYS.map do |key|
+            {
+              'description' => "Set variable if #{key} is pressed",
+              'type' => 'basic',
+              'from' => { 'key_code' => key, 'modifiers' => TYPING_MODIFIERS },
+              'to' => [VAR.set, { 'key_code' => key }],
+              'to_delayed_action' => { 'to_if_invoked' => [VAR.unset] },
+              'conditions' => [Device::CONDITION, NavKeys::VAR.unless_set],
+            }
+          end + [
+            {
+              'description' => "Change #{FROM_KEY} to #{TO_KEY} if variable is set",
+              'type' => 'basic',
+              'from' => { 'key_code' => FROM_KEY, 'modifiers' => Karabiner.from_modifiers },
+              'to' => [VAR.set, { 'key_code' => TO_KEY }],
+              'to_delayed_action' => { 'to_if_invoked' => [VAR.unset] },
+              'conditions' => [Device::CONDITION, VAR.if_set],
+            },
+            {
+              'description' => "Change #{FROM_KEY} to #{TO_KEY} if pressed alone and not held down",
+              'type' => 'basic',
+              'from' => { 'key_code' => FROM_KEY, 'modifiers' => Karabiner.from_modifiers },
+              'to' => [{ 'key_code' => FROM_KEY, 'lazy' => true }],
+              'to_if_alone' => [VAR.set, { 'key_code' => TO_KEY }],
+              'to_if_held_down' => [{ 'key_code' => FROM_KEY }],
+              'to_delayed_action' => { 'to_if_invoked' => [VAR.unset] },
+              'conditions' => [Device::CONDITION, VAR.unless_set],
+              'parameters' => {
+                # Set these parameters to the same value.
+                'basic.to_if_alone_timeout_milliseconds' => 500, # Default value is 1000.
+                'basic.to_if_held_down_threshold_milliseconds' => 500, # Default value.
+              },
+            },
+          ]
+        ),
+      }
+    end
+  end # module RightControl
+end # module Rules
+
+main

--- a/src/json/personal_mingaldrichgan.json.rb
+++ b/src/json/personal_mingaldrichgan.json.rb
@@ -1,0 +1,62 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+require_relative '../lib/karabiner.rb'
+require_relative '../lib/key_codes.rb'
+require_relative '../lib/variable.rb'
+
+def main
+  puts JSON.pretty_generate(
+    'title' => 'Personal rules (@mingaldrichgan)',
+    'maintainers' => ['mingaldrichgan'],
+    'rules' => Rules.constants.map(&Rules.method(:const_get)).map(&:rule)
+  )
+end
+
+module Rules
+  module SymbolicFn
+    FROM_KEYS = %w[escape grave_accent_and_tilde hyphen equal_sign].freeze
+    TO_KEY = 'fn'
+
+    def self.rule
+      {
+        'description' => "Change #{FROM_KEYS.join('/')} to #{TO_KEY} if pressed with f-keys or delete",
+        'manipulators' => Variable.new("use_symbols_as_#{TO_KEY}").remap_to_modifiers(
+          FROM_KEYS,
+          to_modifiers: [TO_KEY],
+          modifiable: KeyCodes.f(1..12) + ['delete_or_backspace']
+        ),
+      }
+    end
+  end # module SymbolicFn
+
+  module Sibelius
+    APP_NAME = 'Sibelius'
+    APP_CONDITION = Karabiner.frontmost_application_if(bundle_identifiers: ['^com\.avid\.sibelius$']).freeze
+
+    def self.rule
+      {
+        'description' => "#{APP_NAME}: Nums keypad workarounds",
+        'manipulators' => [
+          {
+            'description' => 'Change 5 to f5 if modified by shift',
+            'type' => 'basic',
+            'from' => { 'key_code' => '5', 'modifiers' => Karabiner.from_modifiers(['shift']) },
+            'to' => [{ 'key_code' => 'f5', 'modifiers' => ['left_shift'] }],
+            'conditions' => [APP_CONDITION],
+          },
+          {
+            'description' => 'Change return_or_enter to keypad_enter',
+            'type' => 'basic',
+            'from' => { 'key_code' => 'return_or_enter' },
+            'to' => [{ 'key_code' => 'keypad_enter' }],
+            'conditions' => [APP_CONDITION],
+          },
+        ],
+      }
+    end
+  end # module Sibelius
+end # module Rules
+
+main

--- a/src/lib/karabiner.rb
+++ b/src/lib/karabiner.rb
@@ -164,8 +164,7 @@ module Karabiner
     }
   end
 
-  def self.frontmost_application(type, app_aliases)
-    bundle_identifiers = []
+  def self.frontmost_application(type, app_aliases = [], bundle_identifiers: [])
     app_aliases.each do |app_alias|
       if Karabiner::APP_ALIASES[app_alias].nil?
         $stderr << "unknown app_alias: #{app_alias}\n"
@@ -180,12 +179,12 @@ module Karabiner
     }
   end
 
-  def self.frontmost_application_if(app_aliases)
-    frontmost_application('frontmost_application_if', app_aliases)
+  def self.frontmost_application_if(app_aliases = [], bundle_identifiers: [])
+    frontmost_application('frontmost_application_if', app_aliases, bundle_identifiers: bundle_identifiers)
   end
 
-  def self.frontmost_application_unless(app_aliases)
-    frontmost_application('frontmost_application_unless', app_aliases)
+  def self.frontmost_application_unless(app_aliases = [], bundle_identifiers: [])
+    frontmost_application('frontmost_application_unless', app_aliases, bundle_identifiers: bundle_identifiers)
   end
 
   def self.keyboard_type_if(keyboard_types)

--- a/src/lib/key_codes.rb
+++ b/src/lib/key_codes.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module KeyCodes
+  NUMBERS = ('0'..'9').to_a.freeze
+  LETTERS = ('a'..'z').to_a.freeze
+
+  # Non-modifier keys on rows with alphanumeric characters on a Mac keyboard.
+  # On a MacBook, this would be all except the top and bottom rows of keys.
+  ALPHANUMERIC_ROWS = (NUMBERS + LETTERS + %w[
+    grave_accent_and_tilde hyphen equal_sign delete_or_backspace
+    tab open_bracket close_bracket backslash
+    semicolon quote return_or_enter
+    comma period slash
+  ]).freeze
+
+  ARROWS = %w[left right up down].map { |d| "#{d}_arrow" }.freeze
+
+  MODIFIERS = (
+    %w[caps_lock fn command control option shift] +
+    %w[left_ right_].product(%w[command control option shift alt gui]).map(&:join)
+  ).freeze
+
+  # Returns an array of f-key codes (up to +f24+).
+  #
+  # @param range [Range<Number>] Subset of +1..24+ for which to generate f-key codes.
+  # @return [<String>] Array of f-key codes.
+  def self.f(range = 1..24)
+    range.map { |n| "f#{n}" }
+  end
+
+  # Returns an array of +key_code+ hashes that could be used e.g. in +from > simultaneous+ or +to+.
+  #
+  # @param key_codes [<String>] Array of key codes.
+  # @return [<{String=>String}>] Array of +key_code+ hashes.
+  def self.map(*key_codes)
+    key_codes.map { |key_code| { 'key_code' => key_code } }
+  end
+end

--- a/src/lib/variable.rb
+++ b/src/lib/variable.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require_relative 'karabiner.rb'
+require_relative 'key_codes.rb'
+
+class Variable
+  NAMESPACE = File.basename($PROGRAM_NAME, '.json.rb').freeze
+
+  attr_reader :unset
+
+  def initialize(name, unset_value: 0)
+    @qualified_name = "#{NAMESPACE}.#{name}"
+    @unset = set(unset_value)
+  end
+
+  def set(value = 1)
+    Karabiner.set_variable(@qualified_name, value)
+  end
+
+  def if_set(value = 1)
+    Karabiner.variable_if(@qualified_name, value)
+  end
+
+  def unless_set(value = 1)
+    Karabiner.variable_unless(@qualified_name, value)
+  end
+
+  # Remaps one or more keys to one or more modifiers when pressed simultaneously with specified keys.
+  # A variable is used as a {virtual modifier}[https://pqrs.org/osx/karabiner/json.html#virtual-modifier],
+  # allowing non-modifier keys to act like modifiers and remain active as long as they are held down.
+  #
+  # @param from_key_codes [<String>] key code(s) that should act like +to_modifiers+
+  #        when pressed simultaneously with +modifiable+ keys. If more than one,
+  #        any combination of these keys pressed simultaneously also triggers the remapping.
+  # @param to_modifiers [<String>] modifier(s) to which +from_key_codes+ are remapped.
+  # @param modifiable [<String>] key codes that, when pressed simultaneously with
+  #        +from_key_codes+, should act like they are modified by +to_modifiers+ instead.
+  # @param conditions array of {condition definitions}[https://pqrs.org/osx/karabiner/json.html#condition-definition].
+  # @return array of {manipulator definitions}[https://pqrs.org/osx/karabiner/json.html#complex_modifications-manipulator-definition].
+  def remap_to_modifiers(from_key_codes,
+                         from_modifiers: Karabiner.from_modifiers,
+                         to_modifiers: [],
+                         modifiable: [],
+                         conditions: [])
+    [
+      from_key_codes.combination(2).map do |keys|
+        {
+          'description' => "Set variable if #{keys.join(' + ')} are pressed simultaneously",
+          'type' => 'basic',
+          'from' => {
+            'modifiers' => from_modifiers,
+            'simultaneous' => KeyCodes.map(*keys),
+            'simultaneous_options' => { 'to_after_key_up' => [unset] },
+          },
+          'to' => [set],
+          'conditions' => conditions + [unless_set],
+        }
+      end,
+      from_key_codes.product(modifiable - from_key_codes).map do |from_key, other_key|
+        {
+          'description' => "Change #{from_key} to #{to_modifiers.join(' + ')} if pressed with #{other_key}",
+          'type' => 'basic',
+          'from' => {
+            'modifiers' => from_modifiers,
+            'simultaneous' => KeyCodes.map(from_key, other_key),
+            'simultaneous_options' => { 'to_after_key_up' => [unset] },
+          },
+          'to' => [set, { 'key_code' => other_key, 'modifiers' => to_modifiers }],
+          'conditions' => conditions + [unless_set],
+        }
+      end,
+      (modifiable - KeyCodes::MODIFIERS).map do |key|
+        {
+          'description' => "Modify #{key} with #{to_modifiers.join(' + ')} if variable is set",
+          'type' => 'basic',
+          'from' => { 'key_code' => key, 'modifiers' => from_modifiers },
+          'to' => [{ 'key_code' => key, 'modifiers' => to_modifiers }],
+          'conditions' => conditions + [if_set],
+        }
+      end,
+    ].flatten
+  end
+end


### PR DESCRIPTION
The [Matias Ergo Pro](https://matias.ca/ergopro/) is one of the few
ergonomic mechanical keyboards on the market with an mostly-standard
Mac layout. Two quirks stand out:

1. The navigation keys (`home`, `end`, `page_up`, and `page_down`) are
where the `right_option` key is on a MacBook or Magic Keyboard.
2. The `right_control` key is where the B key *would* be *if* it were
on the right side of the split (which it isn't).

The following rules remap theys keys in a context-sensitive manner:

1. Change navigation keys to right_option if pressed with another key
2. Change right_control to b if pressed alone, or while typing

This commit also introduces some personal rules of mine, as well as the
`KeyCodes` and `Variable` utility classes used to build both rule sets
(and likely to be helpful for other future rules too).