### PR TITLE
Updated complex modification: Capslock vim movements to rev2

### DIFF
--- a/public/extra_descriptions/capslock_vim_movements.html
+++ b/public/extra_descriptions/capslock_vim_movements.html
@@ -1,6 +1,6 @@
 <link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
 
-<h4>Caps Lock Vim Movements</h4>
+<h4>Caps Lock Vim Movements (rev 2)</h4>
 
 <p>Simulate Vim movements with caps lock as the main modifier.</p>
 
@@ -32,7 +32,11 @@ set ended up not combining well with native MacOS modifiers.</p>
       <td>Escape</td>
     </tr>
     <tr>
-      <td>Caps lock + Return</td>
+      <td>Caps lock + Return (if enable "CAPS+↩︎ › CAPS" rule)</td>
+      <td>Caps lock</td>
+    </tr>
+    <tr>
+      <td>Caps lock + A (if enable "CAPS+A › CAPS" rule)</td>
       <td>Caps lock</td>
     </tr>
     <tr>
@@ -61,6 +65,15 @@ set ended up not combining well with native MacOS modifiers.</p>
     </tr>
   </tbody>
 </table>
+
+<h5>Change Log</h5>
+
+<dl>
+  <dt>Revision 1</dt>
+  <dd>Original version.</dd>
+  <dt>Revision 2</dt>
+  <dd>Split "CAPS+↩︎ › CAPS" from main rule and added "CAPS+A › CAPS".</dd>
+</dl>
 
 <h5>Credits</h5>
 

--- a/public/json/capslock_vim_movements.json
+++ b/public/json/capslock_vim_movements.json
@@ -1,32 +1,9 @@
 {
-    "title": "Caps Lock Vim Movements",
+    "title": "Caps Lock Vim Movements (rev 2)",
     "rules": [
         {
-            "description": "CAPS › ESC, CAPS+H/J/K/L › ←↓↑→, CAPS+D/U › PG↓↑, CAPS+↩︎ › CAPS",
+            "description": "CAPS › ESC, CAPS+H/J/K/L › ←↓↑→, CAPS+D/U › PG↓↑",
             "manipulators": [
-                {
-                    "conditions": [
-                        {
-                            "name": "caps_lock pressed",
-                            "type": "variable_if",
-                            "value": 1
-                        }
-                    ],
-                    "from": {
-                        "key_code": "return_or_enter",
-                        "modifiers": {
-                            "optional": [
-                                "any"
-                            ]
-                        }
-                    },
-                    "to": [
-                        {
-                            "key_code": "caps_lock"
-                        }
-                    ],
-                    "type": "basic"
-                },
                 {
                     "conditions": [
                         {
@@ -193,6 +170,62 @@
                     "to_if_alone": [
                         {
                             "key_code": "escape"
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "CAPS+↩︎ › CAPS",
+            "manipulators": [
+                {
+                    "conditions": [
+                        {
+                            "name": "caps_lock pressed",
+                            "type": "variable_if",
+                            "value": 1
+                        }
+                    ],
+                    "from": {
+                        "key_code": "return_or_enter",
+                        "modifiers": {
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "caps_lock"
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "CAPS+A › CAPS",
+            "manipulators": [
+                {
+                    "conditions": [
+                        {
+                            "name": "caps_lock pressed",
+                            "type": "variable_if",
+                            "value": 1
+                        }
+                    ],
+                    "from": {
+                        "key_code": "a",
+                        "modifiers": {
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "caps_lock"
                         }
                     ],
                     "type": "basic"


### PR DESCRIPTION
Changes:

- Split out "caps + enter" to trigger caps combo into own rule.
- Added "caps + a" to trigger caps combo rule.