### PR TITLE
Fixed Keychron K2 rule to work with any modifier key

### DIFF
--- a/public/json/keychron_k2.json
+++ b/public/json/keychron_k2.json
@@ -7,7 +7,12 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "right_control"
+            "key_code": "right_control",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
           },
           "to": [
             {
@@ -23,7 +28,12 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "right_command"
+            "key_code": "right_command",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
           },
           "to": [
             {
@@ -34,7 +44,12 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "fn"
+            "key_code": "fn",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
           },
           "to": [
             {
@@ -50,7 +65,12 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "page_up"
+            "key_code": "page_up",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
           },
           "to": [
             {
@@ -61,7 +81,12 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "page_down"
+            "key_code": "page_down",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
           },
           "to": [
             {
@@ -72,7 +97,12 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "home"
+            "key_code": "home",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
           },
           "to": [
             {
@@ -83,7 +113,12 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "end"
+            "key_code": "end",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
           },
           "to": [
             {

--- a/src/json/keychron_k2.json.erb
+++ b/src/json/keychron_k2.json.erb
@@ -6,7 +6,7 @@
             "manipulators": [
                 {
                     "type": "basic",
-                    "from": <%= from("right_control", [], []) %>,
+                    "from": <%= from("right_control", [], ["any"]) %>,
                     "to": <%= to([["right_option"]]) %>
                 }
             ]
@@ -16,12 +16,12 @@
             "manipulators": [
                 {
                     "type": "basic",
-                    "from": <%= from("right_command", [], []) %>,
+                    "from": <%= from("right_command", [], ["any"]) %>,
                     "to": <%= to([["fn"]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("fn", [], []) %>,
+                    "from": <%= from("fn", [], ["any"]) %>,
                     "to": <%= to([["right_command"]]) %>
                 }
             ]
@@ -31,22 +31,22 @@
             "manipulators": [
                 {
                     "type": "basic",
-                    "from": <%= from("page_up", [], []) %>,
+                    "from": <%= from("page_up", [], ["any"]) %>,
                     "to": <%= to([["vk_none"]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("page_down", [], []) %>,
+                    "from": <%= from("page_down", [], ["any"]) %>,
                     "to": <%= to([["vk_none"]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("home", [], []) %>,
+                    "from": <%= from("home", [], ["any"]) %>,
                     "to": <%= to([["vk_none"]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("end", [], []) %>,
+                    "from": <%= from("end", [], ["any"]) %>,
                     "to": <%= to([["vk_none"]]) %>
                 }
             ]


### PR DESCRIPTION
Previously, the rules would behave erratically based on the order in which key combinations are pressed.
e.g. shift+right_option+down_arrow would behave differently from right_option+shift+down_arrow.