### PR TITLE
Fix the mutiple modifier to be mandatory bug & add optional ⌘L

### DIFF
--- a/public/json/cmd_return.json
+++ b/public/json/cmd_return.json
@@ -10,8 +10,7 @@
             "key_code": "return_or_enter",
             "modifiers": {
               "mandatory": [
-                "left_command",
-                "right_command"
+                "command"
               ],
               "optional": [
                 "left_shift",

--- a/src/json/cmd_return.json.erb
+++ b/src/json/cmd_return.json.erb
@@ -2,11 +2,21 @@
     "title": "Command_L|Command_R + Return to Backslash",
     "rules": [
         {
-            "description": "Command_[L|R] (⌘) + Return (⏎) to Backslash and Command_[L|R] (⌘) + Shift (⇧) + Return (⏎) to Pipe (|)",
+            "description": "Command_L (⌘) + Return (⏎) to Backslash and Command_L (⌘) + Shift (⇧) + Return (⏎) to Pipe (|)",
             "manipulators": [
                 {
                     "type": "basic",
-                    "from": <%= from("return_or_enter", ["left_command", "right_command"], ["left_shift", "right_shift"]) %>,
+                    "from": <%= from("return_or_enter", ["left_command"], ["left_shift", "right_shift"]) %>,
+                    "to": <%= to([["backslash"]]) %>
+                }
+            ]
+        },
+        {
+            "description": "Command_R (⌘) + Return (⏎) to Backslash and Command_R (⌘) + Shift (⇧) + Return (⏎) to Pipe (|)",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("return_or_enter", ["right_command"], ["left_shift", "right_shift"]) %>,
                     "to": <%= to([["backslash"]]) %>
                 }
             ]

--- a/src/json/cmd_return.json.erb
+++ b/src/json/cmd_return.json.erb
@@ -2,21 +2,11 @@
     "title": "Command_L|Command_R + Return to Backslash",
     "rules": [
         {
-            "description": "Command_L (⌘) + Return (⏎) to Backslash and Command_L (⌘) + Shift (⇧) + Return (⏎) to Pipe (|)",
+            "description": "Command_[L|R] (⌘) + Return (⏎) to Backslash and Command_[L|R] (⌘) + Shift (⇧) + Return (⏎) to Pipe (|)",
             "manipulators": [
                 {
                     "type": "basic",
-                    "from": <%= from("return_or_enter", ["left_command"], ["left_shift", "right_shift"]) %>,
-                    "to": <%= to([["backslash"]]) %>
-                }
-            ]
-        },
-        {
-            "description": "Command_R (⌘) + Return (⏎) to Backslash and Command_R (⌘) + Shift (⇧) + Return (⏎) to Pipe (|)",
-            "manipulators": [
-                {
-                    "type": "basic",
-                    "from": <%= from("return_or_enter", ["right_command"], ["left_shift", "right_shift"]) %>,
+                    "from": <%= from("return_or_enter", ["command"], ["left_shift", "right_shift"]) %>,
                     "to": <%= to([["backslash"]]) %>
                 }
             ]


### PR DESCRIPTION
I've actually managed to mess it up with this pull request, https://github.com/pqrs-org/KE-complex_modifications/pull/600. (I'm sorry 😅)
The PR was suppose to make Command_L optional but instead it made both L and R mandatory at the same time.
So this PR fix the issue and make Command_L optional, too.