### PR TITLE
For Russian keyboard (exchange № and #)

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -445,6 +445,9 @@
         },
         {
           "path": "json/swedish_umlaut.json"
+        },
+        {
+          "path": "json/For Russian keyboard (exchange № and #).json"
         }
       ]
     },

--- a/public/json/For Russian keyboard (exchange № and #).json
+++ b/public/json/For Russian keyboard (exchange № and #).json
@@ -1,0 +1,66 @@
+{
+  "title": "For Russian keyboard (exchange № and #)",
+  "desciption": "Внутри файла находятся два правила, которые меняют поведение сочетания клавиш «shift + 3» и «alt + 3». На обычной русской раскладке «shift + 3» вернёт №, а «alt + 3» вернёт #. Я изменил это поведение. После применения правила русская раскладка на «shift + 3» вернёт #, а при «alt + 3» вернёт №. Inside the file there are two rules that change the behavior of the key combination «shift + 3» and «alt + 3». On a regular Russian layout, «shift + 3» will return №, and «alt + 3» will return #. I changed this behavior. After applying the rule, the Russian layout on the «shift + 3» will return #, and with «alt + 3» it will return №.",
+  "rules": [
+    {
+      "description": "На русской раскладке меняем поведение сочетания «shift + 3». Был №, а стала #",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "3",
+            "modifiers": {
+              "mandatory": ["shift"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "3",
+              "modifiers": ["left_option"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "На русской раскладке меняем поведение сочетания «alt + 3». Была #, а стал №",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "3",
+            "modifiers": {
+              "mandatory": ["left_option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "3",
+              "modifiers": ["shift"]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
(english below)

Мои первые правила для KE :)

Внутри файла находятся два правила, которые меняют поведение сочетания клавиш «shift + 3» и «alt + 3». На обычной русской раскладке «shift + 3» вернёт №, а «alt + 3» вернёт #. Я изменил это поведение. После применения правила русская раскладка на «shift + 3» вернёт #, а при «alt + 3» вернёт №.


My first rules for KE :)

Inside the file there are two rules that change the behavior of the key combination «shift + 3» and «alt + 3». On a regular Russian layout, «shift + 3» will return №, and «alt + 3» will return #. I changed this behavior. After applying the rule, the Russian layout on the «shift + 3» will return #, and with «alt + 3» it will return №.