### PR TITLE
Jetbrains on OSX mimics modifier placement of PC

### DIFF
--- a/docs/extra_descriptions/jetbrains_osx_mimics_pc.json.html
+++ b/docs/extra_descriptions/jetbrains_osx_mimics_pc.json.html
@@ -1,0 +1,14 @@
+<p style="margin-top: 20px; font-weight: bold">
+  Remap Control, Option, and Command on OSX to mimic the PC layout when using Jetbrains products.
+</p>
+
+<p>
+  Sharing settings via Jetbrains Account Sync and Settings Repositories results in a more intuitive layout. 
+</p>
+
+<ul>
+  <li>command: alt</li>
+  <li>option: ctrl</li>
+  <li>control: command</li>
+  <li>command-tab: command-tab (to preserve window swapping)</li>
+</ul>

--- a/docs/groups.json
+++ b/docs/groups.json
@@ -233,7 +233,11 @@
         },
         {
           "path": "json/vnc_swap_left_cmd_ctrl.json"
-        }
+        },
+        {
+          "path": "json/jetbrains_osx_mimics_pc.json",
+          "extra_description_path": "extra_descriptions/jetbrains_osx_mimics_pc.json.html"
+        }	  
       ]
     },
     {

--- a/docs/json/jetbrains_osx_mimics_pc.json
+++ b/docs/json/jetbrains_osx_mimics_pc.json
@@ -99,7 +99,77 @@
 							]
 						}
 					]
+				},
+				{
+					"type": "basic",
+					"from":
+					{
+						"key_code": "q",
+						"modifiers":
+						{
+							"mandatory":
+							[
+								"option"
+							]
+						}
+					},
+					"to":
+					[
+						{
+							"key_code": "q",
+							"modifiers":
+							[
+								"left_gui"
+							]
+						}
+					],
+					"conditions":
+					[
+						{
+							"type": "frontmost_application_if",
+							"bundle_identifiers":
+							[
+								"^com\\.jetbrains\\.*"
+							]
+						}
+					]
+				},
+				{
+					"type": "basic",
+					"from":
+					{
+						"key_code": "spacebar",
+						"modifiers":
+						{
+							"mandatory":
+							[
+								"option"
+							]
+						}
+					},
+					"to":
+					[
+						{
+							"key_code": "spacebar",
+							"modifiers":
+							[
+								"left_gui"
+							]
+						}
+					],
+					"conditions":
+					[
+						{
+							"type": "frontmost_application_if",
+							"bundle_identifiers":
+							[
+								"^com\\.jetbrains\\.*"
+							]
+						}
+					]
 				}
+
+
 			]
 		},
 		{
@@ -176,7 +246,7 @@
 					"type": "basic",
 					"from":
 					{
-						"key_code": "control",
+						"key_code": "left_control",
 						"modifiers":
 						{
 							"optional":
@@ -203,6 +273,43 @@
 					]
 				}
 			]
+		},
+		{
+			"description": "Ctrl -> Gui in Jetbrains Rider",
+			"manipulators":
+			[
+				{
+					"type": "basic",
+					"from":
+					{
+						"key_code": "right_control",
+						"modifiers":
+						{
+							"optional":
+							[
+								"any"
+							]
+						}
+					},
+					"to":
+					[
+						{
+							"key_code": "right_gui"
+						}
+					],
+					"conditions":
+					[
+						{
+							"type": "frontmost_application_if",
+							"bundle_identifiers":
+							[
+								"^com\\.jetbrains\\.*"
+							]
+						}
+					]
+				}
+			]
 		}
+
 	]
 }

--- a/docs/json/jetbrains_osx_mimics_pc.json
+++ b/docs/json/jetbrains_osx_mimics_pc.json
@@ -1,0 +1,208 @@
+{
+	"title": "Jetbrains matches Windows",
+	"rules":
+	[
+		{
+			"description": "Command -> Alt in Jetbrains Rider",
+			"manipulators":
+			[
+				{
+					"type": "basic",
+					"from":
+					{
+						"key_code": "left_gui",
+						"modifiers":
+						{
+							"optional":
+							[
+								"any"
+							]
+						}
+					},
+					"to":
+					[
+						{
+							"key_code": "left_alt"
+						}
+					],
+					"conditions":
+					[
+						{
+							"type": "frontmost_application_if",
+							"bundle_identifiers":
+							[
+								"^com\\.jetbrains\\.*"
+							]
+						}
+					]
+				},
+				{
+					"type": "basic",
+					"from":
+					{
+						"key_code": "right_gui",
+						"modifiers":
+						{
+							"optional":
+							[
+								"any"
+							]
+						}
+					},
+					"to":
+					[
+						{
+							"key_code": "right_alt"
+						}
+					],
+					"conditions":
+					[
+						{
+							"type": "frontmost_application_if",
+							"bundle_identifiers":
+							[
+								"^com\\.jetbrains\\.*"
+							]
+						}
+					]
+				},
+				{
+					"type": "basic",
+					"from":
+					{
+						"key_code": "tab",
+						"modifiers":
+						{
+							"mandatory":
+							[
+								"option"
+							]
+						}
+					},
+					"to":
+					[
+						{
+							"key_code": "tab",
+							"modifiers":
+							[
+								"left_gui"
+							]
+						}
+					],
+					"conditions":
+					[
+						{
+							"type": "frontmost_application_if",
+							"bundle_identifiers":
+							[
+								"^com\\.jetbrains\\.*"
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"description": "Alt -> Ctrl in Jetbrains Rider",
+			"manipulators":
+			[
+				{
+					"type": "basic",
+					"from":
+					{
+						"key_code": "left_alt",
+						"modifiers":
+						{
+							"optional":
+							[
+								"any"
+							]
+						}
+					},
+					"to":
+					[
+						{
+							"key_code": "left_control"
+						}
+					],
+					"conditions":
+					[
+						{
+							"type": "frontmost_application_if",
+							"bundle_identifiers":
+							[
+								"^com\\.jetbrains\\.*"
+							]
+						}
+					]
+				},
+				{
+					"type": "basic",
+					"from":
+					{
+						"key_code": "right_alt",
+						"modifiers":
+						{
+							"optional":
+							[
+								"any"
+							]
+						}
+					},
+					"to":
+					[
+						{
+							"key_code": "right_control"
+						}
+					],
+					"conditions":
+					[
+						{
+							"type": "frontmost_application_if",
+							"bundle_identifiers":
+							[
+								"^com\\.jetbrains\\.*"
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"description": "Ctrl -> Gui in Jetbrains Rider",
+			"manipulators":
+			[
+				{
+					"type": "basic",
+					"from":
+					{
+						"key_code": "control",
+						"modifiers":
+						{
+							"optional":
+							[
+								"any"
+							]
+						}
+					},
+					"to":
+					[
+						{
+							"key_code": "left_gui"
+						}
+					],
+					"conditions":
+					[
+						{
+							"type": "frontmost_application_if",
+							"bundle_identifiers":
+							[
+								"^com\\.jetbrains\\.*"
+							]
+						}
+					]
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
When in Jetbrains, swap the modifier keys to allow easier syncing of settings between PC and OSX via Jetbrains account sync or a settings repository. 