### PR TITLE
Neo2: fix links and typo

### DIFF
--- a/public/extra_descriptions/neo2.json.html
+++ b/public/extra_descriptions/neo2.json.html
@@ -1,8 +1,8 @@
 <link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
 
 <h2>Neo2 layout</h3>
-<p>Rules for the <a href="http://neo-layout.org/">Neo2 keyboard layout</a>.</p>
-<p>Intended to be used with the <a href="https://github.com/jgosmann/neo2-layout-osx">corresponding keyboard layout file</a>.</p>
+<p>Rules for the <a href="http://neo-layout.org/" target="_blank">Neo2 keyboard layout</a>.</p>
+<p>Intended to be used with the <a href="https://github.com/jgosmann/neo2-layout-osx" target="_blank">corresponding keyboard layout file</a>.</p>
 
 <h3>Base rules</h3>
 <table class="table">
@@ -43,10 +43,10 @@
   </tr>
   <tr>
     <td>Prevent problematic keys (?, /, #, =, and ')') from being treated as option key shortcut</td>
-    <td>This rule servers as a workaround for issues that layer 3 could cause in some applications. See <a href="https://github.com/jgosmann/neo2-layout-osx#know-issues">known issues</a> for more information.</td>
+    <td>This rule servers as a workaround for issues that layer 3 could cause in some applications. See <a href="https://github.com/jgosmann/neo2-layout-osx#know-issues" target="_blank">known issues</a> for more information.</td>
   </tr>
   <tr>
     <td>Prevent all layer 3 keys from being treated as option key shortcut</td>
-    <td>This rule servers as a workaround for issues that layer 3 could cause in some applications. See <a href="https://github.com/jgosmann/neo2-layout-osx#know-issues">known issues</a> for more information.</td>
+    <td>This rule servers as a workaround for issues that layer 3 could cause in some applications. See <a href="https://github.com/jgosmann/neo2-layout-osx#know-issues" target="_blank">known issues</a> for more information.</td>
   </tr>
 </dl>

--- a/public/extra_descriptions/neo2.json.html
+++ b/public/extra_descriptions/neo2.json.html
@@ -43,10 +43,10 @@
   </tr>
   <tr>
     <td>Prevent problematic keys (?, /, #, =, and ')') from being treated as option key shortcut</td>
-    <td>This rule servers as a workaround for issues that layer 3 could cause in some applications. See <a href="https://github.com/jgosmann/neo2-layout-osx#know-issues" target="_blank">known issues</a> for more information.</td>
+    <td>This rule serves as a workaround for issues that layer 3 could cause in some applications. See <a href="https://github.com/jgosmann/neo2-layout-osx#know-issues" target="_blank">known issues</a> for more information.</td>
   </tr>
   <tr>
     <td>Prevent all layer 3 keys from being treated as option key shortcut</td>
-    <td>This rule servers as a workaround for issues that layer 3 could cause in some applications. See <a href="https://github.com/jgosmann/neo2-layout-osx#know-issues" target="_blank">known issues</a> for more information.</td>
+    <td>This rule serves as a workaround for issues that layer 3 could cause in some applications. See <a href="https://github.com/jgosmann/neo2-layout-osx#know-issues" target="_blank">known issues</a> for more information.</td>
   </tr>
 </dl>


### PR DESCRIPTION
Commit 9ea210b forces links to open in new tab/window.
This fixes the current problem that the links 'get blocked' once the user clicks on the them. Reason: Apparently the current global page setup attempts to open them in a html sub-frame.

Commit 599b6bf fixes a small typo