### PR TITLE
Neo2: toggle mod4 lock by pressing left & right mod4 key simultaneously (#747 follow-up)

### DIFF
--- a/public/json/neo2.json
+++ b/public/json/neo2.json
@@ -2,7 +2,7 @@
   "title": "Neo2",
   "rules": [
     {
-      "description": "Neo2 mod 3 and 4 keys (Apple keyboard)",
+      "description": "Neo2 mod 3 and 4 keys (Apple keyboard). Toggle mod4 by pressing both mod4 keys simultaneously.",
       "manipulators": [
         {
           "type": "basic",
@@ -55,24 +55,27 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "grave_accent_and_tilde",
-            "modifiers": {
-              "optional": [
-                "any"
-              ]
-            }
+            "simultaneous": [
+              {
+                "key_code": "grave_accent_and_tilde"
+              },
+              {
+                "key_code": "right_command"
+              }
+            ]
           },
-          "to_if_alone": [
+          "to": [
             {
               "set_variable": {
                 "name": "neo2_mod_4",
-                "value": 0
-              }
+                "value": 2
+              },
+              "halt": true
             }
           ],
           "conditions": [
             {
-              "type": "variable_if",
+              "type": "variable_unless",
               "name": "neo2_mod_4",
               "value": 2
             }
@@ -81,14 +84,16 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "right_command",
-            "modifiers": {
-              "optional": [
-                "any"
-              ]
-            }
+            "simultaneous": [
+              {
+                "key_code": "grave_accent_and_tilde"
+              },
+              {
+                "key_code": "right_command"
+              }
+            ]
           },
-          "to_if_alone": [
+          "to": [
             {
               "set_variable": {
                 "name": "neo2_mod_4",
@@ -120,15 +125,6 @@
                 "name": "neo2_mod_4",
                 "value": 1
               }
-            }
-          ],
-          "to_if_alone": [
-            {
-              "set_variable": {
-                "name": "neo2_mod_4",
-                "value": 2
-              },
-              "halt": true
             }
           ],
           "to_after_key_up": [
@@ -163,15 +159,6 @@
                 "name": "neo2_mod_4",
                 "value": 1
               }
-            }
-          ],
-          "to_if_alone": [
-            {
-              "set_variable": {
-                "name": "neo2_mod_4",
-                "value": 2
-              },
-              "halt": true
             }
           ],
           "to_after_key_up": [
@@ -193,7 +180,7 @@
       ]
     },
     {
-      "description": "Neo2 mod 3 and 4 keys (Windows keyboard)",
+      "description": "Neo2 mod 3 and 4 keys (Windows keyboard). Toggle mod4 by pressing both mod4 keys simultaneously.",
       "manipulators": [
         {
           "type": "basic",
@@ -246,24 +233,27 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "non_us_backslash",
-            "modifiers": {
-              "optional": [
-                "any"
-              ]
-            }
+            "simultaneous": [
+              {
+                "key_code": "non_us_backslash"
+              },
+              {
+                "key_code": "right_command"
+              }
+            ]
           },
-          "to_if_alone": [
+          "to": [
             {
               "set_variable": {
                 "name": "neo2_mod_4",
-                "value": 0
-              }
+                "value": 2
+              },
+              "halt": true
             }
           ],
           "conditions": [
             {
-              "type": "variable_if",
+              "type": "variable_unless",
               "name": "neo2_mod_4",
               "value": 2
             }
@@ -272,14 +262,16 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "right_command",
-            "modifiers": {
-              "optional": [
-                "any"
-              ]
-            }
+            "simultaneous": [
+              {
+                "key_code": "non_us_backslash"
+              },
+              {
+                "key_code": "right_command"
+              }
+            ]
           },
-          "to_if_alone": [
+          "to": [
             {
               "set_variable": {
                 "name": "neo2_mod_4",
@@ -311,15 +303,6 @@
                 "name": "neo2_mod_4",
                 "value": 1
               }
-            }
-          ],
-          "to_if_alone": [
-            {
-              "set_variable": {
-                "name": "neo2_mod_4",
-                "value": 2
-              },
-              "halt": true
             }
           ],
           "to_after_key_up": [
@@ -354,15 +337,6 @@
                 "name": "neo2_mod_4",
                 "value": 1
               }
-            }
-          ],
-          "to_if_alone": [
-            {
-              "set_variable": {
-                "name": "neo2_mod_4",
-                "value": 2
-              },
-              "halt": true
             }
           ],
           "to_after_key_up": [

--- a/src/json/neo2.json.erb
+++ b/src/json/neo2.json.erb
@@ -27,7 +27,21 @@
                         "right_command",
                     ],
                     from_optional_modifiers: ["any"]
-                ) + [mod_4_key, "right_command"].map { |from_key|
+                ) + [mod_4_key].map { |from_key|
+                    {
+                        "type" => "basic",
+                        "from" => { "simultaneous" => [ { "key_code" => from_key }, { "key_code" => "right_command" } ] },
+                        "to" => [ set_mod_4(2, true) ],
+                        "conditions" => [ $if_mod_4_not_locked ]
+                    }
+                } + [mod_4_key].map { |from_key|
+                    {
+                        "type" => "basic",
+                        "from" => { "simultaneous" => [ { "key_code" => from_key }, { "key_code" => "right_command" } ] },
+                        "to" => [ set_mod_4(0) ],
+                        "conditions" => [ $if_mod_4_locked ]
+                    }
+                } + [mod_4_key, "right_command"].map { |from_key|
                     {
                         "type" => "basic",
                         "from" => _from(from_key, [], ["any"]),
@@ -39,50 +53,12 @@
             )
         end %>
         {
-            "description": "Neo2 mod 3 and 4 keys (Apple keyboard)",
+            "description": "Neo2 mod 3 and 4 keys (Apple keyboard). Toggle mod4 by pressing both mod4 keys simultaneously.",
             "manipulators": <%= neo2_modifiers("backslash", "grave_accent_and_tilde") %>
         },
         {
-            "description": "Neo2 mod 3 and 4 keys (Windows keyboard)",
+            "description": "Neo2 mod 3 and 4 keys (Windows keyboard). Toggle mod4 by pressing both mod4 keys simultaneously.",
             "manipulators": <%= neo2_modifiers("non_us_pound", "non_us_backslash") %>
-        },
-        {
-            "description": "Toggle mod4 by pressing grave_accent_and_tilde + right_command at the same time",
-            "manipulators": [
-                    <%= JSON.generate(
-                        {
-                            "type": "basic",
-                            "from": {
-                                "simultaneous": [
-                                    { "key_code": "grave_accent_and_tilde" },
-                                    { "key_code": "right_command" },
-                                ],
-                                "modifiers": {
-                                    "mandatory": [],
-                                    "optional": []
-                                }
-                            },
-                            "to": [ set_mod_4(2, true) ],
-                            "conditions": [ $if_mod_4_not_locked ]
-                        } ) %>,
-                    <%= JSON.generate(
-                        {
-                            "type": "basic",
-                            "from": {
-                                "simultaneous": [
-                                    { "key_code": "grave_accent_and_tilde" },
-                                    { "key_code": "right_command" },
-                                ],
-                                "modifiers": {
-                                    "mandatory": [],
-                                    "optional": []
-                                }
-                            },
-                            "to": [ set_mod_4(0) ],
-                            "conditions": [ $if_mod_4_locked ]
-                        }
-                    ) %>
-            ]
         },
         {
             "description": "Neo2 layer 4",

--- a/src/json/neo2.json.erb
+++ b/src/json/neo2.json.erb
@@ -31,15 +31,7 @@
                     {
                         "type" => "basic",
                         "from" => _from(from_key, [], ["any"]),
-                        "to_if_alone" => [set_mod_4(0)],
-                        "conditions" => [$if_mod_4_locked]
-                    }
-                } + [mod_4_key, "right_command"].map { |from_key|
-                    {
-                        "type" => "basic",
-                        "from" => _from(from_key, [], ["any"]),
                         "to" => [set_mod_4(1)],
-                        "to_if_alone" => [set_mod_4(2, true)],
                         "to_after_key_up" => [set_mod_4(0)],
                         "conditions" => [$if_mod_4_not_locked]
                     }
@@ -53,6 +45,44 @@
         {
             "description": "Neo2 mod 3 and 4 keys (Windows keyboard)",
             "manipulators": <%= neo2_modifiers("non_us_pound", "non_us_backslash") %>
+        },
+        {
+            "description": "Toggle mod4 by pressing grave_accent_and_tilde + right_command at the same time",
+            "manipulators": [
+                    <%= JSON.generate(
+                        {
+                            "type": "basic",
+                            "from": {
+                                "simultaneous": [
+                                    { "key_code": "grave_accent_and_tilde" },
+                                    { "key_code": "right_command" },
+                                ],
+                                "modifiers": {
+                                    "mandatory": [],
+                                    "optional": []
+                                }
+                            },
+                            "to": [ set_mod_4(2, true) ],
+                            "conditions": [ $if_mod_4_not_locked ]
+                        } ) %>,
+                    <%= JSON.generate(
+                        {
+                            "type": "basic",
+                            "from": {
+                                "simultaneous": [
+                                    { "key_code": "grave_accent_and_tilde" },
+                                    { "key_code": "right_command" },
+                                ],
+                                "modifiers": {
+                                    "mandatory": [],
+                                    "optional": []
+                                }
+                            },
+                            "to": [ set_mod_4(0) ],
+                            "conditions": [ $if_mod_4_locked ]
+                        }
+                    ) %>
+            ]
         },
         {
             "description": "Neo2 layer 4",


### PR DESCRIPTION
This is a follow up from github.com/pqrs-org/KE-complex_modifications/pull/747. It allows to toggle mod4 (level4) lock by pressing left & right mod4 keys simultaneously. 
Previously this mode toggle was implemented by just hitting a single mod4 key alone. As some community members weren't happy with this solution I changed it to an implementation which behaves similar to the Linux layout for consistency.
Now the implementation works as follows:

- Rule "Neo2 mod 3 and 4 keys (Apple keyboard).": keys `grave_accent_and_tilde` + `right_command` toggle mod4
- Rule "Neo2 mod 3 and 4 keys (Windows keyboard).": keys `non_us_backslash` + `right_command` toggle mod4

@jgosmann, @christophebeling, @neoissue please check. I would love to get your feedback :-)