### PR TITLE
Fixed key codes for F11, F12 in caps_num_to_func_keys

### DIFF
--- a/public/json/caps_num_to_func_keys.json
+++ b/public/json/caps_num_to_func_keys.json
@@ -245,7 +245,7 @@
             }
           ],
           "from": {
-            "key_code": "-",
+            "key_code": "hyphen",
             "modifiers": {
               "optional": [
                 "any"
@@ -268,7 +268,7 @@
             }
           ],
           "from": {
-            "key_code": "+",
+            "key_code": "equal_sign",
             "modifiers": {
               "optional": [
                 "any"


### PR DESCRIPTION
When loaded `public/json/caps_num_to_func_keys.json` would show this error:

```
[2021-08-15 14:27:47.141] [error] [grabber] karabiner.json error: `from` error: `key_code` error: unknown key_code: `"-"`
[2021-08-15 14:27:47.141] [error] [grabber] karabiner.json error: `from` error: `key_code` error: unknown key_code: `"+"`
```

This change maps the correct key codes.