### PR TITLE
Maps Eject key to toggle Mute Mic in Microsoft Teams

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -445,6 +445,9 @@
         },
         {
           "path": "json/slack_shortcuts.json"
+        },
+        {
+          "path": "json/eject_to_activate_and_toggle_mic_mute_ms_teams.json"
         }
       ]
     },

--- a/public/json/eject_to_activate_and_toggle_mic_mute_ms_teams.json
+++ b/public/json/eject_to_activate_and_toggle_mic_mute_ms_teams.json
@@ -1,0 +1,23 @@
+{
+    "title": "Toggle mic mute in MS Teams with the Eject key",
+    "rules": [
+        {
+            "description": "Maps Eject to ⌘⇧M in Teams",
+            "manipulators": [
+                {
+                    "from": {
+                        "consumer_key_code": "eject"
+                    },
+                    "to": [
+                        {
+                            "shell_command": "if [ $(ps aux | grep -v grep | grep -ci \"Microsoft Teams.app/Contents/Frameworks/Microsoft Teams Helper.app\") -gt 0 ]; then osascript -e 'activate application id \"com.microsoft.teams\"' -e 'tell application \"System Events\" to keystroke \"m\" using {command down, shift down}'; fi",
+                            "lazy": true,
+                            "repeat": true
+                          }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This PR adds a rule to map Eject to an AppleScript that sends ⌘⇧M to MS Teams. It has already proven to useful for noisy environments.