### PR TITLE
Not to use lazy for eisuu/kana to option rule

### DIFF
--- a/src/json/japanese.json.rb
+++ b/src/json/japanese.json.rb
@@ -353,7 +353,7 @@ def main
         ],
       },
       {
-        'description' => '英数・かなキーを他のキーと同時に押したときに、Optionキーを送信する (rev 2)',
+        'description' => '英数・かなキーを他のキーと同時に押したときに、Optionキーを送信する (rev 3)',
         'manipulators' => [
           {
             'type' => 'basic',
@@ -362,18 +362,12 @@ def main
               'modifiers' => Karabiner.from_modifiers,
             },
             'parameters' => {
-              'basic.to_if_held_down_threshold_milliseconds' => 100,
+              'basic.to_if_alone_timeout_milliseconds' => 200,
             },
             'to' => [
               {
                 'key_code' => 'left_option',
-                'lazy' => true,
-              },
-            ],
-            'to_if_held_down' => [
-              {
-                'key_code' => 'left_option',
-              },
+              }
             ],
             'to_if_alone' => [
               {
@@ -388,18 +382,12 @@ def main
               'modifiers' => Karabiner.from_modifiers,
             },
             'parameters' => {
-              'basic.to_if_held_down_threshold_milliseconds' => 100,
+              'basic.to_if_alone_timeout_milliseconds' => 200,
             },
             'to' => [
               {
                 'key_code' => 'right_option',
-                'lazy' => true,
-              },
-            ],
-            'to_if_held_down' => [
-              {
-                'key_code' => 'right_option',
-              },
+              }
             ],
             'to_if_alone' => [
               {


### PR DESCRIPTION
Option is modifier key, so we can immediately send without waiting for held down.
This removes latency in mouse-with-modifier operations and context menu preview.

Also, with this Karabiner does not send eisuu/kana for slightly longer press, so context menu won't close after previewing option key actions.