### PR TITLE
Fixed command description for German programming modification

### DIFF
--- a/public/extra_descriptions/german_programming.json.html
+++ b/public/extra_descriptions/german_programming.json.html
@@ -22,7 +22,7 @@
     <td>[</td>
   </tr>
   <tr>
-    <td>Left Command+#</td>
+    <td>Left Command+ä</td>
     <td>]</td>
   </tr>
   <tr>


### PR DESCRIPTION
Description is wrong it is the key next to "ö" which is "ä" on a German ISO-DE layout.