### PR TITLE
Add Razer Orbweaver Chroma config

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -909,6 +909,9 @@
         {
           "path": "json/microsoft_sculpt_ergonomic_desktop.json",
           "extra_description_path": "extra_descriptions/microsoft_sculpt_ergonomic_desktop.json.html"
+        },
+        {
+          "path": "json/razer_orbweaver_chroma.json"
         }
       ]
     },

--- a/public/json/razer_orbweaver_chroma.json
+++ b/public/json/razer_orbweaver_chroma.json
@@ -1,0 +1,761 @@
+{
+  "title": "Razer Orbweaver Chroma",
+  "rules": [
+    {
+      "description": "Razer 01 to Up Arrow",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "period",
+            "modifiers": {
+              "optional": ["shift", "option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Razer 02 to F1",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "1",
+            "modifiers": {
+              "optional": ["shift", "option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Razer 03 to F2",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "2",
+            "modifiers": {
+              "optional": ["shift", "option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Razer 04 to F3",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "3",
+            "modifiers": {
+              "optional": ["shift", "option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Razer 05 to ]",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "4",
+            "modifiers": {
+              "optional": ["shift", "option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "close_bracket"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Razer 06 to Left Arrow",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "tab",
+            "modifiers": {
+              "optional": ["shift", "option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Razer 07 to F4",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "q",
+            "modifiers": {
+              "optional": ["shift", "option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Razer 08 to F5",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "w",
+            "modifiers": {
+              "optional": ["shift", "option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Razer 09 to F6",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "e",
+            "modifiers": {
+              "optional": ["shift", "option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Razer 10 to V",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "r",
+            "modifiers": {
+              "optional": ["shift", "option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "v"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Razer 11 to Left Shift",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "caps_lock"
+          },
+          "to": [
+            {
+              "key_code": "left_shift"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Razer 12 to F7",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "optional": ["shift", "option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Razer 13 to F8",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "s",
+            "modifiers": {
+              "optional": ["shift", "option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Razer 14 to F9",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "d",
+            "modifiers": {
+              "optional": ["shift", "option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Razer 15 to K",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "f",
+            "modifiers": {
+              "optional": ["shift", "option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Razer 16 to Left Alt",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "left_shift"
+          },
+          "to": [
+            {
+              "key_code": "left_option"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Razer 17 to F10",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "z",
+            "modifiers": {
+              "optional": ["shift", "option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f10"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Razer 18 to F11",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "x",
+            "modifiers": {
+              "optional": ["shift", "option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Razer 19 to F12",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "c",
+            "modifiers": {
+              "optional": ["shift", "option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f12"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Razer 20 to .",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "v",
+            "modifiers": {
+              "optional": ["shift", "option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "period"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Razer Trigger to Escape",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "left_option"
+          },
+          "to": [
+            {
+              "key_code": "escape"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Razer Left Arrow to Q",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "left_arrow"
+          },
+          "to": [
+            {
+              "key_code": "q"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Razer Right Arrow to E",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "right_arrow"
+          },
+          "to": [
+            {
+              "key_code": "e"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Razer Up Arrow to W",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "up_arrow"
+          },
+          "to": [
+            {
+              "key_code": "w"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Razer Down Arrow to S",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "down_arrow"
+          },
+          "to": [
+            {
+              "key_code": "s"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Razer Space to M",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 519,
+                  "vendor_id": 5426
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "spacebar"
+          },
+          "to": [
+            {
+              "key_code": "m"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
A simple map for the Razer Orbweaver Chroma (since Synapse is no longer supported on macOS)