### PR TITLE
Add Rule: From Command + ` to Escape

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -546,6 +546,9 @@
           "path": "json/command_esc_to_command_grave_accent.json"
         },
         {
+          "path": "json/command_grave_accent_and_tilde_to_escape.json"
+        },
+        {
           "path": "json/control_backspace_to_function_backspace.json"
         },
         {

--- a/public/json/command_grave_accent_and_tilde_to_escape.json
+++ b/public/json/command_grave_accent_and_tilde_to_escape.json
@@ -1,0 +1,24 @@
+{
+  "title": "Command + ` Grave Accent, Tilde to Esc",
+  "rules": [
+    {
+      "description": "Command + ` Grave Accent, Tilde to Esc",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "grave_accent_and_tilde",
+            "modifiers": {
+              "mandatory": ["command"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "escape"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds one new rule:

- Convert `cmd` + `` ` `` to `esc`