### PR TITLE
Add keychron K6 f1 helper shortcuts

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -715,6 +715,9 @@
         },
         {
           "path": "json/quattro_tkl_for_mac_jis.json"
+        },
+        {
+          "path": "json/KeychronK6F1HelperShortcuts.json"
         }
       ]
     },

--- a/public/json/KeychronK6F1HelperShortcuts.json
+++ b/public/json/KeychronK6F1HelperShortcuts.json
@@ -1,0 +1,74 @@
+{
+  "title": "Keychron K6 Fn1 Shortcuts",
+  "rules": [
+    {
+      "description": "Shift + Esc to ` Grave Accent",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "escape",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Control + Esc to Tilde",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "escape",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "shift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Command + Esc to Command + Tilda",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "escape",
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "command"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Keychron has <code>\`</code> and `~` on Escape key and to use them one needs to use their f1 helper key 

- `f1` + `esc` = `grave`
- `f1` + `shift` + `esc` = `tilde`
- `f1`+ `shift` + `command` + `esc` = `command` + `esc` (to switch windows of same app)

This commit adds shortcuts for those