### PR TITLE
Add auto_close_brackets_and_quotes.json

### DIFF
--- a/public/extra_descriptions/auto_close_brackets_and_quotes.json.html
+++ b/public/extra_descriptions/auto_close_brackets_and_quotes.json.html
@@ -1,0 +1,21 @@
+<link rel="stylesheet" href="../../vendor/css/bootstrap.min.css"/>
+
+<h2 id="karabiner-auto-quotes">Karabiner Auto Quotes</h2>
+
+<p>A complex modification that automatically closes brackets and quotes while typing. It does the following:</p>
+
+<ul>
+  <li>Typing a <kbd>(</kbd> is automatically followed by a <kbd>)</kbd> and placing the cursor between them</li>
+  <li><kbd>'</kbd></li> is followed by a <kbd>'</kbd>
+  <li>"</li> by another <kbd></kbd>"
+  <li>`</li> by <kbd>`</kbd>
+  <li>[</li> by <kbd>]</kbd>
+  <li>{</li> by <kbd>}</kbd>
+  <li>“</li> by <kbd>”</kbd>
+  <li>‘</li> by <kbd>’</kbd>
+  <li><</li> by <kbd>></kbd>
+</ul>
+
+<p>For normal behavior (i.e. to type a single one of these) hold <kbd>fn</kbd>. For example <kbd>fn</kbd>+<kbd>'</kbd> types one single quote.</p>
+
+<p>It contains exceptions for Atom, iTerm, PyCharm and VSCodium, because all of these already have their own intelligent quote and bracket handling.</p>

