### PR TITLE
made typematrix bepo distinct and added new one

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -986,6 +986,9 @@
           "path": "json/typematrix_bepo_cut_copy_paste_fn_shortcuts.json"
         },
         {
+          "path": "json/typematrix_cut_copy_past_fn_keys.json"
+        },
+        {
           "path": "json/r400.json"
         },
         {

--- a/public/json/typematrix_cut_copy_past_fn_keys.json
+++ b/public/json/typematrix_cut_copy_past_fn_keys.json
@@ -1,5 +1,5 @@
 {
-    "title": "Typematrix 2030 USB pc style Copy/Cut/Paste - BEPO layout",
+    "title": "Typematrix 2030 USB pc style Copy/Cut/Paste",
     "rules": [
         {
             "description": "Function Copy",
@@ -18,7 +18,7 @@
                     },
                     "to": [
                         {
-                            "key_code": "h",
+                            "key_code": "c",
                             "modifiers": [
                                 "command"
                             ]
@@ -45,7 +45,7 @@
                     },
                     "to": [
                         {
-                            "key_code": "c",
+                            "key_code": "x",
                             "modifiers": [
                                 "command"
                             ]
@@ -72,7 +72,7 @@
                     },
                     "to": [
                         {
-                            "key_code": "u",
+                            "key_code": "v",
                             "modifiers": [
                                 "command"
                             ]


### PR DESCRIPTION
The current typematrix json is specifically for bepo layout. 
New json added for normal keys as expected by mac (qwerty/dvorak)