### PR TITLE
added stadia_cmd complex mod

### DIFF
--- a/public/extra_descriptions/stadia_cmd.html
+++ b/public/extra_descriptions/stadia_cmd.html
@@ -1,0 +1,3 @@
+<link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
+
+Use the Mac Command key as ALT for Google Chrome Stadia gaming.  Requires installation of the Stadia chrome app on Macbook.

--- a/public/groups.json
+++ b/public/groups.json
@@ -311,6 +311,10 @@
           "extra_description_path": "extra_descriptions/spectacle_fn_wasdf.json.html"
         },
         {
+          "path": "json/stadia_cmd.json", 
+          "extra_description_path": "extra_descriptions/stadia_cmd.html" 
+        },
+        {
           "path": "json/roon.json"
         },
         {

--- a/public/json/stadia_cmd.json
+++ b/public/json/stadia_cmd.json
@@ -1,0 +1,34 @@
+{
+  "title": "Option to Command Key in Stadia",
+  "rules": [
+    {
+      "description": "Use CMD key as alt for Google Chrome Stadia gaming - requires install of Stadia app on Macbook",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_gui",
+            "modifiers":
+						{
+							"optional":
+							[
+								"any"
+							]
+						}
+          },
+          "to": {
+            "key_code": "left_alt"
+          },
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.google\\.Chrome\\.app\\.*"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Added complex mod that will allow the use of CMD for ALT in google chromes apps.  Specifically designed for Stadia.