### PR TITLE
Add 'w' to list of left-handed keys

### DIFF
--- a/src/json/block_one_handed_combos.json.erb
+++ b/src/json/block_one_handed_combos.json.erb
@@ -5,6 +5,7 @@
             "description": "Block left-handed command + left-handed key",
             "manipulators": [
                 { "type": "basic", "from": <%= from("q", ["left_command"], ["any"]) %>, "to": <%= to([["vk_none" ]]) %> },
+                { "type": "basic", "from": <%= from("w", ["left_command"], ["any"]) %>, "to": <%= to([["vk_none" ]]) %> },
                 { "type": "basic", "from": <%= from("e", ["left_command"], ["any"]) %>, "to": <%= to([["vk_none" ]]) %> },
                 { "type": "basic", "from": <%= from("r", ["left_command"], ["any"]) %>, "to": <%= to([["vk_none" ]]) %> },
                 { "type": "basic", "from": <%= from("t", ["left_command"], ["any"]) %>, "to": <%= to([["vk_none" ]]) %> },
@@ -29,6 +30,7 @@
             "description": "Block left-handed shift + left-handed key",
             "manipulators": [
                 { "type": "basic", "from": <%= from("q", ["left_shift"], ["any"]) %>, "to": <%= to([["vk_none" ]]) %> },
+                { "type": "basic", "from": <%= from("w", ["left_shift"], ["any"]) %>, "to": <%= to([["vk_none" ]]) %> },
                 { "type": "basic", "from": <%= from("e", ["left_shift"], ["any"]) %>, "to": <%= to([["vk_none" ]]) %> },
                 { "type": "basic", "from": <%= from("r", ["left_shift"], ["any"]) %>, "to": <%= to([["vk_none" ]]) %> },
                 { "type": "basic", "from": <%= from("t", ["left_shift"], ["any"]) %>, "to": <%= to([["vk_none" ]]) %> },
@@ -53,6 +55,7 @@
             "description": "Block left-handed option + left-handed key",
             "manipulators": [
                 { "type": "basic", "from": <%= from("q", ["left_option"], ["any"]) %>, "to": <%= to([["vk_none" ]]) %> },
+                { "type": "basic", "from": <%= from("w", ["left_option"], ["any"]) %>, "to": <%= to([["vk_none" ]]) %> },
                 { "type": "basic", "from": <%= from("e", ["left_option"], ["any"]) %>, "to": <%= to([["vk_none" ]]) %> },
                 { "type": "basic", "from": <%= from("r", ["left_option"], ["any"]) %>, "to": <%= to([["vk_none" ]]) %> },
                 { "type": "basic", "from": <%= from("t", ["left_option"], ["any"]) %>, "to": <%= to([["vk_none" ]]) %> },
@@ -77,6 +80,7 @@
             "description": "Block left-handed control + left-handed key",
             "manipulators": [
                 { "type": "basic", "from": <%= from("q", ["left_control"], ["any"]) %>, "to": <%= to([["vk_none" ]]) %> },
+                { "type": "basic", "from": <%= from("w", ["left_control"], ["any"]) %>, "to": <%= to([["vk_none" ]]) %> },
                 { "type": "basic", "from": <%= from("e", ["left_control"], ["any"]) %>, "to": <%= to([["vk_none" ]]) %> },
                 { "type": "basic", "from": <%= from("r", ["left_control"], ["any"]) %>, "to": <%= to([["vk_none" ]]) %> },
                 { "type": "basic", "from": <%= from("t", ["left_control"], ["any"]) %>, "to": <%= to([["vk_none" ]]) %> },


### PR DESCRIPTION
The 'w' key was missing from the list of left-handed keys to block when pressing a left-handed modifier.