### PR TITLE
[ADD] input-source change directly like windows-os for korean

### DIFF
--- a/public/extra_descriptions/ChangeInputSourceDirectlyForKorean.html
+++ b/public/extra_descriptions/ChangeInputSourceDirectlyForKorean.html
@@ -1,0 +1,15 @@
+<link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
+
+<h4>Description</h4>
+<h5>Right_command to korean <-> english</h5>
+<p>
+  right_command to 2-Set korean(두벌식) <-> ABC(로마자)
+</p>
+
+<h4>Notes</h4>
+<p>
+  Originally, the mac-os input-source-change event was triggered by a key-up event.
+  <br>In contrast, the windows-os input-source-change event was triggered by a key-down event.
+  <br>So, this function is windows-os liked input source change system.
+  <br>If you have any issue, email me.
+</p>

--- a/public/groups.json
+++ b/public/groups.json
@@ -557,6 +557,7 @@
         },
         {
           "path": "json/ChangeInputSourceDirectlyForKorean.json"
+          ,"extra_description_path": "extra_descriptions/ChangeInputSourceDirectlyForKorean.html"
         },
         {
           "path": "json/korean_won_to_backtick.json"

--- a/public/groups.json
+++ b/public/groups.json
@@ -556,6 +556,9 @@
           "path": "json/korean_pc.json"
         },
         {
+          "path": "json/ChangeInputSourceDirectlyForKorean.json"
+        },
+        {
           "path": "json/korean_won_to_backtick.json"
         },
         {

--- a/public/json/ChangeInputSourceDirectlyForKorean.json
+++ b/public/json/ChangeInputSourceDirectlyForKorean.json
@@ -1,6 +1,9 @@
 {
-    "title": "Change input-source directly for korean",
-    "rules": [
+    "title": "Change input-source directly for korean"
+    ,"maintainers":[
+      "creatorKoo"
+    ]
+    ,"rules": [
         {
             "description": "Right_command to korean <-> english",
             "manipulators": [

--- a/public/json/ChangeInputSourceDirectlyForKorean.json
+++ b/public/json/ChangeInputSourceDirectlyForKorean.json
@@ -1,0 +1,56 @@
+{
+    "title": "Change input-source directly for korean",
+    "rules": [
+        {
+            "description": "Right_command to korean <-> english",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "right_command"
+                    },
+                    "to": [
+                        {
+                            "select_input_source": {
+                                "input_source_id": "^com\\.apple\\.inputmethod\\.Korean\\.2SetKorean$"
+                            }
+                        }
+                    ],
+                    "conditions": [
+                        {
+                            "type": "input_source_if",
+                            "input_sources": [
+                                {
+                                    "input_source_id": "^com\\.apple\\.keylayout\\.ABC$"
+                                }
+                            ]
+                        }
+                    ]
+                }
+                ,{
+                    "type": "basic",
+                    "from": {
+                        "key_code": "right_command"
+                    },
+                    "to": [
+                        {
+                            "select_input_source": {
+                                "input_source_id": "^com\\.apple\\.keylayout\\.ABC$"
+                            }
+                        }
+                    ],
+                    "conditions": [
+                        {
+                            "type": "input_source_if",
+                            "input_sources": [
+                                {
+                                    "input_source_id": "^com\\.apple\\.inputmethod\\.Korean\\.2SetKorean$"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/public/json/ChangeInputSourceDirectlyForKorean.json
+++ b/public/json/ChangeInputSourceDirectlyForKorean.json
@@ -1,59 +1,69 @@
 {
-    "title": "Change input-source directly for korean"
-    ,"maintainers":[
-      "creatorKoo"
-    ]
-    ,"rules": [
+  "title": "Change input-source directly for korean",
+  "maintainers": [
+    "creatorKoo"
+  ],
+  "rules": [
+    {
+      "description": "Right_command to korean <-> english",
+      "manipulators": [
         {
-            "description": "Right_command to korean <-> english",
-            "manipulators": [
+          "type": "basic",
+          "from": {
+            "key_code": "right_command",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "select_input_source": {
+                "input_source_id": "^com\\.apple\\.inputmethod\\.Korean\\.2SetKorean$"
+              }
+            }
+          ],
+          "conditions": [
+            {
+              "type": "input_source_if",
+              "input_sources": [
                 {
-                    "type": "basic",
-                    "from": {
-                        "key_code": "right_command"
-                    },
-                    "to": [
-                        {
-                            "select_input_source": {
-                                "input_source_id": "^com\\.apple\\.inputmethod\\.Korean\\.2SetKorean$"
-                            }
-                        }
-                    ],
-                    "conditions": [
-                        {
-                            "type": "input_source_if",
-                            "input_sources": [
-                                {
-                                    "input_source_id": "^com\\.apple\\.keylayout\\.ABC$"
-                                }
-                            ]
-                        }
-                    ]
+                  "input_source_id": "^com\\.apple\\.keylayout\\.ABC$"
                 }
-                ,{
-                    "type": "basic",
-                    "from": {
-                        "key_code": "right_command"
-                    },
-                    "to": [
-                        {
-                            "select_input_source": {
-                                "input_source_id": "^com\\.apple\\.keylayout\\.ABC$"
-                            }
-                        }
-                    ],
-                    "conditions": [
-                        {
-                            "type": "input_source_if",
-                            "input_sources": [
-                                {
-                                    "input_source_id": "^com\\.apple\\.inputmethod\\.Korean\\.2SetKorean$"
-                                }
-                            ]
-                        }
-                    ]
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_command",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "select_input_source": {
+                "input_source_id": "^com\\.apple\\.keylayout\\.ABC$"
+              }
+            }
+          ],
+          "conditions": [
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "input_source_id": "^com\\.apple\\.inputmethod\\.Korean\\.2SetKorean$"
                 }
-            ]
+              ]
+            }
+          ]
         }
-    ]
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Originally mac-os input-source-change triggered from key-up event.
But, windows-os input-source-change triggered key-down event.
So, I add windows-os liked input-source-change function to mac-os for korean.