### PR TITLE
Added rshift up if alone rule

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -66,6 +66,9 @@
         },
         {
           "path": "json/remap_rshift_esc_to_tilde.json"
+        },
+        {
+          "path": "json/rshift_up_if_alone.json"
         }
       ]
     },

--- a/public/json/rshift_up_if_alone.json
+++ b/public/json/rshift_up_if_alone.json
@@ -1,0 +1,31 @@
+{
+  "title": "Right Shift Up if alone",
+  "rules": [
+    {
+      "description": "Right Shift Up if alone",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_shift",
+            "modifiers": {
+              "optional": ["any"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_shift",
+              "lazy": true
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "up_arrow"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+


### PR DESCRIPTION
This rule would allow the normal usage of shift in combination with other keys, but allows us to use it as an up key when pressed alone. This is inspired by https://youtu.be/XT2ZmuBbpFE?t=94