### PR TITLE
Change modifier behavior for swapping {} and []

### DIFF
--- a/public/json/exchange_square_brackets_and_curly_brackets.json
+++ b/public/json/exchange_square_brackets_and_curly_brackets.json
@@ -2,7 +2,7 @@
   "title": "Exchange square brackets and curly brackets",
   "rules": [
     {
-      "description": "Swap {} and []",
+      "description": "Exchange {} and []",
       "manipulators": [
         {
           "type": "basic",
@@ -21,7 +21,7 @@
           "from": {
             "key_code": "open_bracket",
             "modifiers": {
-              "mandatory": ["left_shift"]
+              "mandatory": ["shift"]
             }
           },
           "to": [
@@ -47,7 +47,7 @@
           "from": {
             "key_code": "close_bracket",
             "modifiers": {
-              "mandatory": ["left_shift"]
+              "mandatory": ["shift"]
             }
           },
           "to": [


### PR DESCRIPTION
Allow either shift key to be used as the modifier, rather than only allowing the left shift.

Also change the description to match the format of the other 'exchange' rules.