### PR TITLE
added Esc to en_US/ABC keyboard for Vim user with non-English based users

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -613,6 +613,9 @@
         },
         {
           "path": "json/sinoridha_personal_mapping.json"
+        },
+        {
+          "path": "json/esc_to_eng_ime.json"
         }
       ]
     },

--- a/public/json/esc_to_eng_ime.json
+++ b/public/json/esc_to_eng_ime.json
@@ -1,0 +1,54 @@
+{
+   "title":"For Vim User Esc to en_US/ABC IME",
+   "rules":[
+      {
+         "description":"Esc to en_US",
+         "manipulators":[
+            {
+               "type":"basic",
+               "from":{
+                  "key_code":"escape"
+               },
+               "to_if_alone":[
+                  {
+                     "key_code":"escape"
+                  }
+               ],
+               "to_after_key_up":[
+                  {
+                     "select_input_source":{
+                        "input_source_id":"com.apple.keylayout.US",
+                        "language":"en"
+                     }
+                  }
+               ]
+            }
+         ]
+      },
+      {
+         "description":"Esc to ABC",
+         "manipulators":[
+            {
+               "type":"basic",
+               "from":{
+                  "key_code":"escape"
+               },
+               "to_if_alone":[
+                  {
+                     "key_code":"escape"
+                  }
+               ],
+               "to_after_key_up":[
+                  {
+                     "select_input_source":{
+                        "input_source_id":"com.apple.keylayout.ABC",
+                        "language":"en"
+                     }
+                  }
+               ]
+            }
+         ]
+      }
+   ]
+}
+


### PR DESCRIPTION
added Esc to en_US keyboard switch for Vim user with non-alphabet country(ex.CJK).