### PR TITLE
Add 'Exchange Command+Forward-Delete and Option+Forward-Delete'

### DIFF
--- a/docs/groups.json
+++ b/docs/groups.json
@@ -447,6 +447,9 @@
           "path": "json/exchange_command_backspace_and_option_backspace.json"
         },
         {
+          "path": "json/exchange_command_del-forward_and_option_del-forward.json"
+        },
+        {
           "path": "json/mouse_button4_to_double_click.json"
         },
         {

--- a/docs/json/exchange_command_del-forward_and_option_del-forward.json
+++ b/docs/json/exchange_command_del-forward_and_option_del-forward.json
@@ -1,0 +1,59 @@
+{
+  "title": "Exchange Command+Forward-Delete and Option+Forward-Delete",
+  "rules": [
+    {
+      "description": "Change Command+Forward-Delete to Option+Forward-Delete",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "delete_forward",
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_forward",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Change Option+Forward-Delete to Command+Forward-Delete",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "delete_forward",
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_forward",
+              "modifiers": [
+                "command"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I've added a new rule that works like _Exchange Command+Backspace and Option+Backspace_, but with Forward-Delete instead of Backspace.