### PR TITLE
Update windows_shortcuts_on_macos.json, to exclude X11 Macports apps closes #816

### DIFF
--- a/public/json/windows_shortcuts_on_macos.json
+++ b/public/json/windows_shortcuts_on_macos.json
@@ -1012,7 +1012,7 @@
               "conditions": [
                 {
                   "bundle_identifiers": [
-                                "^org\\.macports\\.X11$",
+                    "^org\\.macports\\.X11$",
                     "^com\\.apple\\.Terminal$",
                     "^com\\.googlecode\\.iterm2$",
                     "^co\\.zeit\\.hyper$",
@@ -1052,7 +1052,7 @@
               "conditions": [
                 {
                   "bundle_identifiers": [
-                                "^org\\.macports\\.X11$",
+                    "^org\\.macports\\.X11$",
                     "^com\\.apple\\.Terminal$",
                     "^com\\.googlecode\\.iterm2$",
                     "^co\\.zeit\\.hyper$",

--- a/public/json/windows_shortcuts_on_macos.json
+++ b/public/json/windows_shortcuts_on_macos.json
@@ -52,6 +52,7 @@
                                 "^com\\.citrix\\.XenAppViewer$",
                                 "^com\\.vmware\\.proxyApp\\.",
                                 "^com\\.parallels\\.winapp\\.",
+                                "^org\\.macports\\.X11$",
                                 "^com\\.apple\\.Terminal$",
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyperterm$",
@@ -110,6 +111,7 @@
                                 "^com\\.citrix\\.XenAppViewer$",
                                 "^com\\.vmware\\.proxyApp\\.",
                                 "^com\\.parallels\\.winapp\\.",
+                                "^org\\.macports\\.X11$",
                                 "^com\\.apple\\.Terminal$",
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyperterm$",
@@ -168,6 +170,7 @@
                                 "^com\\.citrix\\.XenAppViewer$",
                                 "^com\\.vmware\\.proxyApp\\.",
                                 "^com\\.parallels\\.winapp\\.",
+                                "^org\\.macports\\.X11$",
                                 "^com\\.apple\\.Terminal$",
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyperterm$",
@@ -210,6 +213,7 @@
                                 "^com\\.citrix\\.XenAppViewer$",
                                 "^com\\.vmware\\.proxyApp\\.",
                                 "^com\\.parallels\\.winapp\\.",
+                                "^org\\.macports\\.X11$",
                                 "^com\\.apple\\.Terminal$",
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyperterm$",
@@ -273,6 +277,7 @@
                                 "^com\\.citrix\\.XenAppViewer$",
                                 "^com\\.vmware\\.proxyApp\\.",
                                 "^com\\.parallels\\.winapp\\.",
+                                "^org\\.macports\\.X11$",
                                 "^com\\.apple\\.Terminal$",
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyperterm$",
@@ -337,6 +342,7 @@
                                 "^com\\.citrix\\.XenAppViewer$",
                                 "^com\\.vmware\\.proxyApp\\.",
                                 "^com\\.parallels\\.winapp\\.",
+                                "^org\\.macports\\.X11$",
                                 "^com\\.apple\\.Terminal$",
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyperterm$",
@@ -400,6 +406,7 @@
                                 "^com\\.citrix\\.XenAppViewer$",
                                 "^com\\.vmware\\.proxyApp\\.",
                                 "^com\\.parallels\\.winapp\\.",
+                                "^org\\.macports\\.X11$",
                                 "^com\\.apple\\.Terminal$",
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyperterm$",
@@ -463,6 +470,7 @@
                                 "^com\\.citrix\\.XenAppViewer$",
                                 "^com\\.vmware\\.proxyApp\\.",
                                 "^com\\.parallels\\.winapp\\.",
+                                "^org\\.macports\\.X11$",
                                 "^com\\.apple\\.Terminal$",
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyperterm$",
@@ -526,6 +534,7 @@
                                 "^com\\.citrix\\.XenAppViewer$",
                                 "^com\\.vmware\\.proxyApp\\.",
                                 "^com\\.parallels\\.winapp\\.",
+                                "^org\\.macports\\.X11$",
                                 "^com\\.apple\\.Terminal$",
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyperterm$",
@@ -584,6 +593,7 @@
                                 "^com\\.citrix\\.XenAppViewer$",
                                 "^com\\.vmware\\.proxyApp\\.",
                                 "^com\\.parallels\\.winapp\\.",
+                                "^org\\.macports\\.X11$",
                                 "^com\\.apple\\.Terminal$",
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyperterm$",
@@ -647,6 +657,7 @@
                                 "^com\\.citrix\\.XenAppViewer$",
                                 "^com\\.vmware\\.proxyApp\\.",
                                 "^com\\.parallels\\.winapp\\.",
+                                "^org\\.macports\\.X11$",
                                 "^com\\.apple\\.Terminal$",
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyperterm$",
@@ -741,6 +752,7 @@
                     "conditions": [
                         {
                             "bundle_identifiers": [
+                                "^org\\.macports\\.X11$",
                                 "^com\\.apple\\.Terminal$",
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyper$",
@@ -772,6 +784,7 @@
                     "conditions": [
                         {
                             "bundle_identifiers": [
+                                "^org\\.macports\\.X11$",
                                 "^com\\.apple\\.Terminal$",
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyper$",
@@ -809,6 +822,7 @@
                     "conditions": [
                         {
                             "bundle_identifiers": [
+                                "^org\\.macports\\.X11$",
                                 "^com\\.apple\\.Terminal$",
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyper$",
@@ -848,6 +862,7 @@
                     "conditions": [
                         {
                             "bundle_identifiers": [
+                                "^org\\.macports\\.X11$",
                                 "^com\\.apple\\.Terminal$",
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyper$",
@@ -879,6 +894,7 @@
                     "conditions": [
                         {
                             "bundle_identifiers": [
+                                "^org\\.macports\\.X11$",
                                 "^com\\.apple\\.Terminal$",
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyper$",
@@ -916,6 +932,7 @@
                     "conditions": [
                         {
                             "bundle_identifiers": [
+                                "^org\\.macports\\.X11$",
                                 "^com\\.apple\\.Terminal$",
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyper$",
@@ -955,6 +972,7 @@
                     "conditions": [
                         {
                             "bundle_identifiers": [
+                                "^org\\.macports\\.X11$",
                                 "^com\\.apple\\.Terminal$",
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyper$",
@@ -994,6 +1012,7 @@
               "conditions": [
                 {
                   "bundle_identifiers": [
+                                "^org\\.macports\\.X11$",
                     "^com\\.apple\\.Terminal$",
                     "^com\\.googlecode\\.iterm2$",
                     "^co\\.zeit\\.hyper$",
@@ -1033,6 +1052,7 @@
               "conditions": [
                 {
                   "bundle_identifiers": [
+                                "^org\\.macports\\.X11$",
                     "^com\\.apple\\.Terminal$",
                     "^com\\.googlecode\\.iterm2$",
                     "^co\\.zeit\\.hyper$",
@@ -1173,6 +1193,7 @@
                                 "^com\\.citrix\\.XenAppViewer$",
                                 "^com\\.vmware\\.proxyApp\\.",
                                 "^com\\.parallels\\.winapp\\.",
+                                "^org\\.macports\\.X11$",
                                 "^com\\.apple\\.Terminal$",
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyperterm$",
@@ -1312,6 +1333,7 @@
                                 "^com\\.citrix\\.XenAppViewer$",
                                 "^com\\.vmware\\.proxyApp\\.",
                                 "^com\\.parallels\\.winapp\\.",
+                                "^org\\.macports\\.X11$",
                                 "^com\\.apple\\.Terminal$",
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyperterm$",
@@ -1370,6 +1392,7 @@
                                 "^com\\.citrix\\.XenAppViewer$",
                                 "^com\\.vmware\\.proxyApp\\.",
                                 "^com\\.parallels\\.winapp\\.",
+                                "^org\\.macports\\.X11$",
                                 "^com\\.apple\\.Terminal$",
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyperterm$",
@@ -1449,6 +1472,7 @@
                                 "^com\\.citrix\\.XenAppViewer$",
                                 "^com\\.vmware\\.proxyApp\\.",
                                 "^com\\.parallels\\.winapp\\.",
+                                "^org\\.macports\\.X11$",
                                 "^com\\.apple\\.Terminal$",
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyperterm$",
@@ -1503,6 +1527,7 @@
                                 "^com\\.citrix\\.XenAppViewer$",
                                 "^com\\.vmware\\.proxyApp\\.",
                                 "^com\\.parallels\\.winapp\\.",
+                                "^org\\.macports\\.X11$",
                                 "^com\\.apple\\.Terminal$",
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyperterm$",


### PR DESCRIPTION
to exclude X11 Macports apps, closes #816