### PR TITLE
Add "[macOS] Windows-like word movement/selection/deletion"

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -36,6 +36,9 @@
         },
         {
           "path": "json/both-command_l-and-command_r-to-escape.json"
+        },
+        {
+          "path": "json/windows_like_word_bindings.json"
         }
       ]
     },

--- a/public/json/windows_like_word_bindings.json
+++ b/public/json/windows_like_word_bindings.json
@@ -1,0 +1,221 @@
+{
+  "title": "[macOS] Windows-like word movement/selection/deletion",
+  "maintainers": [
+    "tyru"
+  ],
+  "rules": [
+    {
+      "description": "Ctrl + Arrow Keys to Option + Arrow Keys",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "up_arrow",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "down_arrow",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "down_arrow",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "left_arrow",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "right_arrow",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Ctrl + Shift + Arrow Keys to Option + Shift + Arrow Keys",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "up_arrow",
+            "modifiers": {
+              "mandatory": [
+                "control",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow",
+              "modifiers": [
+                "option",
+                "shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "down_arrow",
+            "modifiers": {
+              "mandatory": [
+                "control",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "down_arrow",
+              "modifiers": [
+                "option",
+                "shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "left_arrow",
+            "modifiers": {
+              "mandatory": [
+                "control",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow",
+              "modifiers": [
+                "option",
+                "shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "right_arrow",
+            "modifiers": {
+              "mandatory": [
+                "control",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow",
+              "modifiers": [
+                "option",
+                "shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Ctrl + BS/Del Keys to Option + BS/Del Keys",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "delete_or_backspace",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_or_backspace",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "delete_forward",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_forward",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/windows_like_word_bindings.json.rb
+++ b/src/json/windows_like_word_bindings.json.rb
@@ -1,0 +1,197 @@
+#!/usr/bin/env ruby
+
+# You can generate json by executing the following command on Terminal.
+#
+# $ ruby ./emacs_key_bindings.json.rb
+#
+
+require 'json'
+require_relative '../lib/karabiner.rb'
+
+def main
+  puts JSON.pretty_generate(
+    'title' => '[macOS] Windows-like word movement/selection/deletion',
+    'maintainers' => ['tyru'],
+    'rules' => [
+      ctrl_arrow_movements,
+      ctrl_arrow_selections,
+      ctrl_arrow_deletions,
+    ]
+  )
+end
+
+def ctrl_arrow_movements
+  {
+    'description' => 'Ctrl + Arrow Keys to Option + Arrow Keys',
+    'manipulators' => [
+      {
+        'from' => {
+          'key_code' => 'up_arrow',
+          'modifiers' => {
+            'mandatory' => ['control'],
+          },
+        },
+        'to' => [
+          {
+            'key_code' => 'up_arrow',
+            'modifiers' => ['option'],
+          },
+        ],
+        'type' => 'basic',
+      },
+      {
+        'from' => {
+          'key_code' => 'down_arrow',
+          'modifiers' => {
+            'mandatory' => ['control'],
+          },
+        },
+        'to' => [
+          {
+            'key_code' => 'down_arrow',
+            'modifiers' => ['option'],
+          },
+        ],
+        'type' => 'basic',
+      },
+      {
+        'from' => {
+          'key_code' => 'left_arrow',
+          'modifiers' => {
+            'mandatory' => ['control'],
+          },
+        },
+        'to' => [
+          {
+            'key_code' => 'left_arrow',
+            'modifiers' => ['option'],
+          },
+        ],
+        'type' => 'basic',
+      },
+      {
+        'from' => {
+          'key_code' => 'right_arrow',
+          'modifiers' => {
+            'mandatory' => ['control'],
+          },
+        },
+        'to' => [
+          {
+            'key_code' => 'right_arrow',
+            'modifiers' => ['option'],
+          },
+        ],
+        'type' => 'basic',
+      },
+    ],
+  }
+end
+
+def ctrl_arrow_selections
+  {
+    'description' => 'Ctrl + Shift + Arrow Keys to Option + Shift + Arrow Keys',
+    'manipulators' => [
+      {
+        'from' => {
+          'key_code' => 'up_arrow',
+          'modifiers' => {
+            'mandatory' => ['control', 'shift'],
+          },
+        },
+        'to' => [
+          {
+            'key_code' => 'up_arrow',
+            'modifiers' => ['option', 'shift'],
+          },
+        ],
+        'type' => 'basic',
+      },
+      {
+        'from' => {
+          'key_code' => 'down_arrow',
+          'modifiers' => {
+            'mandatory' => ['control', 'shift'],
+          },
+        },
+        'to' => [
+          {
+            'key_code' => 'down_arrow',
+            'modifiers' => ['option', 'shift'],
+          },
+        ],
+        'type' => 'basic',
+      },
+      {
+        'from' => {
+          'key_code' => 'left_arrow',
+          'modifiers' => {
+            'mandatory' => ['control', 'shift'],
+          },
+        },
+        'to' => [
+          {
+            'key_code' => 'left_arrow',
+            'modifiers' => ['option', 'shift'],
+          },
+        ],
+        'type' => 'basic',
+      },
+      {
+        'from' => {
+          'key_code' => 'right_arrow',
+          'modifiers' => {
+            'mandatory' => ['control', 'shift'],
+          },
+        },
+        'to' => [
+          {
+            'key_code' => 'right_arrow',
+            'modifiers' => ['option', 'shift'],
+          },
+        ],
+        'type' => 'basic',
+      },
+    ],
+  }
+end
+
+def ctrl_arrow_deletions
+  {
+    'description' => 'Ctrl + BS/Del Keys to Option + BS/Del Keys',
+    'manipulators' => [
+      {
+        'from' => {
+          'key_code' => 'delete_or_backspace',
+          'modifiers' => {
+            'mandatory' => ['control'],
+          },
+        },
+        'to' => [
+          {
+            'key_code' => 'delete_or_backspace',
+            'modifiers' => ['option'],
+          },
+        ],
+        'type' => 'basic',
+      },
+      {
+        'from' => {
+          'key_code' => 'delete_forward',
+          'modifiers' => {
+            'mandatory' => ['control'],
+          },
+        },
+        'to' => [
+          {
+            'key_code' => 'delete_forward',
+            'modifiers' => ['option'],
+          },
+        ],
+        'type' => 'basic',
+      },
+    ],
+  }
+end
+
+main


### PR DESCRIPTION
This complex modification contains 3 rules.

* Ctrl + Arrow Keys to Option + Arrow Keys
* Ctrl + Shift + Arrow Keys to Option + Shift + Arrow Keys
* Ctrl + BS/Del Keys to Option + BS/Del Keys

Big thanks to @Eivy for example
https://gist.github.com/Eivy/d2832e8671c863bd97fc14d6a0e44036