### PR TITLE
Keychron K3 Remap £ to # for British Keyboard

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -952,6 +952,9 @@
         },
         {
           "path": "json/razer_orbweaver_chroma.json"
+        },
+        {
+          "path": "json/keychron_k3-swap_pound_and_hash.json"
         }
       ]
     },

--- a/public/json/keychron_k3-swap_pound_and_hash.json
+++ b/public/json/keychron_k3-swap_pound_and_hash.json
@@ -1,0 +1,77 @@
+{
+  "title": "Keychron K3 Remap £ to # for British Keyboard",
+  "maintainers": [
+    "fredericrous"
+  ],
+  "rules": [
+    {
+      "description": "Remap £ to # only on your Keychron",
+      "manipulators": [
+        {
+          "type": "basic",
+          "conditions": [
+            {
+                "type": "device_if",
+                "identifiers": [
+                {
+                    "vendor_id": 1452,
+                    "product_id": 591
+                }
+                ]
+            }
+        ],
+          "from": {
+            "key_code": "3",
+            "modifiers": {
+              "mandatory": [ "option" ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "3",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+                "type": "device_if",
+                "identifiers": [
+                {
+                    "vendor_id": 1452,
+                    "product_id": 591
+                }
+                ]
+            }
+        ],
+          "from": {
+            "key_code": "3",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "3",
+              "modifiers": [
+                "left_option"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This scripts swaps the pound and the number sign only on Keychron K3 keyboard.
This means I can keep my British layout on my macbook internal keyboard, and use my Keychron K3 as a normal US keyboard