### PR TITLE
Add new modifications rule: rdp-japanese-us

### DIFF
--- a/public/extra_descriptions/rdp-japanese-us.json.html
+++ b/public/extra_descriptions/rdp-japanese-us.json.html
@@ -1,0 +1,20 @@
+<link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
+
+<h3>リモートデスクトップとUSキーボード、日本語環境の設定</h3>
+
+<p>この設定は、RDPアプリ(Microsoft Remote DesktopまたはParallels Client)をUSキーボードおよび日本語環境で利用する際に有用です。</p>
+
+<h4>この設定では、以下2点の修正を行うことができます。</h4>
+<ul>
+  <li>RDPアプリ<b>以外</b>を利用中に、コマンドキーを単体で押したときに英数・かなキーを送信することができます。</li>
+  <li>RDPアプリ使用中は、左右のCommandとOptionを入れ替えます。すなわち、CommandをAltおよびOptionをWindowsキーとして利用できます。</li>
+</ul>
+
+<p></p>
+
+<h4>注意点</h4>
+<ul>
+  <li>コマンドキーを単体で押したときに英数・かなキーを送信する設定は、<b>For Japanese （日本語環境向けの設定） (rev 6)</b>の<b>コマンドキーを単体で押したときに、英数・かなキーを送信する。（左コマンドキーは英数、右コマンドキーはかな） (rev 3)</b>と同じものです。本設定使用中はこの設定は使用しないでください。</li>
+  <li>RDPアプリ使用中は、<b>⌘-Qや⌘-Tabなどの操作は⌥-Qおよび⌥-Tabなどとなります</b>。</li>
+  <li>RDP接続先のWindowsで<b>alt-ime-ahkを利用している場合、Parallels ClientではAlt空打ちによるIME切り替えが動作しません</b>が、Mirosoft Remote Desktopでは動作します（2021年9月7日現在）。</li>
+</ul>

--- a/public/groups.json
+++ b/public/groups.json
@@ -681,6 +681,10 @@
         {
           "path": "json/cmd-opt-en-ru-uk.json",
           "extra_description_path": "extra_descriptions/cmd-opt-en-ru-uk.html"
+        },
+        {
+          "path": "json/rdp-japanese-us.json",
+          "extra_description_path": "extra_descriptions/rdp-japanese-us.json.html"
         }
       ]
     },

