### PR TITLE
Added right command + v to paste without formatting

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -820,6 +820,9 @@
         },
         {
           "path": "json/caps_escape.json"
+        },
+        {
+          "path": "json/right_command_v_special_paste.json"
         }
       ]
     },

--- a/public/json/right_command_v_special_paste.json
+++ b/public/json/right_command_v_special_paste.json
@@ -1,0 +1,27 @@
+{
+	"title": "Right Command + v to paste without formatting",
+  "rules": [
+    {
+	"description": "Right Command + v does special paste without formatting, equivalent to. cmd+opt+shift+v.",
+      "manipulators": [
+        {
+          "type": "basic",
+
+          "from": {
+            "key_code": "v",
+            "modifiers": {
+              "mandatory": ["right_command"]
+            }
+          },
+
+          "to": [
+            {
+              "key_code": "v",
+				"modifiers": ["left_command", "left_option", "left_shift"]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Hello,

I've written a small complex modification to make `right command + v` paste without formatting. Pretty useful as it's much easier on the hands and a convenient keybinding for anyone who does a lot of copy-pasting into style-aware documents. Thank you!