### PR TITLE
add swap ctrl and cmd except in terminal

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -413,6 +413,9 @@
         {
           "path": "json/preview-vim.json",
           "extra_description_path": "extra_descriptions/preview-vim.html"
+        },
+        {
+          "path": "json/swap_ctrl_and_cmd_except_in_terminal.json"
         }
       ]
     },

--- a/public/json/swap_ctrl_and_cmd_except_in_terminal.json
+++ b/public/json/swap_ctrl_and_cmd_except_in_terminal.json
@@ -1,0 +1,44 @@
+{
+    "title": "backslash",
+    "rules": [
+        {
+            "description": "Swap left-ctrl and command except in Terminal",
+            "manipulators": [
+                {
+                    "from": {
+                        "key_code": "left_command"
+                    },
+                    "to": [
+                        {
+                            "key_code": "left_control"
+                        }
+                    ],
+                    "type": "basic",
+                    "conditions": [
+                        {
+                            "type": "frontmost_application_unless",
+                            "bundle_identifiers": [ "^com\\.apple\\.Terminal" ]
+                        }
+                    ]
+                },
+                {
+                    "from": {
+                        "key_code": "left_control"
+                    },
+                    "to": [
+                        {
+                            "key_code": "left_command"
+                        }
+                    ],
+                    "type": "basic",
+                    "conditions": [
+                        {
+                            "type": "frontmost_application_unless",
+                            "bundle_identifiers": [ "^com\\.apple\\.Terminal" ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/public/json/swap_ctrl_and_cmd_except_in_terminal.json
+++ b/public/json/swap_ctrl_and_cmd_except_in_terminal.json
@@ -1,5 +1,5 @@
 {
-    "title": "backslash",
+    "title": "Swap left-ctrl and command except in Terminal",
     "rules": [
         {
             "description": "Swap left-ctrl and command except in Terminal",


### PR DESCRIPTION
## About
* Add a rule to swap left-ctrl and command, but leave the Terminal as it is to use Emacs shortcuts.