### PR TITLE
Sync Music and System Volume

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -285,6 +285,12 @@
       "id": "application-specific",
       "files": [
         {
+          "path": "json/Sync_SystemVolume_to_Music.json"
+        },
+        {
+          "path": "json/Sync_SystemVolume_to_iTunes.json"
+        },
+        {
           "path": "json/bash.json"
         },
         {

--- a/public/json/Sync_SystemVolume_to_Music.json
+++ b/public/json/Sync_SystemVolume_to_Music.json
@@ -9,7 +9,7 @@
 		  "from": {
 			"key_code": "volume_increment",
 			"modifiers": {
-			  "mandatory": [ "any" ]
+			  "optional": [ "any" ]
 			}
 		  },
 		  "to": [
@@ -26,7 +26,7 @@
 		  "from": {
 			"key_code": "volume_decrement",
 			"modifiers": {
-			  "mandatory": [ "any" ]
+			  "optional": [ "any" ]
 			}
 		  },
 		  "to": [
@@ -48,7 +48,7 @@
 		  "from": {
 			"key_code": "volume_increment",
 			"modifiers": {
-			  "mandatory": [ "any" ]
+			  "optional": [ "any" ]
 			}
 		  },
 		  "to": [
@@ -65,7 +65,7 @@
 		  "from": {
 			"key_code": "volume_decrement",
 			"modifiers": {
-			  "mandatory": [ "any" ]
+			  "optional": [ "any" ]
 			}
 		  },
 		  "to": [

--- a/public/json/Sync_SystemVolume_to_Music.json
+++ b/public/json/Sync_SystemVolume_to_Music.json
@@ -1,0 +1,83 @@
+{
+  "title": "Sync Music and System Volume (no key repeat)",
+  "rules": [
+    {
+	  "description": "Sync Music and System Volume (on volume key events)",
+	  "manipulators": [
+		{
+		  "type": "basic",
+		  "from": {
+			"key_code": "volume_increment",
+			"modifiers": {
+			  "mandatory": [ "any" ]
+			}
+		  },
+		  "to": [
+			{
+			  "shell_command": "osascript -e 'if application \"Music\" is running then' -e 'tell application \"Music\" to try' -e 'set the sound volume to output volume of (get volume settings)' -e 'on error' -e 'set the sound volume to sound volume + 6.5' -e 'end try' -e 'end if'"
+			},
+			{
+			  "key_code": "volume_increment"
+			}
+		  ]
+		},
+		{
+		  "type": "basic",
+		  "from": {
+			"key_code": "volume_decrement",
+			"modifiers": {
+			  "mandatory": [ "any" ]
+			}
+		  },
+		  "to": [
+			{
+			  "shell_command": "osascript -e 'if application \"Music\" is running then' -e 'tell application \"Music\" to try' -e 'set the sound volume to output volume of (get volume settings)' -e 'on error' -e 'set the sound volume to sound volume - 6.5' -e 'end try' -e 'end if'"
+			},
+			{
+			  "key_code": "volume_decrement"
+			}
+		  ]
+		}
+	  ]
+	},
+	{
+	  "description": "Sync Music and System Volume (on volume key events, allow offset)",
+	  "manipulators": [
+		{
+		  "type": "basic",
+		  "from": {
+			"key_code": "volume_increment",
+			"modifiers": {
+			  "mandatory": [ "any" ]
+			}
+		  },
+		  "to": [
+			{
+			  "shell_command": "osascript -e 'if application \"Music\" is running then' -e 'tell application \"Music\" to set the sound volume to sound volume + 6.5' -e 'end if'"
+			},
+			{
+			  "key_code": "volume_increment"
+			}
+		  ]
+		},
+		{
+		  "type": "basic",
+		  "from": {
+			"key_code": "volume_decrement",
+			"modifiers": {
+			  "mandatory": [ "any" ]
+			}
+		  },
+		  "to": [
+			{
+			  "shell_command": "osascript -e 'if application \"Music\" is running then' -e 'tell application \"Music\" to set the sound volume to sound volume - 6.5' -e 'end if'"
+			},
+			{
+			  "key_code": "volume_decrement"
+			}
+		  ]
+		}
+	  ]
+	}
+  ]
+}

--- a/public/json/Sync_SystemVolume_to_iTunes.json
+++ b/public/json/Sync_SystemVolume_to_iTunes.json
@@ -9,7 +9,7 @@
 		  "from": {
 			"key_code": "volume_increment",
 			"modifiers": {
-			  "mandatory": [ "any" ]
+			  "optional": [ "any" ]
 			}
 		  },
 		  "to": [
@@ -26,7 +26,7 @@
 		  "from": {
 			"key_code": "volume_decrement",
 			"modifiers": {
-			  "mandatory": [ "any" ]
+			  "optional": [ "any" ]
 			}
 		  },
 		  "to": [
@@ -48,7 +48,7 @@
 		  "from": {
 			"key_code": "volume_increment",
 			"modifiers": {
-			  "mandatory": [ "any" ]
+			  "optional": [ "any" ]
 			}
 		  },
 		  "to": [
@@ -65,7 +65,7 @@
 		  "from": {
 			"key_code": "volume_decrement",
 			"modifiers": {
-			  "mandatory": [ "any" ]
+			  "optional": [ "any" ]
 			}
 		  },
 		  "to": [

--- a/public/json/Sync_SystemVolume_to_iTunes.json
+++ b/public/json/Sync_SystemVolume_to_iTunes.json
@@ -1,0 +1,83 @@
+{
+  "title": "Sync iTunes and System Volume (no key repeat)",
+  "rules": [
+    {
+	  "description": "Sync iTunes and System Volume (on volume key events)",
+	  "manipulators": [
+		{
+		  "type": "basic",
+		  "from": {
+			"key_code": "volume_increment",
+			"modifiers": {
+			  "mandatory": [ "any" ]
+			}
+		  },
+		  "to": [
+			{
+			  "shell_command": "osascript -e 'if application \"iTunes\" is running then' -e 'tell application \"Music\" to try' -e 'set the sound volume to output volume of (get volume settings)' -e 'on error' -e 'set the sound volume to sound volume + 6.5' -e 'end try' -e 'end if'"
+			},
+			{
+			  "key_code": "volume_increment"
+			}
+		  ]
+		},
+		{
+		  "type": "basic",
+		  "from": {
+			"key_code": "volume_decrement",
+			"modifiers": {
+			  "mandatory": [ "any" ]
+			}
+		  },
+		  "to": [
+			{
+			  "shell_command": "osascript -e 'if application \"Music\" is running then' -e 'tell application \"Music\" to try' -e 'set the sound volume to output volume of (get volume settings)' -e 'on error' -e 'set the sound volume to sound volume - 6.5' -e 'end try' -e 'end if'"
+			},
+			{
+			  "key_code": "volume_decrement"
+			}
+		  ]
+		}
+	  ]
+	},
+	{
+	  "description": "Sync iTunes and System Volume (on volume key events, allow offset)",
+	  "manipulators": [
+		{
+		  "type": "basic",
+		  "from": {
+			"key_code": "volume_increment",
+			"modifiers": {
+			  "mandatory": [ "any" ]
+			}
+		  },
+		  "to": [
+			{
+			  "shell_command": "osascript -e 'if application \"iTunes\" is running then' -e 'tell application \"Music\" to set the sound volume to sound volume + 6.5' -e 'end if'"
+			},
+			{
+			  "key_code": "volume_increment"
+			}
+		  ]
+		},
+		{
+		  "type": "basic",
+		  "from": {
+			"key_code": "volume_decrement",
+			"modifiers": {
+			  "mandatory": [ "any" ]
+			}
+		  },
+		  "to": [
+			{
+			  "shell_command": "osascript -e 'if application \"iTunes\" is running then' -e 'tell application \"Music\" to set the sound volume to sound volume - 6.5' -e 'end if'"
+			},
+			{
+			  "key_code": "volume_decrement"
+			}
+		  ]
+		}
+	  ]
+	}
+  ]
+}


### PR DESCRIPTION
This one I am particularly proud of. Mainly because I desperately missed an app, I used to use years ago with iTunes, which kept iTunes and system volume in sync. While I just prefer this behaviour generally, it also enables you to control non-system-wide AirPlay audio via the volume keys, which I need quite often.
Still missing is key repeat functionality, as this is apparently not supported for shell commands. Therefor it is intentionally disabled altogether (for the volume keys) to not behave weirdly.