### PR TITLE
Neo2 layout: Home/end key for your terminal in macOS.

### DIFF
--- a/public/extra_descriptions/neo2_macos_terminal.html
+++ b/public/extra_descriptions/neo2_macos_terminal.html
@@ -1,0 +1,16 @@
+<link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
+
+<p>This is an addon to the Karabiner alternative keyboard layout 'Neo2' for macOS. The addon lets you jump to the beginning and the end of a line in your terminal directly using ↖ and ↘︎ on layer 4. More precisely it maps <code>a</code>+<code>mod4</code> to <code>home</code> and <code>g</code>+<code>mod4</code> to <code>end</code> in the following terminal apps:
+<ul>
+<li>macOS Terminal</a>
+<li>iTerm2</a>
+<li>Hyper</a>
+<li>alacritty</a>
+<li>kitty</a>
+</ul>
+Installation steps:
+<ol>
+<li>Import this rule to Karabiner-Elements.</li>
+<li>In the Karabiner-Elements preferences: Make sure that you move this complex modification <em>above</em> the rule 'Neo2 layer 4' .</li>
+<li>In case you use the macOS Terminal: You need to perform an additional configuration step in the macOS Terminal preferences: Go to 'Terminal' -> 'Preferences' -> 'Profiles' -> 'Keyboard' and add the following two entries: Key: ↖ Action: \033OH and Key: ↘︎ Action: \033OF.</li>
+</ol>

--- a/public/groups.json
+++ b/public/groups.json
@@ -430,6 +430,10 @@
         },
         {
           "path": "json/KeynoteAndIllustrator.json"
+        },
+        {
+          "path": "json/neo2_macos_terminal.json",
+          "extra_description_path": "extra_descriptions/neo2_macos_terminal.html"
         }
       ]
     },

--- a/public/json/neo2_macos_terminal.json
+++ b/public/json/neo2_macos_terminal.json
@@ -1,0 +1,82 @@
+{
+  "title": "Neo2 extensions",
+  "rules": [
+    {
+      "description": "Neo2 - Terminal ↖ (home) and ↘︎ (end) extension.",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "optional": [
+                "shift",
+                "caps_lock",
+                "left_option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "home"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$",
+                "^co\\.zeit\\.hyperterm$",
+                "^co\\.zeit\\.hyper$",
+                "^io\\.alacritty$",
+                "^net\\.kovidgoyal\\.kitty$"
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "neo2_mod_4",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "g",
+            "modifiers": {
+              "optional": [
+                "shift",
+                "caps_lock",
+                "left_option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "end"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "neo2_mod_4",
+              "value": 0
+            },
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$",
+                "^co\\.zeit\\.hyperterm$",
+                "^co\\.zeit\\.hyper$",
+                "^io\\.alacritty$",
+                "^net\\.kovidgoyal\\.kitty$"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This rule lets you jump to the beginning and the end of a line in your
terminal directly using ↖ and ↘︎ on layer 4 in macOS.
So far it was not possible to do so via layer 4 in macOS using the standard Karabiner Neo2 rules.
