### PR TITLE
Move for_korean_keyboard rules from Modifier Keys to International (Language Specific)

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -62,10 +62,6 @@
           "path": "json/e0da_caps_lock.json"
         },
         {
-          "path": "json/for_korean_keyboard.json",
-          "extra_description_path": "extra_descriptions/for_korean_keyboard.html"
-        },
-        {
           "path": "json/function_keys.json",
           "extra_description_path": "extra_descriptions/function_keys.json.html"
         },
@@ -639,6 +635,10 @@
         {
           "path": "json/swiss_pc_shortcuts.json",
           "extra_description_path": "extra_descriptions/swiss_pc_shortcuts.json.html"
+        },
+        {
+          "path": "json/for_korean_keyboard.json",
+          "extra_description_path": "extra_descriptions/for_korean_keyboard.html"
         },
         {
           "path": "json/korean_pc.json"


### PR DESCRIPTION
It should be categorized into `International(Language Specific)`.