### PR TITLE
Right option as an EMOJI 😊 key

### DIFF
--- a/public/json/Right_option_as_emoji_key.json
+++ b/public/json/Right_option_as_emoji_key.json
@@ -1,0 +1,35 @@
+{
+  "title": "Emoji-key",
+  "rules": [
+      {
+      "description": "Press right_alt alone toggles emoji input",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_alt",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_alt"
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "spacebar",
+              "modifiers": [
+				"left_control",
+				"left_command"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I kinda missed the touchbar emoji keyboard when using my MacBook Pro in clamshell mode with my eGPU.

Thus I created this inspired by Microsoft.

This transforms the right option key to an emoji key like found on some recent microsoft keyboards.
https://www.reviewgeek.com/thumbcache/0/0/7514b702e9fd8fb1dc73e9b70ca8dbeb/p/uploads/2019/10/98fb5154.jpg