### PR TITLE
Update Right_option_as_emoji_key.json

### DIFF
--- a/public/json/Right_option_as_emoji_key.json
+++ b/public/json/Right_option_as_emoji_key.json
@@ -1,5 +1,5 @@
 {
-  "title": "Emoji-key",
+  "title": "Emoji-key (non-apple keyboard [not fn])",
   "rules": [
       {
       "description": "Press right_alt alone toggles emoji input",
@@ -21,11 +21,7 @@
           ],
           "to_if_alone": [
             {
-              "key_code": "spacebar",
-              "modifiers": [
-				"left_control",
-				"left_command"
-              ]
+              "key_code": "fn"
             }
           ]
         }


### PR DESCRIPTION
Since macOS now has a native toggle key for this (pressing fn alone) we can leverage this, so that the toggle is actually a toggle (open AND close the emoji input mask).
!!! This might break pre macOS 11/10.15? compatibility.
------
Big advantage now, is the ability to close the emoji interface, and thus more closely mimic macOS native functionality.

The macOS native function for this however does NOT replace this, as it only works for apple manufactured keyboards (or ones that actually passthrough the fn key to the OS to let it deal with functions rather than passing the either function key codes or fX keys.