### PR TITLE
Add control and option as optional modifiers in JIS to US remappings

### DIFF
--- a/public/json/jis_to_us_symbols.json
+++ b/public/json/jis_to_us_symbols.json
@@ -14,7 +14,8 @@
             "modifiers": {
               "optional": [
                 "control",
-                "option"
+                "option",
+                "command"
               ],
               "mandatory": [
                 "shift"
@@ -47,7 +48,8 @@
             "modifiers": {
               "optional": [
                 "control",
-                "option"
+                "option",
+                "command"
               ],
               "mandatory": [
                 "shift"
@@ -80,7 +82,8 @@
             "modifiers": {
               "optional": [
                 "control",
-                "option"
+                "option",
+                "command"
               ],
               "mandatory": [
                 "shift"
@@ -116,7 +119,8 @@
             "modifiers": {
               "optional": [
                 "control",
-                "option"
+                "option",
+                "command"
               ],
               "mandatory": [
                 "shift"
@@ -152,7 +156,8 @@
             "modifiers": {
               "optional": [
                 "control",
-                "option"
+                "option",
+                "command"
               ],
               "mandatory": [
                 "shift"
@@ -188,7 +193,8 @@
             "modifiers": {
               "optional": [
                 "control",
-                "option"
+                "option",
+                "command"
               ],
               "mandatory": [
                 "shift"
@@ -224,7 +230,8 @@
             "modifiers": {
               "optional": [
                 "control",
-                "option"
+                "option",
+                "command"
               ],
               "mandatory": [
                 "shift"
@@ -257,7 +264,8 @@
             "modifiers": {
               "optional": [
                 "control",
-                "option"
+                "option",
+                "command"
               ]
             }
           },
@@ -290,7 +298,8 @@
             "modifiers": {
               "optional": [
                 "control",
-                "option"
+                "option",
+                "command"
               ],
               "mandatory": [
                 "shift"
@@ -326,7 +335,8 @@
             "modifiers": {
               "optional": [
                 "control",
-                "option"
+                "option",
+                "command"
               ]
             }
           },
@@ -359,7 +369,8 @@
             "modifiers": {
               "optional": [
                 "control",
-                "option"
+                "option",
+                "command"
               ],
               "mandatory": [
                 "shift"
@@ -395,7 +406,8 @@
             "modifiers": {
               "optional": [
                 "control",
-                "option"
+                "option",
+                "command"
               ]
             }
           },
@@ -425,7 +437,8 @@
             "modifiers": {
               "optional": [
                 "control",
-                "option"
+                "option",
+                "command"
               ],
               "mandatory": [
                 "shift"
@@ -461,7 +474,8 @@
             "modifiers": {
               "optional": [
                 "control",
-                "option"
+                "option",
+                "command"
               ]
             }
           },
@@ -491,7 +505,8 @@
             "modifiers": {
               "optional": [
                 "control",
-                "option"
+                "option",
+                "command"
               ],
               "mandatory": [
                 "shift"
@@ -527,7 +542,8 @@
             "modifiers": {
               "optional": [
                 "control",
-                "option"
+                "option",
+                "command"
               ],
               "mandatory": [
                 "shift"
@@ -560,7 +576,8 @@
             "modifiers": {
               "optional": [
                 "control",
-                "option"
+                "option",
+                "command"
               ]
             }
           },
@@ -593,7 +610,8 @@
             "modifiers": {
               "optional": [
                 "control",
-                "option"
+                "option",
+                "command"
               ],
               "mandatory": [
                 "shift"
@@ -629,7 +647,8 @@
             "modifiers": {
               "optional": [
                 "control",
-                "option"
+                "option",
+                "command"
               ]
             }
           },
@@ -662,7 +681,8 @@
             "modifiers": {
               "optional": [
                 "control",
-                "option"
+                "option",
+                "command"
               ],
               "mandatory": [
                 "shift"

--- a/public/json/jis_to_us_symbols.json
+++ b/public/json/jis_to_us_symbols.json
@@ -12,6 +12,10 @@
           "from": {
             "key_code": "2",
             "modifiers": {
+              "optional": [
+                "control",
+                "option"
+              ],
               "mandatory": [
                 "shift"
               ]
@@ -41,6 +45,10 @@
           "from": {
             "key_code": "6",
             "modifiers": {
+              "optional": [
+                "control",
+                "option"
+              ],
               "mandatory": [
                 "shift"
               ]
@@ -70,6 +78,10 @@
           "from": {
             "key_code": "7",
             "modifiers": {
+              "optional": [
+                "control",
+                "option"
+              ],
               "mandatory": [
                 "shift"
               ]
@@ -102,6 +114,10 @@
           "from": {
             "key_code": "8",
             "modifiers": {
+              "optional": [
+                "control",
+                "option"
+              ],
               "mandatory": [
                 "shift"
               ]
@@ -134,6 +150,10 @@
           "from": {
             "key_code": "9",
             "modifiers": {
+              "optional": [
+                "control",
+                "option"
+              ],
               "mandatory": [
                 "shift"
               ]
@@ -166,6 +186,10 @@
           "from": {
             "key_code": "0",
             "modifiers": {
+              "optional": [
+                "control",
+                "option"
+              ],
               "mandatory": [
                 "shift"
               ]
@@ -198,6 +222,10 @@
           "from": {
             "key_code": "hyphen",
             "modifiers": {
+              "optional": [
+                "control",
+                "option"
+              ],
               "mandatory": [
                 "shift"
               ]
@@ -225,7 +253,13 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "equal_sign"
+            "key_code": "equal_sign",
+            "modifiers": {
+              "optional": [
+                "control",
+                "option"
+              ]
+            }
           },
           "to": [
             {
@@ -254,6 +288,10 @@
           "from": {
             "key_code": "equal_sign",
             "modifiers": {
+              "optional": [
+                "control",
+                "option"
+              ],
               "mandatory": [
                 "shift"
               ]
@@ -284,7 +322,13 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "international3"
+            "key_code": "international3",
+            "modifiers": {
+              "optional": [
+                "control",
+                "option"
+              ]
+            }
           },
           "to": [
             {
@@ -313,6 +357,10 @@
           "from": {
             "key_code": "international3",
             "modifiers": {
+              "optional": [
+                "control",
+                "option"
+              ],
               "mandatory": [
                 "shift"
               ]
@@ -343,7 +391,13 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "open_bracket"
+            "key_code": "open_bracket",
+            "modifiers": {
+              "optional": [
+                "control",
+                "option"
+              ]
+            }
           },
           "to": [
             {
@@ -369,6 +423,10 @@
           "from": {
             "key_code": "open_bracket",
             "modifiers": {
+              "optional": [
+                "control",
+                "option"
+              ],
               "mandatory": [
                 "shift"
               ]
@@ -399,7 +457,13 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "close_bracket"
+            "key_code": "close_bracket",
+            "modifiers": {
+              "optional": [
+                "control",
+                "option"
+              ]
+            }
           },
           "to": [
             {
@@ -425,6 +489,10 @@
           "from": {
             "key_code": "close_bracket",
             "modifiers": {
+              "optional": [
+                "control",
+                "option"
+              ],
               "mandatory": [
                 "shift"
               ]
@@ -457,6 +525,10 @@
           "from": {
             "key_code": "semicolon",
             "modifiers": {
+              "optional": [
+                "control",
+                "option"
+              ],
               "mandatory": [
                 "shift"
               ]
@@ -484,7 +556,13 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "quote"
+            "key_code": "quote",
+            "modifiers": {
+              "optional": [
+                "control",
+                "option"
+              ]
+            }
           },
           "to": [
             {
@@ -513,6 +591,10 @@
           "from": {
             "key_code": "quote",
             "modifiers": {
+              "optional": [
+                "control",
+                "option"
+              ],
               "mandatory": [
                 "shift"
               ]
@@ -543,7 +625,13 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "backslash"
+            "key_code": "backslash",
+            "modifiers": {
+              "optional": [
+                "control",
+                "option"
+              ]
+            }
           },
           "to": [
             {
@@ -572,6 +660,10 @@
           "from": {
             "key_code": "backslash",
             "modifiers": {
+              "optional": [
+                "control",
+                "option"
+              ],
               "mandatory": [
                 "shift"
               ]

--- a/src/json/jis_to_us_symbols.json.rb
+++ b/src/json/jis_to_us_symbols.json.rb
@@ -14,7 +14,7 @@ def create_rule(mapping)
   from = {
     'key_code': mapping.from_key,
     'modifiers': {
-      'optional': ['control', 'option']
+      'optional': ['control', 'option', 'command']
     }
   }
   if mapping.is_from_shift

--- a/src/json/jis_to_us_symbols.json.rb
+++ b/src/json/jis_to_us_symbols.json.rb
@@ -11,9 +11,14 @@ Mapping = Struct.new(:description, :from_key, :is_from_shift, :to_key, :is_to_sh
 end
 
 def create_rule(mapping)
-  from = { 'key_code': mapping.from_key }
+  from = {
+    'key_code': mapping.from_key,
+    'modifiers': {
+      'optional': ['control', 'option']
+    }
+  }
   if mapping.is_from_shift
-    from[:modifiers] = { 'mandatory': ['shift'] }
+    from[:modifiers][:mandatory] = ['shift']
   end
 
   to = { 'key_code': mapping.to_key }


### PR DESCRIPTION
An add-on to previous PR #888, allowing control and option specifically to be optional modifiers in the rules. It's handy when attempting combinations such as shift+alt+;
