### PR TITLE
CAPS 4 Tenkey

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -196,6 +196,9 @@
         {
           "path": "json/left_option_plus_hjkl_to_arrows.json",
           "extra_description_path": "extra_descriptions/left_option_plus_hjkl_to_arrows.json.html"
+        },
+        {
+          "path": "json/caps_tenkey_mode.json"
         }
       ]
     },

--- a/public/json/caps_tenkey_mode.json
+++ b/public/json/caps_tenkey_mode.json
@@ -1,0 +1,437 @@
+{
+  "title": "CAPS 4 Tenkey",
+  "maintainers": [
+    "IvanShamatov"
+  ],
+  "rules": [
+    {
+      "description": "CAPS Tenkey: TenkeyMode on/off toggle",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "caps_lock",
+            "modifiers": {
+              "mandatory": [
+
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "type": "basic",
+          "to": {
+            "set_variable": {
+              "name": "tenkey_mode",
+              "value": 1
+            }
+          },
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "tenkey_mode",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "key_code": "caps_lock",
+            "modifiers": {
+              "mandatory": [
+
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "type": "basic",
+          "to": {
+            "set_variable": {
+              "name": "tenkey_mode",
+              "value": 0
+            }
+          },
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "tenkey_mode",
+              "value": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "CAPS Tenkey: if TenkeyMode ON m,.jkluio maps to 1234567890",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "m",
+            "modifiers": {
+              "mandatory": [
+
+              ],
+              "optional": [
+
+              ]
+            }
+          },
+          "to": {
+            "key_code": "1"
+          },
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "tenkey_mode",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "comma",
+            "modifiers": {
+              "mandatory": [
+
+              ],
+              "optional": [
+
+              ]
+            }
+          },
+          "to": {
+            "key_code": "2"
+          },
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "tenkey_mode",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "period",
+            "modifiers": {
+              "mandatory": [
+
+              ],
+              "optional": [
+
+              ]
+            }
+          },
+          "to": {
+            "key_code": "3"
+          },
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "tenkey_mode",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "mandatory": [
+
+              ],
+              "optional": [
+
+              ]
+            }
+          },
+          "to": {
+            "key_code": "4"
+          },
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "tenkey_mode",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "k",
+            "modifiers": {
+              "mandatory": [
+
+              ],
+              "optional": [
+
+              ]
+            }
+          },
+          "to": {
+            "key_code": "5"
+          },
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "tenkey_mode",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "mandatory": [
+
+              ],
+              "optional": [
+
+              ]
+            }
+          },
+          "to": {
+            "key_code": "6"
+          },
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "tenkey_mode",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "u",
+            "modifiers": {
+              "mandatory": [
+
+              ],
+              "optional": [
+
+              ]
+            }
+          },
+          "to": {
+            "key_code": "7"
+          },
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "tenkey_mode",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": [
+
+              ],
+              "optional": [
+
+              ]
+            }
+          },
+          "to": {
+            "key_code": "8"
+          },
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "tenkey_mode",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "o",
+            "modifiers": {
+              "mandatory": [
+
+              ],
+              "optional": [
+
+              ]
+            }
+          },
+          "to": {
+            "key_code": "9"
+          },
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "tenkey_mode",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "spacebar",
+            "modifiers": {
+              "mandatory": [
+
+              ],
+              "optional": [
+
+              ]
+            }
+          },
+          "to": {
+            "key_code": "0"
+          },
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "tenkey_mode",
+              "value": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "CAPS Tenkey: if TenkeyMode ON 90p;/ maps to /*-+=",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "semicolon",
+            "modifiers": {
+              "mandatory": [
+
+              ],
+              "optional": [
+
+              ]
+            }
+          },
+          "to": {
+            "key_code": "keypad_plus"
+          },
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "tenkey_mode",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "p",
+            "modifiers": {
+              "mandatory": [
+
+              ],
+              "optional": [
+
+              ]
+            }
+          },
+          "to": {
+            "key_code": "keypad_hyphen"
+          },
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "tenkey_mode",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "slash",
+            "modifiers": {
+              "mandatory": [
+
+              ],
+              "optional": [
+
+              ]
+            }
+          },
+          "to": {
+            "key_code": "keypad_equal_sign"
+          },
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "tenkey_mode",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "9",
+            "modifiers": {
+              "mandatory": [
+
+              ],
+              "optional": [
+
+              ]
+            }
+          },
+          "to": {
+            "key_code": "keypad_slash"
+          },
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "tenkey_mode",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "0",
+            "modifiers": {
+              "mandatory": [
+
+              ],
+              "optional": [
+
+              ]
+            }
+          },
+          "to": {
+            "key_code": "keypad_asterisk"
+          },
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "tenkey_mode",
+              "value": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/caps_tenkey_mode.json.rb
+++ b/src/json/caps_tenkey_mode.json.rb
@@ -1,0 +1,107 @@
+require 'json'
+require_relative '../lib/karabiner.rb'
+
+TENKEY_MAPPING = {
+  'm'=> '1',
+  'comma'=> '2',
+  'period'=> '3',
+  'j'=> '4',
+  'k'=> '5',
+  'l'=> '6',
+  'u'=> '7',
+  'i'=> '8',
+  'o'=> '9',
+  'spacebar'=> '0'
+}
+
+ARITHMETIC_SYMBOLS_MAPPING = {
+  'semicolon' => 'keypad_plus',
+  'p' => 'keypad_hyphen',
+  'slash'=> 'keypad_equal_sign',
+  '9' => 'keypad_slash',
+  '0' => 'keypad_asterisk'
+}
+
+def main
+  puts JSON.pretty_generate(
+    title: 'CAPS 4 Tenkey',
+    maintainers: %w[IvanShamatov],
+    rules: [
+      tenkey_toggle,
+      tenkey_mapping,
+      arithmetic_symbols_mapping,
+    ]
+  )
+end
+
+def tenkey_toggle
+  {
+    description: 'CAPS Tenkey: TenkeyMode on/off toggle',
+    manipulators: [
+      # Turning on Tenkey mode
+      {
+        from: _from('caps_lock', [], ['any']),
+        type: 'basic',
+        to: _set_variable('tenkey_mode', 1),
+        conditions: tenkey_mode_off
+      },
+      # Turning off Tenkey mode
+      {
+        from: _from('caps_lock', [], ['any']),
+        type: 'basic',
+        to: _set_variable('tenkey_mode', 0),
+        conditions: tenkey_mode_on
+      }
+    ]
+  }
+end
+
+def tenkey_mapping
+  {
+    description: 'CAPS Tenkey: if TenkeyMode ON m,.jkluio' ' maps to 1234567890',
+    manipulators: map_keys(TENKEY_MAPPING, conditions: tenkey_mode_on)
+  }
+end
+
+def arithmetic_symbols_mapping
+  {
+    description: 'CAPS Tenkey: if TenkeyMode ON 90p;/ maps to /*-+=',
+    manipulators: map_keys(ARITHMETIC_SYMBOLS_MAPPING, conditions: tenkey_mode_on)
+  }
+end
+
+
+def _from(key_code, mandatory = [], optional = [])
+  {
+    key_code: key_code,
+    modifiers: {
+      mandatory: mandatory,
+      optional: optional
+    }
+  }
+end
+
+def map_keys(mapping, conditions: [])
+  mapping.map do |from_key, to_key|
+    {
+      type: 'basic',
+      from: _from(from_key),
+      to: { key_code: to_key },
+      conditions: conditions
+    }
+  end
+end
+
+def _set_variable(name, value)
+  { set_variable: { name: name, value: value } }
+end
+
+def tenkey_mode_on
+  [{ type: 'variable_if', name: 'tenkey_mode', value: 1 }]
+end
+
+def tenkey_mode_off
+  [{ type: 'variable_if', name: 'tenkey_mode', value: 0 }]
+end
+
+main


### PR DESCRIPTION
CAPS works like numlock, enabling keys around right hand. 

```ruby
TENKEY_MAPPING = {
  'm'=> '1',
  'comma'=> '2',
  'period'=> '3',
  'j'=> '4',
  'k'=> '5',
  'l'=> '6',
  'u'=> '7',
  'i'=> '8',
  'o'=> '9',
  'spacebar'=> '0'
}
```

In addition to that, I added arithmetic operations next to numbers: 

```ruby
ARIPHMETIC_SYMBOLS_MAPPING = {
  'semicolon' => 'keypad_plus',
  'p' => 'keypad_hyphen',
  'slash'=> 'keypad_equal_sign',
  '9' => 'keypad_slash',
  '0' => 'keypad_asterisk'
}
```