### PR TITLE
Fixed the u (home) and o (end) keys on TouchCursor Mode

### DIFF
--- a/docs/json/touchcursor_mode.json
+++ b/docs/json/touchcursor_mode.json
@@ -140,7 +140,10 @@
           },
           "to": [
             {
-              "key_code": "home"
+              "key_code": "left_arrow",
+              "modifiers": [
+                "command"
+              ]
             }
           ],
           "conditions": [
@@ -163,7 +166,10 @@
           },
           "to": [
             {
-              "key_code": "end"
+              "key_code": "right_arrow",
+              "modifiers": [
+                "command"
+              ]
             }
           ],
           "conditions": [

--- a/src/json/touchcursor_mode.json.erb
+++ b/src/json/touchcursor_mode.json.erb
@@ -66,7 +66,7 @@
                 {
                     "type": "basic",
                     "from": <%= from("u", [], ["any"]) %>,
-                    "to": <%= to([["home"]]) %>,
+                    "to": <%= to([["left_arrow", ["command"]]]) %>,
                     "conditions": [
                         { "type": "variable_if", "name": "touchcursor_mode", "value": 1 }
                     ]
@@ -74,7 +74,7 @@
                 {
                     "type": "basic",
                     "from": <%= from("o", [], ["any"]) %>,
-                    "to": <%= to([["end"]]) %>,
+                    "to": <%= to([["right_arrow", ["command"]]]) %>,
                     "conditions": [
                         { "type": "variable_if", "name": "touchcursor_mode", "value": 1 }
                     ]


### PR DESCRIPTION
The default setting (to: "home", "end") did not work in most applications. This PR changes the output to command + left/right arrow.