### PR TITLE
Map esc to grave accent and tilde

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -83,6 +83,9 @@
         },
         {
           "path": "json/mouse_key_gesture.json"
+        },
+        {
+          "path": "json/map_esc_grave_accent_and_tilde.json"
         }
       ]
     },

--- a/public/json/colemak_dh_ansi_layout.json
+++ b/public/json/colemak_dh_ansi_layout.json
@@ -682,7 +682,7 @@
           },
           "to": [
             {
-              "key_code": "m"
+              "key_code": "k"
             }
           ]
         },
@@ -924,7 +924,7 @@
           },
           "to": [
             {
-              "key_code": "k"
+              "key_code": "m"
             }
           ]
         },
@@ -1877,7 +1877,7 @@
           },
           "to": [
             {
-              "key_code": "m",
+              "key_code": "k",
               "modifiers": [
                 "left_shift"
               ]
@@ -2185,7 +2185,7 @@
           },
           "to": [
             {
-              "key_code": "k",
+              "key_code": "m",
               "modifiers": [
                 "left_shift"
               ]
@@ -3165,7 +3165,7 @@
           },
           "to": [
             {
-              "key_code": "m",
+              "key_code": "k",
               "modifiers": [
                 "right_shift"
               ]
@@ -3473,7 +3473,7 @@
           },
           "to": [
             {
-              "key_code": "k",
+              "key_code": "m",
               "modifiers": [
                 "right_shift"
               ]
@@ -4297,7 +4297,7 @@
           },
           "to": [
             {
-              "key_code": "m"
+              "key_code": "k"
             }
           ]
         },
@@ -4539,7 +4539,7 @@
           },
           "to": [
             {
-              "key_code": "k"
+              "key_code": "m"
             }
           ]
         },
@@ -5498,7 +5498,7 @@
           },
           "to": [
             {
-              "key_code": "m",
+              "key_code": "k",
               "modifiers": [
                 "left_shift"
               ]
@@ -5806,7 +5806,7 @@
           },
           "to": [
             {
-              "key_code": "k",
+              "key_code": "m",
               "modifiers": [
                 "left_shift"
               ]
@@ -6786,7 +6786,7 @@
           },
           "to": [
             {
-              "key_code": "m",
+              "key_code": "k",
               "modifiers": [
                 "right_shift"
               ]
@@ -7094,7 +7094,7 @@
           },
           "to": [
             {
-              "key_code": "k",
+              "key_code": "m",
               "modifiers": [
                 "right_shift"
               ]
@@ -7890,7 +7890,7 @@
           },
           "to": [
             {
-              "key_code": "m"
+              "key_code": "k"
             }
           ]
         },
@@ -8132,7 +8132,7 @@
           },
           "to": [
             {
-              "key_code": "k"
+              "key_code": "m"
             }
           ]
         },
@@ -9091,7 +9091,7 @@
           },
           "to": [
             {
-              "key_code": "m",
+              "key_code": "k",
               "modifiers": [
                 "left_shift"
               ]
@@ -9399,7 +9399,7 @@
           },
           "to": [
             {
-              "key_code": "k",
+              "key_code": "m",
               "modifiers": [
                 "left_shift"
               ]
@@ -10379,7 +10379,7 @@
           },
           "to": [
             {
-              "key_code": "m",
+              "key_code": "k",
               "modifiers": [
                 "right_shift"
               ]
@@ -10687,7 +10687,7 @@
           },
           "to": [
             {
-              "key_code": "k",
+              "key_code": "m",
               "modifiers": [
                 "right_shift"
               ]

--- a/public/json/colemak_dh_ansi_layout.json
+++ b/public/json/colemak_dh_ansi_layout.json
@@ -682,7 +682,7 @@
           },
           "to": [
             {
-              "key_code": "k"
+              "key_code": "m"
             }
           ]
         },
@@ -924,7 +924,7 @@
           },
           "to": [
             {
-              "key_code": "m"
+              "key_code": "k"
             }
           ]
         },
@@ -1877,7 +1877,7 @@
           },
           "to": [
             {
-              "key_code": "k",
+              "key_code": "m",
               "modifiers": [
                 "left_shift"
               ]
@@ -2185,7 +2185,7 @@
           },
           "to": [
             {
-              "key_code": "m",
+              "key_code": "k",
               "modifiers": [
                 "left_shift"
               ]
@@ -3165,7 +3165,7 @@
           },
           "to": [
             {
-              "key_code": "k",
+              "key_code": "m",
               "modifiers": [
                 "right_shift"
               ]
@@ -3473,7 +3473,7 @@
           },
           "to": [
             {
-              "key_code": "m",
+              "key_code": "k",
               "modifiers": [
                 "right_shift"
               ]
@@ -4297,7 +4297,7 @@
           },
           "to": [
             {
-              "key_code": "k"
+              "key_code": "m"
             }
           ]
         },
@@ -4539,7 +4539,7 @@
           },
           "to": [
             {
-              "key_code": "m"
+              "key_code": "k"
             }
           ]
         },
@@ -5498,7 +5498,7 @@
           },
           "to": [
             {
-              "key_code": "k",
+              "key_code": "m",
               "modifiers": [
                 "left_shift"
               ]
@@ -5806,7 +5806,7 @@
           },
           "to": [
             {
-              "key_code": "m",
+              "key_code": "k",
               "modifiers": [
                 "left_shift"
               ]
@@ -6786,7 +6786,7 @@
           },
           "to": [
             {
-              "key_code": "k",
+              "key_code": "m",
               "modifiers": [
                 "right_shift"
               ]
@@ -7094,7 +7094,7 @@
           },
           "to": [
             {
-              "key_code": "m",
+              "key_code": "k",
               "modifiers": [
                 "right_shift"
               ]
@@ -7890,7 +7890,7 @@
           },
           "to": [
             {
-              "key_code": "k"
+              "key_code": "m"
             }
           ]
         },
@@ -8132,7 +8132,7 @@
           },
           "to": [
             {
-              "key_code": "m"
+              "key_code": "k"
             }
           ]
         },
@@ -9091,7 +9091,7 @@
           },
           "to": [
             {
-              "key_code": "k",
+              "key_code": "m",
               "modifiers": [
                 "left_shift"
               ]
@@ -9399,7 +9399,7 @@
           },
           "to": [
             {
-              "key_code": "m",
+              "key_code": "k",
               "modifiers": [
                 "left_shift"
               ]
@@ -10379,7 +10379,7 @@
           },
           "to": [
             {
-              "key_code": "k",
+              "key_code": "m",
               "modifiers": [
                 "right_shift"
               ]
@@ -10687,7 +10687,7 @@
           },
           "to": [
             {
-              "key_code": "m",
+              "key_code": "k",
               "modifiers": [
                 "right_shift"
               ]

--- a/public/json/map_esc_grave_accent_and_tilde.json
+++ b/public/json/map_esc_grave_accent_and_tilde.json
@@ -1,0 +1,48 @@
+{
+  "title": "shift + Esc Tilde to ~, command + Esc Tilde to `",
+  "rules": [
+    {
+      "description": "command + Esc, Tilde to `",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "escape",
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "shift + Esc, Tilde to ~",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "escape",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": ["shift"]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
For **hhkb keyboard**, _**grave accent and tilde**_ layout at the upper right corner of the keyboard, which is difficult to adapt. So through the combination of _**command**_ and _**shift**_ function keys with _**esc**_ to map the key.
