### PR TITLE
Added autoshift rules

### DIFF
--- a/docs/groups.json
+++ b/docs/groups.json
@@ -650,6 +650,9 @@
         },
         {
           "path": "json/workaround_broken_sw2tabesc.json"
+        },
+        {
+          "path": "json/autoshift.json"
         }
       ]
     }

--- a/docs/json/autoshift.json
+++ b/docs/json/autoshift.json
@@ -1,0 +1,1232 @@
+{
+  "title": "Autoshift: Engage shifted key by holding key",
+  "rules": [
+    {
+      "description": "Autoshift: Engage shifted key by holding key",
+      "manipulators": [
+        {
+            "from": {
+                "key_code": "q",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "q",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "q",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "w",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "w",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "w",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "e",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "e",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "e",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "r",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "r",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "r",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "t",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "t",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "t",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "y",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "y",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "y",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "u",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "u",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "u",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "i",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "i",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "i",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "o",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "o",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "o",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "p",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "p",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "p",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "open_bracket",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "open_bracket",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "open_bracket",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "close_bracket",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "close_bracket",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "close_bracket",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "backslash",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "backslash",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "backslash",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "a",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "a",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "a",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "s",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "s",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "s",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "d",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "d",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "d",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "f",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "f",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "f",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "g",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "g",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "g",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "h",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "h",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "h",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "j",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "j",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "j",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "k",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "k",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "k",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "l",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "l",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "l",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "semicolon",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "semicolon",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "semicolon",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "quote",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "quote",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "quote",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "z",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "z",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "z",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "x",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "x",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "x",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "c",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "c",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "c",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "v",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "v",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "v",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "b",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "b",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "b",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "n",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "n",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "n",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "m",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "m",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "m",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "comma",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "comma",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "comma",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "period",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "period",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "period",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "slash",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "slash",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "slash",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "grave_accent_and_tilde",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "grave_accent_and_tilde",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "grave_accent_and_tilde",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "1",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "1",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "1",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "2",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "2",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "2",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "3",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "3",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "3",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "4",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "4",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "4",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "5",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "5",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "5",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "6",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "6",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "6",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "7",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "7",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "7",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "8",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "8",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "8",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "9",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "9",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "9",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "0",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "0",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "0",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "hyphen",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "hyphen",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "hyphen",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "equal_sign",
+                "modifiers": {
+                    "optional": [
+                        "caps_lock"
+                    ]
+                }
+            },
+            "to_if_alone": [
+                {
+                    "key_code": "equal_sign",
+                    "repeat": false
+                }
+            ],
+            "to_if_held_down": [
+                {
+                    "key_code": "equal_sign",
+                    "modifiers": [
+                        "left_shift"
+                    ],
+                    "repeat": false
+                }
+            ],
+            "type": "basic"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Engages "shift + key" by holding the key, and "key" by tapping it. Only applies to alpha & number keys, including tilde and backslash.

A KE implementation of https://github.com/qmk/qmk_firmware/blob/master/docs/feature_auto_shift.md

In response to this issue: 
https://github.com/tekezo/Karabiner-Elements/issues/1395