### PR TITLE
fix caps_lock_enhancement bug (hyper+esc not work)

### DIFF
--- a/public/extra_descriptions/caps_lock_enhancement.json.html
+++ b/public/extra_descriptions/caps_lock_enhancement.json.html
@@ -1,6 +1,7 @@
 <link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
+
 <br>
-<h1><a name="capslock-enhancement" class="md-header-anchor"></a><span>Capslock Enhancement</span></h1>
+<h1><a name="capslock-enhancement" class="md-header-anchor"></a><span>Capslock Enhancement (rev 3)</span></h1>
 <br>
 <p>
   <em><span>Transform ⇪CapsLock into a powerful </span><strong><span>modifier</span></strong><span> </span><strong><span>✱ Hyper</span></strong><span> that miraculously increases your work productivity!</span></em>
@@ -13,7 +14,7 @@
 
 
 <p>Latest Import URL (v3): <a href="karabiner://karabiner/assets/complex_modifications/import?url=https://vonng.com/capslock.json">https://vonng.com/capslock.json</a></p>
-<p>Github Import URL (v3): <a href="karabiner://karabiner/assets/complex_modifications/import?url=https://github.com/Vonng/Capslock/raw/master/mac/capslock.json">https://github.com/Vonng/Capslock/raw/master/mac/capslock.json</a></p>
+<p>Github Import URL (v3): <a href="karabiner://karabiner/assets/complex_modifications/import?url=https://github.com/Vonng/Capslock/raw/master/mac_v3/capslock.json">https://github.com/Vonng/Capslock/raw/master/mac_v3/capslock.json</a></p>
 
 <img style="width: 100%;" src="https://github.com/Vonng/Capslock/raw/master/mac_v3/images/keyboard.png" referrerpolicy="no-referrer">
 
@@ -39,22 +40,22 @@
     <tr>
       <td style='text-align:center;'><code>⇪</code><span> Hold</span></td>
       <td style='text-align:center;'><code>✱</code><span>  Hyper</span></td>
-      <td><span>Hold Capslock to enable </span><strong><span>Hyper</span></strong><span> modifier.</span></td>
+      <td><span>Hold Capslock to enable </span><strong><span>Hyper</span></strong><span> modifier</span></td>
     </tr>
     <tr>
       <td style='text-align:center;'><code>✱⎋</code></td>
       <td style='text-align:center;'><code>⇪</code><span> Capslock</span></td>
-      <td><span>Press to enable Capslock, Hold to disable Capslock</span></td>
+      <td><span>Press to switch Capslock status</span></td>
     </tr>
     <tr>
       <td style='text-align:center;'><code>✱␣</code></td>
       <td style='text-align:center;'><code>⌃␣</code></td>
-      <td><span>Switch input source, +</span><code>⌘</code><span> to emoji</span></td>
+      <td><span>Press to switch input source  +</span><code>⌘</code><span> to emoji</span></td>
     </tr>
     </tbody>
   </table>
 </figure><p>
-  <span>Note that ✱ is implemented as combinition of </span><strong><span>ALL RIGHT MODIFIERS</span></strong><span>:  ⌘⌥⌃⇧. Hold  </span><strong><span>✱ Hyper</span></strong><span> to enable other hyper functionalites</span>
+  <span>Note that ✱ is implemented as combination of </span><strong><span>ALL RIGHT MODIFIERS</span></strong><span>:  ⌘⌥⌃⇧. Hold  </span><strong><span>✱ Hyper</span></strong><span> to enable other hyper functionalities</span>
 </p>
 <figure>
   <table class="table">
@@ -543,7 +544,7 @@
     </tr>
     </tbody>
   </table>
-</figure><h3><a name="terminal-control" class="md-header-anchor"></a><span>Terminal Control</span></h3><p><code>D</code><span>, </span><code>Z</code><span>, </span><code>X</code><span>, </span><code>C</code><span>, </span><code>V</code><span>, </span><code>B</code><span> are used as terminal control keys. Sending singals and IDE commands. (green area)</span>
+</figure><h3><a name="terminal-control" class="md-header-anchor"></a><span>Terminal Control</span></h3><p><code>D</code><span>, </span><code>Z</code><span>, </span><code>X</code><span>, </span><code>C</code><span>, </span><code>V</code><span>, </span><code>B</code><span> are used as terminal control keys. Sending signals and IDE commands. (green area)</span>
 </p>
 <figure>
   <table class="table">

--- a/public/json/caps_lock_enhancement.json
+++ b/public/json/caps_lock_enhancement.json
@@ -1,8 +1,7 @@
 {
   "title": "Capslock Enhancement",
   "url": "https://vonng.com/capslock.json",
-  "src": "https://vonng.com/capslock.yml",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "maintainers": [
     "Vonng"
   ],
@@ -49,29 +48,9 @@
           "from": {
             "key_code": "escape",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "caps_lock",
-              "modifiers": [
-                "left_control"
-              ]
-            }
-          ]
-        },
-        {
-          "description": "escape = capslock switch",
-          "type": "basic",
-          "from": {
-            "key_code": "escape",
-            "modifiers": {
+              "optional": [
+                "caps_lock"
+              ],
               "mandatory": [
                 "right_command",
                 "right_control",


### PR DESCRIPTION
fix caps_lock_enhancement bug that hyper+esc does not turn capslock status back.
fix some typo in document.