### PR TITLE
Add rules to remap symbols from JIS to US keyboard

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -545,6 +545,9 @@
           "path": "json/jis_to_ascii.json"
         },
         {
+          "path": "json/jis_to_us_symbols.json"
+        },
+        {
           "path": "json/german_pc_shortcuts.json"
         },
         {

--- a/public/json/jis_to_us_symbols.json
+++ b/public/json/jis_to_us_symbols.json
@@ -21,6 +21,14 @@
             {
               "key_code": "open_bracket"
             }
+          ],
+          "conditions": [
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": [
+                "jis"
+              ]
+            }
           ]
         }
       ]
@@ -41,6 +49,14 @@
           "to": [
             {
               "key_code": "equal_sign"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": [
+                "jis"
+              ]
             }
           ]
         }
@@ -64,6 +80,14 @@
               "key_code": "6",
               "modifiers": [
                 "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": [
+                "jis"
               ]
             }
           ]
@@ -90,6 +114,14 @@
                 "left_shift"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": [
+                "jis"
+              ]
+            }
           ]
         }
       ]
@@ -112,6 +144,14 @@
               "key_code": "8",
               "modifiers": [
                 "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": [
+                "jis"
               ]
             }
           ]
@@ -138,6 +178,14 @@
                 "left_shift"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": [
+                "jis"
+              ]
+            }
           ]
         }
       ]
@@ -159,6 +207,14 @@
             {
               "key_code": "international1"
             }
+          ],
+          "conditions": [
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": [
+                "jis"
+              ]
+            }
           ]
         }
       ]
@@ -176,6 +232,14 @@
               "key_code": "hyphen",
               "modifiers": [
                 "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": [
+                "jis"
               ]
             }
           ]
@@ -202,6 +266,14 @@
                 "left_shift"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": [
+                "jis"
+              ]
+            }
           ]
         }
       ]
@@ -219,6 +291,14 @@
               "key_code": "open_bracket",
               "modifiers": [
                 "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": [
+                "jis"
               ]
             }
           ]
@@ -245,6 +325,14 @@
                 "left_shift"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": [
+                "jis"
+              ]
+            }
           ]
         }
       ]
@@ -260,6 +348,14 @@
           "to": [
             {
               "key_code": "close_bracket"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": [
+                "jis"
+              ]
             }
           ]
         }
@@ -285,6 +381,14 @@
                 "left_shift"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": [
+                "jis"
+              ]
+            }
           ]
         }
       ]
@@ -300,6 +404,14 @@
           "to": [
             {
               "key_code": "backslash"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": [
+                "jis"
+              ]
             }
           ]
         }
@@ -325,6 +437,14 @@
                 "left_shift"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": [
+                "jis"
+              ]
+            }
           ]
         }
       ]
@@ -346,6 +466,14 @@
             {
               "key_code": "quote"
             }
+          ],
+          "conditions": [
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": [
+                "jis"
+              ]
+            }
           ]
         }
       ]
@@ -363,6 +491,14 @@
               "key_code": "7",
               "modifiers": [
                 "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": [
+                "jis"
               ]
             }
           ]
@@ -389,6 +525,14 @@
                 "left_shift"
               ]
             }
+          ],
+          "conditions": [
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": [
+                "jis"
+              ]
+            }
           ]
         }
       ]
@@ -406,6 +550,14 @@
               "key_code": "international3",
               "modifiers": [
                 "left_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": [
+                "jis"
               ]
             }
           ]
@@ -430,6 +582,14 @@
               "key_code": "international3",
               "modifiers": [
                 "left_shift"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": [
+                "jis"
               ]
             }
           ]

