### PR TITLE
Neo2: Home/end key for your terminal.

### DIFF
--- a/public/json/neo2.json
+++ b/public/json/neo2.json
@@ -4164,7 +4164,7 @@
       ]
     },
     {
-      "description": "Neo2 mod 4: Map ↖ to Home and ↘︎ to End in terminal windows.",
+      "description": "Neo2 mod 4: Map ↖ to Home and ↘︎ to End in terminal apps (move this above the rule 'Neo2 layer 4').",
       "manipulators": [
         {
           "type": "basic",

--- a/public/json/neo2.json
+++ b/public/json/neo2.json
@@ -4162,6 +4162,83 @@
           ]
         }
       ]
+    },
+    {
+      "description": "Neo2 mod 4: Map ↖ to Home and ↘︎ to End in terminal windows.",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "optional": [
+                "shift",
+                "caps_lock",
+                "left_option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "home"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$",
+                "^co\\.zeit\\.hyperterm$",
+                "^co\\.zeit\\.hyper$",
+                "^io\\.alacritty$",
+                "^net\\.kovidgoyal\\.kitty$"
+              ]
+            },
+            {
+              "type": "variable_unless",
+              "name": "neo2_mod_4",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "g",
+            "modifiers": {
+              "optional": [
+                "shift",
+                "caps_lock",
+                "left_option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "end"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_unless",
+              "name": "neo2_mod_4",
+              "value": 0
+            },
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.apple\\.Terminal$",
+                "^com\\.googlecode\\.iterm2$",
+                "^co\\.zeit\\.hyperterm$",
+                "^co\\.zeit\\.hyper$",
+                "^io\\.alacritty$",
+                "^net\\.kovidgoyal\\.kitty$"
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/public/json/neo2.json
+++ b/public/json/neo2.json
@@ -4164,7 +4164,7 @@
       ]
     },
     {
-      "description": "Neo2 mod 4: Map ↖ to Home and ↘︎ to End in terminal apps (move this above the rule 'Neo2 layer 4').",
+      "description": "Neo2 mod 4: Map ↖ to Home and ↘︎ to End in terminal apps (move this rule above the rule 'Neo2 layer 4').",
       "manipulators": [
         {
           "type": "basic",
@@ -4185,6 +4185,11 @@
           ],
           "conditions": [
             {
+              "type": "variable_unless",
+              "name": "neo2_mod_4",
+              "value": 0
+            },
+            {
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^com\\.apple\\.Terminal$",
@@ -4194,11 +4199,6 @@
                 "^io\\.alacritty$",
                 "^net\\.kovidgoyal\\.kitty$"
               ]
-            },
-            {
-              "type": "variable_unless",
-              "name": "neo2_mod_4",
-              "value": 0
             }
           ]
         },

--- a/src/json/neo2.json.erb
+++ b/src/json/neo2.json.erb
@@ -212,6 +212,17 @@
                   to_pre_events: [["a", ["left_option", "left_shift"]]]
               )
           ) %>
+        },
+        {
+          "description": "Neo2 mod 4: Map ↖ to Home and ↘︎ to End in terminal apps (move this rule above the rule 'Neo2 layer 4').",
+          "manipulators":
+            <%= each_key(
+                source_keys_list: ["a", "g"],
+                dest_keys_list: ["home", "end"],
+                conditions: [$if_mod_4_on, JSON.parse(frontmost_application_if(["terminal"])) ],
+                from_optional_modifiers: ["shift", "caps_lock", "left_option"],
+                as_json: true
+            ) %>
         }
     ]
 }


### PR DESCRIPTION
<p>This rule lets you jump to the beginning and the end of a line in your terminal directly using <kbd>↖</kbd> and <kbd>↘︎</kbd> on layer 4. More precisely it maps <kbd>a</kbd> + <kbd>mod4</kbd> to <kbd>Home</kbd> and <kbd>g</kbd> + <kbd>mod4</kbd> to<kbd>End</kbd> in the following terminal apps: macOS Terminal, iTerm2, Hyper, alacritty, kitty.</p>
        <p>Make sure to move this rule <em>above</em> the rule 'Neo2 layer 4' in the Karabiner-Elements preferences.</p>
        <p>In case you use the macOS Terminal: You need to perform an additional configuration step in the macOS Terminal preferences: Go to 'Terminal' -> 'Preferences' -> 'Profiles' -> 'Keyboard' and add the following two entries: Key: ↖ Action: \033OH and Key: ↘︎ Action: \033OF.</p>