### PR TITLE
Fix Ultimate MacOS config

### DIFF
--- a/public/json/ultimate_macOS.json
+++ b/public/json/ultimate_macOS.json
@@ -2,10 +2,11 @@
     "title": "ultimate macOS",
     "maintainers": ["suliveevil"],
     "homepage": "https://github.com/suliveevil/Capslock",
-    "import_url": "karabiner://karabiner/assets/complex_modifications/import?url=https://raw.githubusercontent.com/suliveevil/Capslock/master/mac/ultimate_macOS.json",
+    "import_url": "karabiner://karabiner/assets/complex_modifications/import?url=https://github.com/pqrs-org/KE-complex_modifications/raw/master/public/json/ultimate_macOS.json",
     "rules": [
         {
-            "description": "ultimate macOS (version: 1556140182)"
+            "description": "ultimate macOS (version: 1556140182)",
+            "manipulators": [{}]
         },
         {
             "description": "KBD: BluetoothConverter、IKBC_C87、XD60: Swap Win/CMD and Alt/Opt",


### PR DESCRIPTION
Fixes #716.

Importing "Ultimate MacOS" config failed due to no `manipulators` in the first rule.
Added an empty `manipulators` to fix it and also changed `import_url`.