### PR TITLE
Disabled lazy option

### DIFF
--- a/docs/json/japanese.json
+++ b/docs/json/japanese.json
@@ -19,8 +19,7 @@
           },
           "to": [
             {
-              "key_code": "left_command",
-              "lazy": true
+              "key_code": "left_command"
             }
           ],
           "to_if_held_down": [
@@ -49,8 +48,7 @@
           },
           "to": [
             {
-              "key_code": "right_command",
-              "lazy": true
+              "key_code": "right_command"
             }
           ],
           "to_if_held_down": [
@@ -91,8 +89,7 @@
           },
           "to": [
             {
-              "key_code": "left_command",
-              "lazy": true
+              "key_code": "left_command"
             }
           ],
           "to_if_alone": [
@@ -123,8 +120,7 @@
           },
           "to": [
             {
-              "key_code": "left_command",
-              "lazy": true
+              "key_code": "left_command"
             }
           ],
           "to_if_alone": [
@@ -155,8 +151,7 @@
           },
           "to": [
             {
-              "key_code": "right_command",
-              "lazy": true
+              "key_code": "right_command"
             }
           ],
           "to_if_alone": [
@@ -187,8 +182,7 @@
           },
           "to": [
             {
-              "key_code": "right_command",
-              "lazy": true
+              "key_code": "right_command"
             }
           ],
           "to_if_alone": [
@@ -224,8 +218,7 @@
           },
           "to": [
             {
-              "key_code": "right_command",
-              "lazy": true
+              "key_code": "right_command"
             }
           ],
           "to_if_alone": [
@@ -256,8 +249,7 @@
           },
           "to": [
             {
-              "key_code": "right_command",
-              "lazy": true
+              "key_code": "right_command"
             }
           ],
           "to_if_alone": [
@@ -522,8 +514,7 @@
           },
           "to": [
             {
-              "key_code": "left_control",
-              "lazy": true
+              "key_code": "left_control"
             }
           ],
           "to_if_alone": [
@@ -544,8 +535,7 @@
           },
           "to": [
             {
-              "key_code": "right_command",
-              "lazy": true
+              "key_code": "right_command"
             }
           ],
           "to_if_alone": [

--- a/src/json/japanese.json.rb
+++ b/src/json/japanese.json.rb
@@ -27,7 +27,6 @@ def main
             'to' => [
               {
                 'key_code' => 'left_command',
-                'lazy' => true,
               },
             ],
             'to_if_held_down' => [
@@ -53,7 +52,6 @@ def main
             'to' => [
               {
                 'key_code' => 'right_command',
-                'lazy' => true,
               },
             ],
             'to_if_held_down' => [
@@ -91,7 +89,6 @@ def main
             'to' => [
               {
                 'key_code' => 'left_command',
-                'lazy' => true,
               },
             ],
             'to_if_alone' => [
@@ -119,7 +116,6 @@ def main
             'to' => [
               {
                 'key_code' => 'left_command',
-                'lazy' => true,
               },
             ],
             'to_if_alone' => [
@@ -147,7 +143,6 @@ def main
             'to' => [
               {
                 'key_code' => 'right_command',
-                'lazy' => true,
               },
             ],
             'to_if_alone' => [
@@ -175,7 +170,6 @@ def main
             'to' => [
               {
                 'key_code' => 'right_command',
-                'lazy' => true,
               },
             ],
             'to_if_alone' => [
@@ -208,7 +202,6 @@ def main
             'to' => [
               {
                 'key_code' => 'right_command',
-                'lazy' => true,
               },
             ],
             'to_if_alone' => [
@@ -236,7 +229,6 @@ def main
             'to' => [
               {
                 'key_code' => 'right_command',
-                'lazy' => true,
               },
             ],
             'to_if_alone' => [
@@ -470,7 +462,6 @@ def main
             'to' => [
               {
                 'key_code' => 'left_control',
-                'lazy' => true,
               },
             ],
             'to_if_alone' => [
@@ -488,7 +479,6 @@ def main
             'to' => [
               {
                 'key_code' => 'right_command',
-                'lazy' => true,
               },
             ],
             'to_if_alone' => [


### PR DESCRIPTION
If the lazy option is true, clicking a link while pressing the Command key on Google Chrome doesn't open the link in a new tab.

Additionally, the lazy option was needed to enable key mapping change when the key in "from" and another key are pressed at the same time only.
But it is not needed now because "to_if_alone" works instead of that.