### PR TITLE
Add RShift+ESC to tilde for HHKB Professional 2

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -63,6 +63,9 @@
         },
         {
           "path": "json/windows_like_word_bindings.json"
+        },
+        {
+          "path": "json/remap_rshift_esc_to_tilde.json"
         }
       ]
     },

--- a/public/json/remap_rshift_esc_to_tilde.json
+++ b/public/json/remap_rshift_esc_to_tilde.json
@@ -1,0 +1,24 @@
+{
+  "title": "Remap R_Shift+ESC to Tilde rules",
+  "rules": [{
+    "description": "Remap R_Shift+ESC to Tilde",
+    "manipulators": [{
+      "type": "basic",
+      "from": {
+        "key_code": "escape",
+        "modifiers": {
+          "mandatory": "right_shift",
+          "optional": [
+            "any"
+          ]
+        }
+      },
+      "to": [{
+        "key_code": "grave_accent_and_tilde",
+        "modifiers": [
+          "left_shift"
+        ]
+      }]
+    }]
+  }]
+}


### PR DESCRIPTION
  In the HHKB Professional 2 layout, it is very difficult to input the tilde, so map RShift+ESC to the tilde.