### PR TITLE
added eject to screenshot rule

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -600,6 +600,9 @@
         },
         {
           "path": "json/esc_to_eng_ime.json"
+        },
+        {
+          "path": "json/eject_take_screenshot.json"
         }
       ]
     },

--- a/public/json/eject_take_screenshot.json
+++ b/public/json/eject_take_screenshot.json
@@ -1,0 +1,25 @@
+{
+    "title": "Maps Eject to Screenshot",
+    "rules": [
+        {
+            "description": "Eject to Screenshot",
+            "manipulators": [
+                {
+                    "from": {
+                        "consumer_key_code": "eject"
+                    },
+                    "to": [
+                        {
+                            "key_code": "5",
+                            "modifiers": [
+                                "left_command",
+                                "left_shift"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Simple rule that maps Eject key from magic keyboard to shift-cmd-5 (screenshot)