--- a/public/json/jis_to_us_symbols.json
+++ b/public/json/jis_to_us_symbols.json
@@ -13,23 +13,7 @@
             "key_code": "2",
             "modifiers": {
               "mandatory": [
-                "left_shift"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "open_bracket"
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "2",
-            "modifiers": {
-              "mandatory": [
-                "right_shift"
+                "shift"
               ]
             }
           },
@@ -50,23 +34,7 @@
             "key_code": "6",
             "modifiers": {
               "mandatory": [
-                "left_shift"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "equal_sign"
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "6",
-            "modifiers": {
-              "mandatory": [
-                "right_shift"
+                "shift"
               ]
             }
           },
@@ -87,26 +55,7 @@
             "key_code": "7",
             "modifiers": {
               "mandatory": [
-                "left_shift"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "6",
-              "modifiers": [
-                "left_shift"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "7",
-            "modifiers": {
-              "mandatory": [
-                "right_shift"
+                "shift"
               ]
             }
           },
@@ -130,26 +79,7 @@
             "key_code": "8",
             "modifiers": {
               "mandatory": [
-                "left_shift"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "quote",
-              "modifiers": [
-                "left_shift"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "8",
-            "modifiers": {
-              "mandatory": [
-                "right_shift"
+                "shift"
               ]
             }
           },
@@ -173,26 +103,7 @@
             "key_code": "9",
             "modifiers": {
               "mandatory": [
-                "left_shift"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "8",
-              "modifiers": [
-                "left_shift"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "9",
-            "modifiers": {
-              "mandatory": [
-                "right_shift"
+                "shift"
               ]
             }
           },
@@ -216,26 +127,7 @@
             "key_code": "0",
             "modifiers": {
               "mandatory": [
-                "left_shift"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "9",
-              "modifiers": [
-                "left_shift"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "0",
-            "modifiers": {
-              "mandatory": [
-                "right_shift"
+                "shift"
               ]
             }
           },
@@ -259,23 +151,7 @@
             "key_code": "hyphen",
             "modifiers": {
               "mandatory": [
-                "left_shift"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "international1"
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "hyphen",
-            "modifiers": {
-              "mandatory": [
-                "right_shift"
+                "shift"
               ]
             }
           },
@@ -315,26 +191,7 @@
             "key_code": "equal_sign",
             "modifiers": {
               "mandatory": [
-                "left_shift"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "semicolon",
-              "modifiers": [
-                "left_shift"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "equal_sign",
-            "modifiers": {
-              "mandatory": [
-                "right_shift"
+                "shift"
               ]
             }
           },
@@ -377,26 +234,7 @@
             "key_code": "international3",
             "modifiers": {
               "mandatory": [
-                "left_shift"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "equal_sign",
-              "modifiers": [
-                "left_shift"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "international3",
-            "modifiers": {
-              "mandatory": [
-                "right_shift"
+                "shift"
               ]
             }
           },
@@ -436,26 +274,7 @@
             "key_code": "open_bracket",
             "modifiers": {
               "mandatory": [
-                "left_shift"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "close_bracket",
-              "modifiers": [
-                "left_shift"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "open_bracket",
-            "modifiers": {
-              "mandatory": [
-                "right_shift"
+                "shift"
               ]
             }
           },
@@ -495,26 +314,7 @@
             "key_code": "close_bracket",
             "modifiers": {
               "mandatory": [
-                "left_shift"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "backslash",
-              "modifiers": [
-                "left_shift"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "close_bracket",
-            "modifiers": {
-              "mandatory": [
-                "right_shift"
+                "shift"
               ]
             }
           },
@@ -538,23 +338,7 @@
             "key_code": "semicolon",
             "modifiers": {
               "mandatory": [
-                "left_shift"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "quote"
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "semicolon",
-            "modifiers": {
-              "mandatory": [
-                "right_shift"
+                "shift"
               ]
             }
           },
@@ -594,26 +378,7 @@
             "key_code": "quote",
             "modifiers": {
               "mandatory": [
-                "left_shift"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "2",
-              "modifiers": [
-                "left_shift"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "quote",
-            "modifiers": {
-              "mandatory": [
-                "right_shift"
+                "shift"
               ]
             }
           },
@@ -656,26 +421,7 @@
             "key_code": "backslash",
             "modifiers": {
               "mandatory": [
-                "left_shift"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "international3",
-              "modifiers": [
-                "left_shift"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "backslash",
-            "modifiers": {
-              "mandatory": [
-                "right_shift"
+                "shift"
               ]
             }
           },

--- a/public/json/jis_to_us_symbols.json
+++ b/public/json/jis_to_us_symbols.json
@@ -1,0 +1,694 @@
+{
+  "title": "Japanese JIS to US Keyboard: Remap Symbol Keys",
+  "maintainers": [
+    "halfwhole"
+  ],
+  "rules": [
+    {
+      "description": "Change shift + 2 from \" to @",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "2",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "open_bracket"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "2",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "open_bracket"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change shift + 6 from & to ^",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "6",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "equal_sign"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "6",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "equal_sign"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change shift + 7 from ' to &",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "7",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "6",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "7",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "6",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change shift + 8 from ( to *",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "8",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "quote",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "8",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "quote",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change shift + 9 from ) to (",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "9",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "8",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "9",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "8",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change shift + 0 from 0 to )",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "0",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "9",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "0",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "9",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change shift + - from = to _",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "hyphen",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "international1"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "hyphen",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "international1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change ^ to =",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "equal_sign"
+          },
+          "to": [
+            {
+              "key_code": "hyphen",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change shift + ^ from ~ to +",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "equal_sign",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "semicolon",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "equal_sign",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "semicolon",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change ¥ to `",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "international3"
+          },
+          "to": [
+            {
+              "key_code": "open_bracket",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change shift + ¥ from | to ~",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "international3",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "equal_sign",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "international3",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "equal_sign",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change @ to [",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "open_bracket"
+          },
+          "to": [
+            {
+              "key_code": "close_bracket"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change shift + @ from ` to {",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "open_bracket",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "close_bracket",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "open_bracket",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "close_bracket",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change [ to ]",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "close_bracket"
+          },
+          "to": [
+            {
+              "key_code": "backslash"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change shift + [ from { to }",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "close_bracket",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "backslash",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "close_bracket",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "backslash",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change shift + ; from + to :",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "semicolon",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "quote"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "semicolon",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "quote"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change : to '",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "quote"
+          },
+          "to": [
+            {
+              "key_code": "7",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change shift + : from * to \"",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "quote",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "2",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "quote",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "2",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change ] to \\",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "backslash"
+          },
+          "to": [
+            {
+              "key_code": "international3",
+              "modifiers": [
+                "left_option"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change shift + ] from } to |",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "backslash",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "international3",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "backslash",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "international3",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/jis_to_us_symbols.json.rb
+++ b/src/json/jis_to_us_symbols.json.rb
@@ -11,19 +11,10 @@ Mapping = Struct.new(:description, :from_key, :is_from_shift, :to_key, :is_to_sh
 end
 
 def create_rule(mapping)
-  def create_manipulator(from, to)
-    {
-      'type': 'basic',
-      'from': from,
-      'to': [to]
-    }
-  end
-
   from = { 'key_code': mapping.from_key }
-  from_left_shift = from.clone
-  from_right_shift = from.clone
-  from_left_shift[:modifiers] = { 'mandatory': ['left_shift'] }
-  from_right_shift[:modifiers] = { 'mandatory': ['right_shift'] }
+  if mapping.is_from_shift
+    from[:modifiers] = { 'mandatory': ['shift'] }
+  end
 
   to = { 'key_code': mapping.to_key }
   if mapping.is_to_shift
@@ -34,9 +25,13 @@ def create_rule(mapping)
 
   {
     'description': mapping.description,
-    'manipulators': mapping.is_from_shift ?
-      [create_manipulator(from_left_shift, to), create_manipulator(from_right_shift, to)] :
-      [create_manipulator(from, to)]
+    'manipulators': [
+      {
+        'type': 'basic',
+        'from': from,
+        'to': [to]
+      }
+    ]
   }
 end
 

--- a/src/json/jis_to_us_symbols.json.rb
+++ b/src/json/jis_to_us_symbols.json.rb
@@ -1,0 +1,76 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+
+Mapping = Struct.new(:description, :from_key, :is_from_shift, :to_key, :is_to_shift, :is_to_option) do
+  def initialize(*)
+    super
+    self.is_to_option ||= false
+  end
+end
+
+def create_rule(mapping)
+  def create_manipulator(from, to)
+    {
+      'type': 'basic',
+      'from': from,
+      'to': [to]
+    }
+  end
+
+  from = { 'key_code': mapping.from_key }
+  from_left_shift = from.clone
+  from_right_shift = from.clone
+  from_left_shift[:modifiers] = { 'mandatory': ['left_shift'] }
+  from_right_shift[:modifiers] = { 'mandatory': ['right_shift'] }
+
+  to = { 'key_code': mapping.to_key }
+  if mapping.is_to_shift
+    to[:modifiers] = ['left_shift']
+  elsif mapping.is_to_option
+    to[:modifiers] = ['left_option']
+  end
+
+  {
+    'description': mapping.description,
+    'manipulators': mapping.is_from_shift ?
+      [create_manipulator(from_left_shift, to), create_manipulator(from_right_shift, to)] :
+      [create_manipulator(from, to)]
+  }
+end
+
+def main
+  mappings = [
+    # Number mappings
+    Mapping.new('Change shift + 2 from " to @', '2', true, 'open_bracket', false),
+    Mapping.new('Change shift + 6 from & to ^', '6', true, 'equal_sign', false),
+    Mapping.new('Change shift + 7 from \' to &', '7', true, '6', true),
+    Mapping.new('Change shift + 8 from ( to *', '8', true, 'quote', true),
+    Mapping.new('Change shift + 9 from ) to (', '9', true, '8', true),
+    Mapping.new('Change shift + 0 from 0 to )', '0', true, '9', true),
+    # Other symbol mappings
+    Mapping.new('Change shift + - from = to _', 'hyphen', true, 'international1', false),
+    Mapping.new('Change ^ to =', 'equal_sign', false, 'hyphen', true),
+    Mapping.new('Change shift + ^ from ~ to +', 'equal_sign', true, 'semicolon', true),
+    Mapping.new('Change ¥ to `', 'international3', false, 'open_bracket', true),
+    Mapping.new('Change shift + ¥ from | to ~', 'international3', true, 'equal_sign', true),
+    Mapping.new('Change @ to [', 'open_bracket', false, 'close_bracket', false),
+    Mapping.new('Change shift + @ from ` to {', 'open_bracket', true, 'close_bracket', true),
+    Mapping.new('Change [ to ]', 'close_bracket', false, 'backslash', false),
+    Mapping.new('Change shift + [ from { to }', 'close_bracket', true, 'backslash', true),
+    Mapping.new('Change shift + ; from + to :', 'semicolon', true, 'quote', false),
+    Mapping.new('Change : to \'', 'quote', false, '7', true),
+    Mapping.new('Change shift + : from * to "', 'quote', true, '2', true),
+    Mapping.new('Change ] to \\', 'backslash', false, 'international3', false, true),  # \ is option + ¥
+    Mapping.new('Change shift + ] from } to |', 'backslash', true, 'international3', true)
+  ]
+  result = {
+    'title': 'Japanese JIS to US Keyboard: Remap Symbol Keys',
+    'maintainers': ['halfwhole'],
+    'rules': mappings.map { |mapping| create_rule(mapping) }
+  }
+  puts JSON.pretty_generate(result)
+end
+
+main

--- a/src/json/jis_to_us_symbols.json.rb
+++ b/src/json/jis_to_us_symbols.json.rb
@@ -23,13 +23,19 @@ def create_rule(mapping)
     to[:modifiers] = ['left_option']
   end
 
+  condition = {
+    'type': 'keyboard_type_if',
+    'keyboard_types': ['jis']
+  }
+
   {
     'description': mapping.description,
     'manipulators': [
       {
         'type': 'basic',
         'from': from,
-        'to': [to]
+        'to': [to],
+        'conditions': [condition]
       }
     ]
   }


### PR DESCRIPTION
These rules help to remap the symbols on a JIS keyboard to a layout that's much more reminiscent to that of a US keyboard