--- a/public/json/rdp-japanese-us.json
+++ b/public/json/rdp-japanese-us.json
@@ -1,0 +1,193 @@
+{
+  "title": "RDP for Japanese, US Keyboard （リモートデスクトップとUSキーボード、日本語環境の設定）",
+  "rules": [
+    {
+      "description": "[RDP] RDPアプリ以外では、コマンドキーを単体で押したときに、英数・かなキーを送信する。（左コマンドキーは英数、右コマンドキーはかな） (rev 3)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_command",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "parameters": {
+            "basic.to_if_held_down_threshold_milliseconds": 100
+          },
+          "to": [
+            {
+              "key_code": "left_command",
+              "lazy": true
+            }
+          ],
+          "to_if_held_down": [
+            {
+              "key_code": "left_command"
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "japanese_eisuu"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.2X\\.Client\\.Mac$",
+                "^com\\.microsoft\\.rdc\\.macos$"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_command",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "parameters": {
+            "basic.to_if_held_down_threshold_milliseconds": 100
+          },
+          "to": [
+            {
+              "key_code": "right_command",
+              "lazy": true
+            }
+          ],
+          "to_if_held_down": [
+            {
+              "key_code": "right_command"
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "japanese_kana"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.2X\\.Client\\.Mac$",
+                "^com\\.microsoft\\.rdc\\.macos$"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "[RDP] RDPアプリではCommandをAlt, OptionをWindowsキーに入れ替える",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_command",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_option"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.2X\\.Client\\.Mac$",
+                "^com\\.microsoft\\.rdc\\.macos$"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_option",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_command"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.2X\\.Client\\.Mac$",
+                "^com\\.microsoft\\.rdc\\.macos$"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_command",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_option"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.2X\\.Client\\.Mac$",
+                "^com\\.microsoft\\.rdc\\.macos$"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_option",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_command"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.2X\\.Client\\.Mac$",
+                "^com\\.microsoft\\.rdc\\.macos$"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/rdp-japanese-us.json.erb
+++ b/src/json/rdp-japanese-us.json.erb
@@ -1,0 +1,193 @@
+{
+    "title": "RDP for Japanese, US Keyboard （リモートデスクトップとUSキーボード、日本語環境の設定）",
+    "rules": [
+        {
+            "description": "[RDP] RDPアプリ以外では、コマンドキーを単体で押したときに、英数・かなキーを送信する。（左コマンドキーは英数、右コマンドキーはかな） (rev 3)",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "left_command",
+                        "modifiers": {
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "parameters": {
+                        "basic.to_if_held_down_threshold_milliseconds": 100
+                    },
+                    "to": [
+                        {
+                            "key_code": "left_command",
+                            "lazy": true
+                        }
+                    ],
+                    "to_if_held_down": [
+                        {
+                            "key_code": "left_command"
+                        }
+                    ],
+                    "to_if_alone": [
+                        {
+                            "key_code": "japanese_eisuu"
+                        }
+                    ],
+                    "conditions": [
+                        {
+                            "type": "frontmost_application_unless",
+                            "bundle_identifiers": [
+                                "^com\\.2X\\.Client\\.Mac$",
+                                "^com\\.microsoft\\.rdc\\.macos$"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "right_command",
+                        "modifiers": {
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "parameters": {
+                        "basic.to_if_held_down_threshold_milliseconds": 100
+                    },
+                    "to": [
+                        {
+                            "key_code": "right_command",
+                            "lazy": true
+                        }
+                    ],
+                    "to_if_held_down": [
+                        {
+                            "key_code": "right_command"
+                        }
+                    ],
+                    "to_if_alone": [
+                        {
+                            "key_code": "japanese_kana"
+                        }
+                    ],
+                    "conditions": [
+                        {
+                            "type": "frontmost_application_unless",
+                            "bundle_identifiers": [
+                                "^com\\.2X\\.Client\\.Mac$",
+                                "^com\\.microsoft\\.rdc\\.macos$"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "[RDP] RDPアプリではCommandをAlt, OptionをWindowsキーに入れ替える",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "left_command",
+                        "modifiers": {
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "left_option"
+                        }
+                    ],
+                    "conditions": [
+                        {
+                            "type": "frontmost_application_if",
+                            "bundle_identifiers": [
+                                "^com\\.2X\\.Client\\.Mac$",
+                                "^com\\.microsoft\\.rdc\\.macos$"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "left_option",
+                        "modifiers": {
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "left_command"
+                        }
+                    ],
+                    "conditions": [
+                        {
+                            "type": "frontmost_application_if",
+                            "bundle_identifiers": [
+                                "^com\\.2X\\.Client\\.Mac$",
+                                "^com\\.microsoft\\.rdc\\.macos$"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "right_command",
+                        "modifiers": {
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "right_option"
+                        }
+                    ],
+                    "conditions": [
+                        {
+                            "type": "frontmost_application_if",
+                            "bundle_identifiers": [
+                                "^com\\.2X\\.Client\\.Mac$",
+                                "^com\\.microsoft\\.rdc\\.macos$"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "right_option",
+                        "modifiers": {
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "right_command"
+                        }
+                    ],
+                    "conditions": [
+                        {
+                            "type": "frontmost_application_if",
+                            "bundle_identifiers": [
+                                "^com\\.2X\\.Client\\.Mac$",
+                                "^com\\.microsoft\\.rdc\\.macos$"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This rule can make following modifications:

- Send Japanese Eisu/Kana when Left/Right Command was pressed
   - Same as _For Japanese （日本語環境向けの設定） (rev 6)_ in the International (Language Specific) category
   - But only if Microsoft Remote Desktop or Parallels Client is not the frontmost application
- Swap Command and Option Keys
   - If Microsoft Remote Desktop or Parallels Client is the frontmost application