### PR TITLE
Use webfactory/ssh-agent@v0.4.1 in deploy pipeline

### DIFF
--- a/.github/workflows/update-gh-pages.yml
+++ b/.github/workflows/update-gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 1
       - name: build
         run: make
-      - uses: webfactory/ssh-agent@v0.2.0
+      - uses: webfactory/ssh-agent@v0.4.1
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: deploy


### PR DESCRIPTION
This should fix the problem with the deprecated set-env command [according to the changelog](https://github.com/webfactory/ssh-agent/blob/master/CHANGELOG.md#v041-2020-10-07).

Example of failure: https://github.com/pqrs-org/KE-complex_modifications/runs/1438517877