### PR TITLE
Add ctrlquote.json complex modification

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -446,6 +446,9 @@
       "id": "key-specific",
       "files": [
         {
+          "path": "json/ctrlquote.json"
+        },
+        {
           "path": "json/escape.json"
         },
         {

--- a/public/json/ctrlquote.json
+++ b/public/json/ctrlquote.json
@@ -1,0 +1,25 @@
+{
+  "title": "Convert <c-'> to double quote",
+  "rules": [
+    {
+      "description": "Remaps mistyped control-quote into a shft-quote. Occurs often when caps lock is remapped to control key.",
+      "manipulators": [
+    {
+        "type": "basic",
+        "from": {
+            "key_code": "quote",
+            "modifiers": {
+		"mandatory": [ "left_control" ]
+	    }
+        },
+        "to": [
+            {
+                "key_code": "quote",
+		"modifiers": [ "shift" ]
+            }
+        ]
+    }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
remaps a mistyped ctrl-quote to a shift-quote. Happens frequently for caps locked keys remapped to ctrl.