### PR TITLE
add modifiers_to_arrows complex modification

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -392,6 +392,9 @@
           "path": "json/modifiers_to_f-keys.json"
         },
         {
+          "path": "json/modifiers_to_arrows.json"
+        },
+        {
           "path": "json/return_to_ctrl.json"
         },
         {

--- a/public/json/modifiers_to_arrows.json
+++ b/public/json/modifiers_to_arrows.json
@@ -1,0 +1,112 @@
+{
+    "title": "Change modifiers to arrows",
+    "maintainers": [
+        "thoelze1"
+    ],
+    "rules": [
+        {
+            "description": "Change left_shift to left_arrow if pressed alone",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "left_shift",
+                        "modifiers": {
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "left_shift"
+                        }
+                    ],
+                    "to_if_alone": [
+                        {
+                            "key_code": "left_arrow"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "Change right_shift to right_arrow if pressed alone",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "right_shift",
+                        "modifiers": {
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "right_shift"
+                        }
+                    ],
+                    "to_if_alone": [
+                        {
+                            "key_code": "right_arrow"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "Change left_command to down_arrow if pressed alone",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "left_command",
+                        "modifiers": {
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "left_command"
+                        }
+                    ],
+                    "to_if_alone": [
+                        {
+                            "key_code": "down_arrow"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "Change right_command to up_arrow if pressed alone",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "right_command",
+                        "modifiers": {
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "right_command"
+                        }
+                    ],
+                    "to_if_alone": [
+                        {
+                            "key_code": "up_arrow"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
I added a complex modification that remaps modifier keys to arrow keys when pressed alone. I followed the instructions on the readme: `make` succeeded and the `index.html` looked good after running `make server`. Thanks!