### PR TITLE
Lists rules explicitly in matias_ergo_pro.json.rb and personal_mingaldrichgan.json.rb

### DIFF
--- a/src/json/matias_ergo_pro.json.rb
+++ b/src/json/matias_ergo_pro.json.rb
@@ -10,7 +10,7 @@ def main
   puts JSON.pretty_generate(
     'title' => Device::NAME,
     'maintainers' => ['mingaldrichgan'],
-    'rules' => Rules.constants.map(&Rules.method(:const_get)).map(&:rule)
+    'rules' => [Rules::NavKeys, Rules::RightControl].map(&:rule)
   )
 end
 

--- a/src/json/personal_mingaldrichgan.json.rb
+++ b/src/json/personal_mingaldrichgan.json.rb
@@ -10,7 +10,7 @@ def main
   puts JSON.pretty_generate(
     'title' => 'Personal rules (@mingaldrichgan)',
     'maintainers' => ['mingaldrichgan'],
-    'rules' => Rules.constants.map(&Rules.method(:const_get)).map(&:rule)
+    'rules' => [Rules::SymbolicFn, Rules::Sibelius].map(&:rule)
   )
 end
 


### PR DESCRIPTION
`Rules.constants` is not guaranteed to return items in any particular order, and my local builds were enumerating the rules in **matias_ergo_pro.json.rb** in a different order than I had expected. This commit replaces `Rules.constants.map(&Rules.method(:const_get))` in **matias_ergo_pro.json.rb** and **personal_mingaldrichgan.json.rb** with explicit arrays to prevent future build inconsistencies.