### PR TITLE
Shortcut to set a numpad

### DIFF
--- a/public/extra_descriptions/set_num_lock.html
+++ b/public/extra_descriptions/set_num_lock.html
@@ -1,0 +1,10 @@
+Use a shortcut to toggle a portion of your keyboard to a numeric keypad. Perfect for 60%-keyboard users. 
+
+Shortcut: left_control + left_shift + N
+
+Layout of numeric keypad:
+
+9 0 -   maps to 7 8 9
+o p [   maps to 4 5 6
+l ; '   maps to 1 2 3
+,       maps to 0 

--- a/public/groups.json
+++ b/public/groups.json
@@ -262,6 +262,10 @@
           "extra_description_path": "extra_descriptions/numeric_keypad.json.html"
         },
         {
+          "path": "json/set_num_lock.json",
+          "extra_description_path": "extra_descriptions/set_num_lock.html" // optional
+        },
+        {
           "path": "json/pc_shortcuts.json"
         },
         {

--- a/public/json/set_num_lock.json
+++ b/public/json/set_num_lock.json
@@ -1,0 +1,64 @@
+{
+  "title": "LCtrl-LShift-N to toggle num-lock",
+  "rules": [
+    {
+      "description": "LCtrl-LShift-N to toggle num-lock",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "mandatory": [
+                "left_control",
+                "left_shift"
+              ]
+            },
+            "key_code": "n"
+          },
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "numeric_keypad_mode",
+              "value": 0
+            }
+          ],
+          "to": [
+            {
+              "set_variable": {
+                "name": "numeric_keypad_mode",
+                "value": 1
+              }
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "mandatory": [
+                "left_control",
+                "left_shift"
+              ]
+            },
+            "key_code": "n"
+          },
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "numeric_keypad_mode",
+              "value": 1
+            }
+          ],
+          "to": [
+            {
+              "set_variable": {
+                "name": "numeric_keypad_mode",
+                "value": 0
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Use a shortcut to toggle a portion of your keyboard to a numeric keypad. Perfect for 60%-keyboard users. 

Shortcut: left_control + left_shift + N

Layout of numeric keypad:

9 0 -   maps to 7 8 9
o p [   maps to 4 5 6
l ; '   maps to 1 2 3
,       maps to 0 