### PR TITLE
Add rule: Section Sign to Backtick

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -775,6 +775,9 @@
           "path": "json/section_sign_to_escape.json"
         },
         {
+          "path": "json/section_sign_to_backtick.json"
+        },
+        {
           "path": "json/sinoridha_personal_mapping.json"
         },
         {

--- a/public/json/section_sign_to_backtick.json
+++ b/public/json/section_sign_to_backtick.json
@@ -23,6 +23,23 @@
           "from": {
             "key_code": "non_us_backslash",
             "modifiers": {
+              "mandatory": ["option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "non_us_backslash",
+            "modifiers": {
               "mandatory": [
                 "shift"
               ],

--- a/public/json/section_sign_to_backtick.json
+++ b/public/json/section_sign_to_backtick.json
@@ -1,0 +1,46 @@
+{
+  "title": "Section sign (§) to backtick (`)",
+  "maintainers": [
+    "fredericrous"
+  ],
+  "rules": [
+    {
+      "description": "Remap section sign (§) from British Keyboard to US's backtick + plus minus (±) to tilde (~)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "non_us_backslash"
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "non_us_backslash",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "shift"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
remap the useless Section Sign on British keyboards to the common backtick found on US keyboards