### PR TITLE
Add Archiss Quattro TKL JIS layout

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -750,6 +750,9 @@
         },
         {
           "path": "json/NuType-F1.json"
+        },
+        {
+          "path": "json/quattro_tkl_for_mac_jis.json"
         }
       ]
     },

--- a/public/json/quattro_tkl_for_mac_jis.json
+++ b/public/json/quattro_tkl_for_mac_jis.json
@@ -1,0 +1,73 @@
+{
+  "title": "ARCHISS Quattro TKL for macOS JIS",
+  "rules": [
+    {
+      "description": "L-Button/R-Buttonを英数/かなへ代替",
+      "manipulators": [
+        {
+          "type": "basic",
+          "description": "L-Buttonを英数キーに",
+          "from": {
+            "pointing_button": "button1"
+          },
+          "to": [
+            {
+              "key_code": "japanese_eisuu",
+              "modifiers": []
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "description": "R-Buttonをかなキーに",
+          "from": {
+            "pointing_button": "button2"
+          },
+          "to": [
+            {
+              "key_code": "japanese_kana",
+              "modifiers": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Ctrl+Buttonをマウスクリックへ代替",
+      "manipulators": [
+        {
+          "type": "basic",
+          "description": "Ctrl + L-Buttonを左マウスクリックに",
+          "from": {
+            "pointing_button": "button1",
+            "modifiers": {
+              "mandatory": ["control"]
+            }
+          },
+          "to": [
+            {
+              "pointing_button": "button1",
+              "modifiers": []
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "description": "Ctrl + R-Buttonを右マウスクリック",
+          "from": {
+            "pointing_button": "button2",
+            "modifiers": {
+              "mandatory": ["control"]
+            }
+          },
+          "to": [
+            {
+              "pointing_button": "button2",
+              "modifiers": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
More information about this device
https://www.archisite.co.jp/products/archiss/quattro/tkl-jp/

Quattro TKL JIS is a Japanese keyboard device for PC.
This keyboard has a unique key layout that the left and right of the space key replace to mouse buttons.
But the Japanese general key layout for macOS has international keys  "Kana" and "Eisu" at the left and right of the space key. These necessary keys have been stolen, so that keyboard is very difficult to use as Japanese macOS users.

This rule recovers and replaces the international keys for Quattro TKL JIS.