### PR TITLE
print_screen to left_command+left_shift+4

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -522,6 +522,9 @@
         },
         {
           "path": "json/f14_to_copy_f15_to_paste.json"
+        },
+        {
+          "path": "json/print_screen_to_command_shift_4.json"
         }
       ]
     },

--- a/public/json/print_screen_to_command_shift_4.json
+++ b/public/json/print_screen_to_command_shift_4.json
@@ -1,0 +1,23 @@
+{
+  "title": "Print Screen to Command+Shift+4",
+  "rules": [
+    {
+      "description": "Use PC print screen button for screen capture",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "print_screen"
+          },
+          "to": {
+            "key_code": "4",
+            "modifiers": [
+              "left_command",
+              "left_shift"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Added mapping from print_screen to left_command+left_shift+4 for using PC print screen button to capture screen regions. Tested with macOS Mojave 10.14.6 and KE 12.8.0.