### PR TITLE
Map ctrl+delete to option+delete

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -447,6 +447,12 @@
           "path": "json/ctrl_arrows_to_option_arrows.json"
         },
         {
+          "path": "json/ctrl_delete.json"
+        },
+        {
+          "path": "json/ctrl_forward_delete.json"
+        },
+        {
           "path": "json/command_esc_to_command_grave_accent.json"
         },
         {

--- a/public/json/ctrl_delete.json
+++ b/public/json/ctrl_delete.json
@@ -1,0 +1,32 @@
+{
+  "title": "Map Ctrl+Backward-Delete to Option+Backward-Delete (delete current word)",
+  "rules": [
+    {
+      "description": "Add Ctrl+Backward-Delete",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "delete_or_backspace",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_or_backspace",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}

--- a/public/json/ctrl_forward_delete.json
+++ b/public/json/ctrl_forward_delete.json
@@ -1,0 +1,32 @@
+{
+  "title": "Map Ctrl+Forward-Delete to Option+Forward-Delete (forward delete current word)",
+  "rules": [
+    {
+      "description": "Add Ctrl+Forward-Delete",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "delete_forward",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_forward",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I use the rule for switching ctrl+arrows with option+arrows so that my ctrl+left/right go to the beginning/end of the current word. This pull request adds rules for doing the same thing with ctrl+back/forward delete.