--- a/public/groups.json
+++ b/public/groups.json
@@ -446,181 +446,127 @@
     {
       "name": "Key Specific",
       "id": "key-specific",
-      "files": [{
-          "path": "json/ctrl_L-OR-ctrl_R+up-to-down-arrow.json"
-        },
-        {
-          "path": "json/ctrl-to-shift.json"
-        },
-        {
-          "path": "json/ctrlquote.json"
-        },
-        {
-          "path": "json/escape.json"
-        },
-        {
-          "path": "json/change_grave_accent_to_escape.json"
-        },
-        {
-          "path": "json/modifiers_to_f-keys.json"
-        },
-        {
-          "path": "json/modifiers_to_arrows.json"
-        },
-        {
-          "path": "json/return_to_ctrl.json"
-        },
-        {
-          "path": "json/delete.json"
-        },
-        {
-          "path": "json/fn_backspace_to_forward_delete.json"
-        },
-        {
-          "path": "json/wolfXu.json"
-        },
-        {
-          "path": "json/accute_accent_deadkey_azerty.json",
-          "extra_description_path": "extra_descriptions/accute_accent_deadkey_azerty.json.html"
-        },
-        {
-          "path": "json/section_sign_to_escape.json"
-        },
-        {
-          "path": "json/exchange_command_tab_and_control_tab.json"
-        },
-        {
-          "path": "json/exchange_numbers_and_symbols.json"
-        },
-        {
-          "path": "json/exchange_semicolon_and_colon.json"
-        },
-        {
-          "path": "json/exchange_single_and_double_quote.json"
-        },
-        {
-          "path": "json/exchange_square_brackets_and_curly_brackets.json"
-        },
-        {
-          "path": "json/swap-paren-and-sqbrackets.json"
-        },
-        {
-          "path": "json/nonbreaking_space.json"
-        },
-        {
-          "path": "json/spacebar.json"
-        },
-        {
-          "path": "json/command_arrows_to_option_arrows.json"
-        },
-        {
-          "path": "json/command_arrows_to_ctrl_arrows.json"
-        },
-        {
-          "path": "json/ctrl_arrows_to_option_arrows.json"
-        },
-        {
-          "path": "json/ctrl_delete.json"
-        },
-        {
-          "path": "json/ctrl_forward_delete.json"
-        },
-        {
-          "path": "json/command_esc_to_command_grave_accent.json"
-        },
-        {
-          "path": "json/command_grave_accent_and_tilde_to_escape.json"
-        },
-        {
-          "path": "json/control_backspace_to_function_backspace.json"
-        },
-        {
-          "path": "json/exchange_command_backspace_and_option_backspace.json"
-        },
-        {
-          "path": "json/exchange_command_del-forward_and_option_del-forward.json"
-        },
-        {
-          "path": "json/mouse_button4_to_double_click.json"
-        },
-        {
-          "path": "json/mousebutton4tocontrolz.json"
-        },
-        {
-          "path": "json/mousebutton5tocontrolmouse1.json"
-        },
-        {
-          "path": "json/mouse_button.json"
-        },
-        {
-          "path": "json/mousebuttons_copy_paste_screenshot.json"
-        },
-        {
-          "path": "json/equals_del_to_forward_del.json"
-        },
-        {
-          "path": "json/command_r_and_shift_r_to_command_tab.json"
-        },
-        {
-          "path": "json/fn_grave_accent.json"
-        },
-        {
-          "path": "json/standard_function_keys_on_fn.json",
-          "extra_description_path": "extra_descriptions/standard_function_keys_on_fn.json.html"
-        },
-        {
-          "path": "json/fn-copy-paste.json"
-        },
-        {
-          "path": "json/f12-to-dev-tools-networking-mac-ff.json"
-        },
-        {
-          "path": "json/screenshot_f3.json"
-        },
-        {
-          "path": "json/leftclick.json"
-        },
-        {
-          "path": "json/lshift_to_escape.json"
-        },
-        {
-          "path": "json/spacebar_changes.json"
-        },
-        {
-          "path": "json/exchange_left_paren_and_semicolon.json"
-        },
-        {
-          "path": "json/media_key_only_control_itunes.json",
-          "extra_description_path": "extra_descriptions/media_key_only_control_itunes.html"
-        },
-        {
-          "path": "json/option-fb-to-option-arrows.json"
-        },
-        {
-          "path": "json/control_comma_period.json"
-        },
-        {
-          "path": "json/focusaperture_Controls_Media_Playback_and_Screen_Brightness.json"
-        },
-        {
-          "path": "json/f14_to_copy_f15_to_paste.json"
-        },
-        {
-          "path": "json/print_screen_to_command_shift_4.json"
-        },
-        {
-          "path": "json/f2_cut_f3_copy_f4_paste.json"
-        },
-        {
-          "path": "json/sinoridha_personal_mapping.json"
-        },
-        {
-          "path": "json/esc_to_eng_ime.json"
-        },
-        {
-          "path": "json/eject_take_screenshot.json"
-        }
-      ]
+      "files":     [{
+        "path": "json/accute_accent_deadkey_azerty.json",
+        "extra_description_path": "extra_descriptions/accute_accent_deadkey_azerty.json.html"
+      }, {
+        "path": "json/auto_close_brackets_and_quotes.json",
+        "extra_description_path": "extra_descriptions/auto_close_brackets_and_quotes.json.html"
+      }, {
+        "path": "json/change_grave_accent_to_escape.json"
+      }, {
+        "path": "json/command_arrows_to_ctrl_arrows.json"
+      }, {
+        "path": "json/command_arrows_to_option_arrows.json"
+      }, {
+        "path": "json/command_esc_to_command_grave_accent.json"
+      }, {
+        "path": "json/command_grave_accent_and_tilde_to_escape.json"
+      }, {
+        "path": "json/command_r_and_shift_r_to_command_tab.json"
+      }, {
+        "path": "json/control_backspace_to_function_backspace.json"
+      }, {
+        "path": "json/control_comma_period.json"
+      }, {
+        "path": "json/ctrl-to-shift.json"
+      }, {
+        "path": "json/ctrl_L-OR-ctrl_R+up-to-down-arrow.json"
+      }, {
+        "path": "json/ctrl_arrows_to_option_arrows.json"
+      }, {
+        "path": "json/ctrl_delete.json"
+      }, {
+        "path": "json/ctrl_forward_delete.json"
+      }, {
+        "path": "json/ctrlquote.json"
+      }, {
+        "path": "json/delete.json"
+      }, {
+        "path": "json/eject_take_screenshot.json"
+      }, {
+        "path": "json/equals_del_to_forward_del.json"
+      }, {
+        "path": "json/esc_to_eng_ime.json"
+      }, {
+        "path": "json/escape.json"
+      }, {
+        "path": "json/exchange_command_backspace_and_option_backspace.json"
+      }, {
+        "path": "json/exchange_command_del-forward_and_option_del-forward.json"
+      }, {
+        "path": "json/exchange_command_tab_and_control_tab.json"
+      }, {
+        "path": "json/exchange_left_paren_and_semicolon.json"
+      }, {
+        "path": "json/exchange_numbers_and_symbols.json"
+      }, {
+        "path": "json/exchange_semicolon_and_colon.json"
+      }, {
+        "path": "json/exchange_single_and_double_quote.json"
+      }, {
+        "path": "json/exchange_square_brackets_and_curly_brackets.json"
+      }, {
+        "path": "json/f12-to-dev-tools-networking-mac-ff.json"
+      }, {
+        "path": "json/f14_to_copy_f15_to_paste.json"
+      }, {
+        "path": "json/f2_cut_f3_copy_f4_paste.json"
+      }, {
+        "path": "json/fn-copy-paste.json"
+      }, {
+        "path": "json/fn_backspace_to_forward_delete.json"
+      }, {
+        "path": "json/fn_grave_accent.json"
+      }, {
+        "path": "json/focusaperture_Controls_Media_Playback_and_Screen_Brightness.json"
+      }, {
+        "path": "json/leftclick.json"
+      }, {
+        "path": "json/lshift_to_escape.json"
+      }, {
+        "path": "json/media_key_only_control_itunes.json",
+        "extra_description_path": "extra_descriptions/media_key_only_control_itunes.html"
+      }, {
+        "path": "json/modifiers_to_arrows.json"
+      }, {
+        "path": "json/modifiers_to_f-keys.json"
+      }, {
+        "path": "json/mouse_button.json"
+      }, {
+        "path": "json/mouse_button4_to_double_click.json"
+      }, {
+        "path": "json/mousebutton4tocontrolz.json"
+      }, {
+        "path": "json/mousebutton5tocontrolmouse1.json"
+      }, {
+        "path": "json/mousebuttons_copy_paste_screenshot.json"
+      }, {
+        "path": "json/nonbreaking_space.json"
+      }, {
+        "path": "json/option-fb-to-option-arrows.json"
+      }, {
+        "path": "json/print_screen_to_command_shift_4.json"
+      }, {
+        "path": "json/return_to_ctrl.json"
+      }, {
+        "path": "json/screenshot_f3.json"
+      }, {
+        "path": "json/section_sign_to_escape.json"
+      }, {
+        "path": "json/sinoridha_personal_mapping.json"
+      }, {
+        "path": "json/spacebar.json"
+      }, {
+        "path": "json/spacebar_changes.json"
+      }, {
+        "path": "json/standard_function_keys_on_fn.json",
+        "extra_description_path": "extra_descriptions/standard_function_keys_on_fn.json.html"
+      }, {
+        "path": "json/swap-paren-and-sqbrackets.json"
+      }, {
+        "path": "json/wolfXu.json"
+      }]
     },
     {
       "name": "OS Functionality",

--- a/public/json/auto_close_brackets_and_quotes.json
+++ b/public/json/auto_close_brackets_and_quotes.json
@@ -1,0 +1,605 @@
+{
+  "title": "Auto close brackets & quotes",
+  "maintainers": [
+    "harmtemolder"
+  ],
+  "rules": [
+    {
+      "description": "(1/2) Do not auto close brackets & quotes when holding fn",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "9",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "9",
+              "modifiers": [
+                "shift"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.github.atom",
+                "com.googlecode.iterm2",
+                "com.jetbrains.pycharm",
+                "com.visualstudio.code.oss"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "quote",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "quote"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.github.atom",
+                "com.googlecode.iterm2",
+                "com.jetbrains.pycharm",
+                "com.visualstudio.code.oss"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "quote",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "quote",
+              "modifiers": [
+                "shift"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.github.atom",
+                "com.googlecode.iterm2",
+                "com.jetbrains.pycharm",
+                "com.visualstudio.code.oss"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "grave_accent_and_tilde",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.github.atom",
+                "com.googlecode.iterm2",
+                "com.jetbrains.pycharm",
+                "com.visualstudio.code.oss"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "open_bracket",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "open_bracket"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.github.atom",
+                "com.googlecode.iterm2",
+                "com.jetbrains.pycharm",
+                "com.visualstudio.code.oss"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "open_bracket",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "open_bracket",
+              "modifiers": [
+                "shift"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.github.atom",
+                "com.googlecode.iterm2",
+                "com.jetbrains.pycharm",
+                "com.visualstudio.code.oss"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "open_bracket",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "open_bracket",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.github.atom",
+                "com.googlecode.iterm2",
+                "com.jetbrains.pycharm",
+                "com.visualstudio.code.oss"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "close_bracket",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "close_bracket",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.github.atom",
+                "com.googlecode.iterm2",
+                "com.jetbrains.pycharm",
+                "com.visualstudio.code.oss"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "comma",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "comma",
+              "modifiers": [
+                "shift"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.github.atom",
+                "com.googlecode.iterm2",
+                "com.jetbrains.pycharm",
+                "com.visualstudio.code.oss"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "(2/2) Auto close brackets & quotes ( (), '', \"\", ``, [], {}, \u201c\u201d, \u2018\u2019, <> )",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "9",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "9",
+              "modifiers": [
+                "shift"
+              ]
+            },
+            {
+              "key_code": "0",
+              "modifiers": [
+                "shift"
+              ]
+            },
+            {
+              "key_code": "left_arrow"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.github.atom",
+                "com.googlecode.iterm2",
+                "com.jetbrains.pycharm",
+                "com.visualstudio.code.oss"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "quote"
+          },
+          "to": [
+            {
+              "key_code": "quote"
+            },
+            {
+              "key_code": "quote"
+            },
+            {
+              "key_code": "left_arrow"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.github.atom",
+                "com.googlecode.iterm2",
+                "com.jetbrains.pycharm",
+                "com.visualstudio.code.oss"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "quote",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "quote",
+              "modifiers": [
+                "shift"
+              ]
+            },
+            {
+              "key_code": "quote",
+              "modifiers": [
+                "shift"
+              ]
+            },
+            {
+              "key_code": "left_arrow"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.github.atom",
+                "com.googlecode.iterm2",
+                "com.jetbrains.pycharm",
+                "com.visualstudio.code.oss"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "grave_accent_and_tilde"
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde"
+            },
+            {
+              "key_code": "grave_accent_and_tilde"
+            },
+            {
+              "key_code": "left_arrow"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.github.atom",
+                "com.googlecode.iterm2",
+                "com.jetbrains.pycharm",
+                "com.visualstudio.code.oss"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "open_bracket"
+          },
+          "to": [
+            {
+              "key_code": "open_bracket"
+            },
+            {
+              "key_code": "close_bracket"
+            },
+            {
+              "key_code": "left_arrow"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.github.atom",
+                "com.googlecode.iterm2",
+                "com.jetbrains.pycharm",
+                "com.visualstudio.code.oss"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "open_bracket",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "open_bracket",
+              "modifiers": [
+                "shift"
+              ]
+            },
+            {
+              "key_code": "close_bracket",
+              "modifiers": [
+                "shift"
+              ]
+            },
+            {
+              "key_code": "left_arrow"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.github.atom",
+                "com.googlecode.iterm2",
+                "com.jetbrains.pycharm",
+                "com.visualstudio.code.oss"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "open_bracket",
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "open_bracket",
+              "modifiers": [
+                "option"
+              ]
+            },
+            {
+              "key_code": "open_bracket",
+              "modifiers": [
+                "option",
+                "shift"
+              ]
+            },
+            {
+              "key_code": "left_arrow"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.github.atom",
+                "com.googlecode.iterm2",
+                "com.jetbrains.pycharm",
+                "com.visualstudio.code.oss"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "close_bracket",
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "close_bracket",
+              "modifiers": [
+                "option"
+              ]
+            },
+            {
+              "key_code": "close_bracket",
+              "modifiers": [
+                "option",
+                "shift"
+              ]
+            },
+            {
+              "key_code": "left_arrow"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.github.atom",
+                "com.googlecode.iterm2",
+                "com.jetbrains.pycharm",
+                "com.visualstudio.code.oss"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "comma",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "comma",
+              "modifiers": [
+                "shift"
+              ]
+            },
+            {
+              "key_code": "period",
+              "modifiers": [
+                "shift"
+              ]
+            },
+            {
+              "key_code": "left_arrow"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.github.atom",
+                "com.googlecode.iterm2",
+                "com.jetbrains.pycharm",
+                "com.visualstudio.code.oss"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I've been running this mod for a while now so I feel it is ready to be published here: It automatically closes brackets and quotes when you type the left one. E.g. typing a <kbd>(</kbd> will automatically be followed by a <kbd>)</kbd>, after which the cursor is placed between the two. Holding <kbd>fn</kbd> negates this behavior, in case you want to type a single <kbd>'</kbd>, for example.