### PR TITLE
Add shortcuts for Apple Mail and Slack

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -430,6 +430,12 @@
         },
         {
           "path": "json/KeynoteAndIllustrator.json"
+        },
+        {
+          "path": "json/apple_mail_shortcuts.json"
+        },
+        {
+          "path": "json/slack_shortcuts.json"
         }
       ]
     },

--- a/public/json/apple_mail_shortcuts.json
+++ b/public/json/apple_mail_shortcuts.json
@@ -1,0 +1,39 @@
+{
+  "title": "Apple Mail shortcuts",
+  "rules": [
+    {
+      "description": "⌘-enter to send in Apple Mail",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            },
+            "key_code": "return_or_enter"
+          },
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "description": "Only for Apple Mail",
+              "bundle_identifiers": [
+                "com.apple.mail"
+              ]
+            }
+          ],
+          "to": [
+            {
+              "key_code": "d",
+              "modifiers": [
+                "shift",
+                "command"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/public/json/slack_shortcuts.json
+++ b/public/json/slack_shortcuts.json
@@ -1,0 +1,39 @@
+{
+  "title": "Slack shortcuts",
+  "rules": [
+    {
+      "description": "⌘-k to hyperlink in Slack",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "k",
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "description": "Only for Slack",
+              "bundle_identifiers": [
+                "com.tinyspeck.slackmacgap"
+              ]
+            }
+          ],
+          "to": [
+            {
+              "key_code": "u",
+              "modifiers": [
+                "shift",
+                "command"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adding some app-specific shortcuts that are impossible to set with System Preferences.

### Apple Mail
- **⌘-enter to send mail like in lots of other apps and websites**  
I've tried setting this with `defaults write com.apple.mail NSUserKeyEquivalents -dict-add "Send" "@\\U21a9"` and it shows up in the menu correctly, but doesn't actually function, so I think a key remap is required.

### Slack
- **⌘-k to insert or convert to hyperlink like most apps and sites**  
This has no menu item, so it's impossible to set with the OS.
