### PR TITLE
:sparkles: add right_control home/end press/hold

### DIFF
--- a/docs/groups.json
+++ b/docs/groups.json
@@ -664,6 +664,9 @@
         },
         {
           "path": "json/autoshift.json"
+        },
+        {
+          "path":"json/shift_r_home_end_keypress.json"
         }
       ]
     }

--- a/docs/json/shift_r_home_end_keypress.json
+++ b/docs/json/shift_r_home_end_keypress.json
@@ -1,0 +1,16 @@
+{
+  "title": "right_control to end; and if held, home",
+  "rules": [
+    {
+      "description": "Map right control to end; and if held, home",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {"key_code": "right_control"},
+          "to": {"key_code": "end"},
+          "to_if_held_down":{"key_code": "home"}
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/shift_r_home_end_keypress.erb
+++ b/src/json/shift_r_home_end_keypress.erb
@@ -1,0 +1,16 @@
+{
+  "title": "right_control to end; and if held, home",
+  "rules": [
+    {
+      "description": "Map right control to end; and if held, home",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {"key_code": "right_control"},
+          "to": {"key_code": "end"},
+          "to_if_held_down":{"key_code": "home"}
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Description
Added a complex modifier to allow the right_control key to act as both end and home. If the `right_control` key is pressed, `end` is invoked. If `right_control` is pressed and held, `home` is invoked.

The purpose of this change is to bring home/end key functionality to condensed keyboard. 

How to Test?

From the root of this project:

1. Run Make
 Copy a json file to `~/.config/karabiner/assets/complex_modifications`
2    cp docs/json/your_awesome_configuration.json ~/.config/karabiner/assets/complex_modifications
3.  Import rules from Karabiner-Elements Preferences.
 `Karabiner-Elements Preferences > Complex Modifications > Rules > Add rule`
4. Test pressing/press-hold `right_control`
