### PR TITLE
Config for dvorak with qwerty cmd only applicable to US intput type

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -433,6 +433,9 @@
           "path": "json/dvorak_cmd_qwerty_layout.json"
         },
         {
+          "path": "json/dvorak_cmd_qwerty_layout_only_us_input.json"
+        },
+        {
           "path": "json/programmer_dvorak_cmd_qwerty_layout.json"
         },
         {

--- a/public/json/dvorak_cmd_qwerty_layout_only_us_input.json
+++ b/public/json/dvorak_cmd_qwerty_layout_only_us_input.json
@@ -1,0 +1,3644 @@
+{
+    "title": "Dvorak-CmdQwerty Keyboard",
+    "rules": [
+      {
+        "description": "Remap keys to use Dvorak-CmdQwerty keyboard layout only on US input",
+        "manipulators": [
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "grave_accent_and_tilde"
+            },
+            "to": [
+              {
+                "key_code": "grave_accent_and_tilde"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "1"
+            },
+            "to": [
+              {
+                "key_code": "1"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "2"
+            },
+            "to": [
+              {
+                "key_code": "2"
+              }
+            ]
+          },
+          {          
+            "conditions": [
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                }
+              ]
+            }
+          ],
+            "type": "basic",
+            "from": {
+              "key_code": "4"
+            },
+            "to": [
+              {
+                "key_code": "4"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "5"
+            },
+            "to": [
+              {
+                "key_code": "5"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "6"
+            },
+            "to": [
+              {
+                "key_code": "6"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "7"
+            },
+            "to": [
+              {
+                "key_code": "7"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "8"
+            },
+            "to": [
+              {
+                "key_code": "8"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "9"
+            },
+            "to": [
+              {
+                "key_code": "9"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "0"
+            },
+            "to": [
+              {
+                "key_code": "0"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "hyphen"
+            },
+            "to": [
+              {
+                "key_code": "open_bracket"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "equal_sign"
+            },
+            "to": [
+              {
+                "key_code": "close_bracket"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "q"
+            },
+            "to": [
+              {
+                "key_code": "quote"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "w"
+            },
+            "to": [
+              {
+                "key_code": "comma"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "e"
+            },
+            "to": [
+              {
+                "key_code": "period"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "r"
+            },
+            "to": [
+              {
+                "key_code": "p"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "t"
+            },
+            "to": [
+              {
+                "key_code": "y"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "y"
+            },
+            "to": [
+              {
+                "key_code": "f"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "u"
+            },
+            "to": [
+              {
+                "key_code": "g"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "i"
+            },
+            "to": [
+              {
+                "key_code": "c"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "o"
+            },
+            "to": [
+              {
+                "key_code": "r"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "p"
+            },
+            "to": [
+              {
+                "key_code": "l"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "open_bracket"
+            },
+            "to": [
+              {
+                "key_code": "slash"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "close_bracket"
+            },
+            "to": [
+              {
+                "key_code": "equal_sign"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "backslash"
+            },
+            "to": [
+              {
+                "key_code": "backslash"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "a"
+            },
+            "to": [
+              {
+                "key_code": "a"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "s"
+            },
+            "to": [
+              {
+                "key_code": "o"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "d"
+            },
+            "to": [
+              {
+                "key_code": "e"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "f"
+            },
+            "to": [
+              {
+                "key_code": "u"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "g"
+            },
+            "to": [
+              {
+                "key_code": "i"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "h"
+            },
+            "to": [
+              {
+                "key_code": "d"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "j"
+            },
+            "to": [
+              {
+                "key_code": "h"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "k"
+            },
+            "to": [
+              {
+                "key_code": "t"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "l"
+            },
+            "to": [
+              {
+                "key_code": "n"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "semicolon"
+            },
+            "to": [
+              {
+                "key_code": "s"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "quote"
+            },
+            "to": [
+              {
+                "key_code": "hyphen"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "z"
+            },
+            "to": [
+              {
+                "key_code": "semicolon"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "x"
+            },
+            "to": [
+              {
+                "key_code": "q"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "c"
+            },
+            "to": [
+              {
+                "key_code": "j"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "v"
+            },
+            "to": [
+              {
+                "key_code": "k"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "b"
+            },
+            "to": [
+              {
+                "key_code": "x"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "n"
+            },
+            "to": [
+              {
+                "key_code": "b"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "m"
+            },
+            "to": [
+              {
+                "key_code": "m"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "comma"
+            },
+            "to": [
+              {
+                "key_code": "w"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "period"
+            },
+            "to": [
+              {
+                "key_code": "v"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "slash"
+            },
+            "to": [
+              {
+                "key_code": "z"
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "grave_accent_and_tilde",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "1",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "1",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "2",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "2",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "4",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "4",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "5",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "5",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "6",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "6",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "7",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "7",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "8",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "8",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "9",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "9",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "0",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "0",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "hyphen",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "open_bracket",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "equal_sign",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "close_bracket",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "q",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "quote",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "w",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "comma",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "e",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "period",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "r",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "p",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "t",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "y",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "y",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "f",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "u",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "g",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "i",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "c",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "o",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "r",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "p",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "l",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "open_bracket",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "slash",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "close_bracket",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "equal_sign",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "backslash",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "backslash",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "a",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "a",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "s",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "o",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "d",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "e",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "f",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "u",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "g",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "i",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "h",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "d",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "j",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "h",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "k",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "t",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "l",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "n",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "semicolon",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "s",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "quote",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "hyphen",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "z",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "semicolon",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "x",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "q",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "c",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "j",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "v",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "k",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "b",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "x",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "n",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "b",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "m",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "m",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "comma",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "w",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "period",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "v",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "slash",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "z",
+                "modifiers": [
+                  "left_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "grave_accent_and_tilde",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "1",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "1",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "2",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "2",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "4",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "4",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "5",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "5",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "6",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "6",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "7",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "7",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "8",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "8",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "9",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "9",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "0",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "0",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "hyphen",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "open_bracket",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "equal_sign",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "close_bracket",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "q",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "quote",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "w",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "comma",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "e",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "period",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "r",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "p",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "t",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "y",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "y",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "f",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "u",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "g",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "i",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "c",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "o",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "r",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "p",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "l",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "open_bracket",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "slash",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "close_bracket",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "equal_sign",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "backslash",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "backslash",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "a",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "a",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "s",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "o",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "d",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "e",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "f",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "u",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "g",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "i",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "h",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "d",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "j",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "h",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "k",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "t",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "l",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "n",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "semicolon",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "s",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "quote",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "hyphen",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "z",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "semicolon",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "x",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "q",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "c",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "j",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "v",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "k",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "b",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "x",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "n",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "b",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "m",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "m",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "comma",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "w",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "period",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "v",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          },
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "input_source_id": "^com\\.apple\\.keylayout\\.US$"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "slash",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "z",
+                "modifiers": [
+                  "right_shift"
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }


### PR DESCRIPTION
[dvorak_cmd_qwerty_layout.json](https://github.com/pqrs-org/KE-complex_modifications/blob/master/public/json/dvorak_cmd_qwerty_layout.json) works fine when you use only one input type.
In case you used to having more than one input type, it becomes fairly inconvenient.
Proposed config ties changes only to US input type