### PR TITLE
Added rule Keychron K2

### DIFF
--- a/public/extra_descriptions/keychron_k2.json.html
+++ b/public/extra_descriptions/keychron_k2.json.html
@@ -1,0 +1,11 @@
+<link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
+
+<h2>Keychron K2</h2>
+
+<p>This rule modifies the Keychron K2 keyboard layout to more closely resemble an Apple keyboard.</p>
+
+<ul>
+  <li>Changes right_control to right_option</li>
+  <li>Swaps right_command and fn</li>
+  <li>Disable page_up, page_down, home, and end</li>
+</ul>

--- a/public/groups.json
+++ b/public/groups.json
@@ -865,6 +865,16 @@
           "path": "json/command_h_j_k_l_u_i_to_left_down_up_right_home_end.json"
         }
       ]
+    },
+    {
+      "name": "Keychron K2",
+      "id": "Keychron K2",
+      "files": [
+        {
+          "path": "json/keychron_k2.json",
+          "extra_description_path": "extra_descriptions/keychron_k2.json.html"
+        }
+      ]
     }
   ],
 

--- a/public/json/keychron_k2.json
+++ b/public/json/keychron_k2.json
@@ -1,0 +1,97 @@
+{
+  "title": "Change Keychron K2 keyboard layout to more closely resemble an Apple keyboard",
+  "rules": [
+    {
+      "description": "Post right_option if right_control is pressed alone.",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_control"
+          },
+          "to": [
+            {
+              "key_code": "right_option"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Exchange right_command and fn.",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_command"
+          },
+          "to": [
+            {
+              "key_code": "fn"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "fn"
+          },
+          "to": [
+            {
+              "key_code": "right_command"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Disable page_up, page_down, home, and end.",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "page_up"
+          },
+          "to": [
+            {
+              "key_code": "vk_none"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "page_down"
+          },
+          "to": [
+            {
+              "key_code": "vk_none"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "home"
+          },
+          "to": [
+            {
+              "key_code": "vk_none"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "end"
+          },
+          "to": [
+            {
+              "key_code": "vk_none"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/keychron_k2.json.erb
+++ b/src/json/keychron_k2.json.erb
@@ -1,0 +1,55 @@
+{
+    "title": "Change Keychron K2 keyboard layout to more closely resemble an Apple keyboard",
+    "rules": [
+        {
+            "description": "Post right_option if right_control is pressed alone.",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("right_control", [], []) %>,
+                    "to": <%= to([["right_option"]]) %>
+                }
+            ]
+        },
+        {
+            "description": "Exchange right_command and fn.",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("right_command", [], []) %>,
+                    "to": <%= to([["fn"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("fn", [], []) %>,
+                    "to": <%= to([["right_command"]]) %>
+                }
+            ]
+        },
+        {
+            "description": "Disable page_up, page_down, home, and end.",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": <%= from("page_up", [], []) %>,
+                    "to": <%= to([["vk_none"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("page_down", [], []) %>,
+                    "to": <%= to([["vk_none"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("home", [], []) %>,
+                    "to": <%= to([["vk_none"]]) %>
+                },
+                {
+                    "type": "basic",
+                    "from": <%= from("end", [], []) %>,
+                    "to": <%= to([["vk_none"]]) %>
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This rule modifies the Keychron K2 keyboard layout to more closely resemble an Apple keyboard.

- Changes right_control to right_option
- Swaps right_command and fn
- Disable page_up, page_down, home, and end