### PR TITLE
Add NuPhy NuType-F1 keyboard changes

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -747,6 +747,9 @@
         },
         {
           "path": "json/hub16-launchapps.json"
+        },
+        {
+          "path": "json/NuType-F1.json"
         }
       ]
     },

--- a/public/json/NuType-F1.json
+++ b/public/json/NuType-F1.json
@@ -1,0 +1,57 @@
+{
+  "title": "NuPhy NuType F1 keyboard",
+  "rules": [
+    {
+      "manipulators": [
+        {
+          "from": {
+            "modifiers": { "optional": ["any"], "mandatory": ["fn"] },
+            "key_code": "grave_accent_and_tilde"
+          },
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591,
+                  "is_keyboard": true
+                }
+              ],
+              "description": "NuPhy NuType F1 keyboards"
+            }
+          ],
+          "to": [{ "repeat": false, "key_code": "escape" }],
+          "type": "basic"
+        }
+      ],
+      "description": "Change fn+escape to escape"
+    },
+    {
+      "description": "Change escape to grave accent and tilde",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "escape",
+            "modifiers": { "optional": ["any"] }
+          },
+          "to": [{ "key_code": "grave_accent_and_tilde" }],
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452,
+                  "product_id": 591,
+                  "is_keyboard": true
+                }
+              ],
+              "description": "NuPhy NuType F1 keyboards"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
More information about this device:
https://nuphy.com

This change allows the keyboard to work more like expected experience.
In kickstarter page:
https://www.kickstarter.com/projects/nuphy/nutype-revolutionizing-the-laptop-typing-experience/description
this was the original intent, but then modified before shipping the
units to production:
> For example, you can press 'FN' + '~' to substitute the use of 'ESC' button.

When writting markdown it is normal to use '`' often to add some code
blocks. Having to press 'FN' to get the normal key to work doesn't seem
natural and doesn't work like other keyboards that have the 'ESC' button
in a different location (as expected - like new MacBook Pro 16").