### PR TITLE
Add Hyper Key w/ Caps Lock fallback

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -5,6 +5,9 @@
       "id": "modifier-keys",
       "files": [
         {
+          "path": "json/hyper_key.json"
+        },
+        {
           "path": "json/bepo-cmdqwerty-toggle.json"
         },
         {

--- a/public/json/hyper_key.json
+++ b/public/json/hyper_key.json
@@ -1,5 +1,5 @@
 {
-	"title": "Hyper Key",
+	"title": "Caps Lock → Hyper Key (⌃⌥⇧⌘) (Caps Lock if alone)",
 	"rules": [
 		{
 			"description": "Caps Lock → Hyper Key (⌃⌥⇧⌘) (Caps Lock if alone)",

--- a/public/json/hyper_key.json
+++ b/public/json/hyper_key.json
@@ -1,0 +1,31 @@
+{
+	"title": "Hyper Key",
+	"rules": [
+		{
+			"description": "Caps Lock → Hyper Key (⌃⌥⇧⌘) (Caps Lock if alone)",
+			"manipulators": [
+				{
+					"from": {
+						"key_code": "caps_lock"
+					},
+					"to": [
+						{
+							"key_code": "left_shift",
+							"modifiers": [
+								"left_command",
+								"left_control",
+								"left_option"
+							]
+						}
+					],
+					"to_if_alone": [
+						{
+							"key_code": "caps_lock"
+						}
+					],
+					"type": "basic"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
There are a bunch of hyper key rules in the directory, but I didn't see any that still function as caps lock when pressed alone. (Most seem to go to Esc—I have an escape key for that.)