### PR TITLE
change rules: emacs like key binds only for Obsidian.app, at vim-insert mode (rev02)

### DIFF
--- a/public/json/obsidian_emacs_vim-insert.json
+++ b/public/json/obsidian_emacs_vim-insert.json
@@ -1,5 +1,5 @@
 {
-  "title": "emacs like key for Obsidian.app_rev02",
+  "title": "Obsidian.app, emacs like key at vim-insert mode_rev02",
   "rules": [
     {
       "description": "ctrl + bfpnae (only for Obsidian.app)_rev02",

--- a/public/json/obsidian_emacs_vim-insert.json
+++ b/public/json/obsidian_emacs_vim-insert.json
@@ -1,8 +1,8 @@
 {
-  "title": "Obsidian.app, emacs like key at vim-insert mode",
+  "title": "emacs like key for Obsidian.app_rev02",
   "rules": [
     {
-      "description": "ctrl + bfpnae (only for Obsidian.app)",
+      "description": "ctrl + bfpnae (only for Obsidian.app)_rev02",
       "manipulators": [
         {
           "type": "basic",
@@ -12,9 +12,7 @@
               "mandatory": [
                 "left_control"
               ],
-              "optional": [
-                "any"
-              ]
+              "optional": []
             }
           },
           "to": [
@@ -39,9 +37,7 @@
               "mandatory": [
                 "left_control"
               ],
-              "optional": [
-                "any"
-              ]
+              "optional": []
             }
           },
           "to": [
@@ -66,9 +62,7 @@
               "mandatory": [
                 "left_control"
               ],
-              "optional": [
-                "any"
-              ]
+              "optional": []
             }
           },
           "to": [
@@ -93,9 +87,7 @@
               "mandatory": [
                 "left_control"
               ],
-              "optional": [
-                "any"
-              ]
+              "optional": []
             }
           },
           "to": [
@@ -120,9 +112,7 @@
               "mandatory": [
                 "left_control"
               ],
-              "optional": [
-                "any"
-              ]
+              "optional": []
             }
           },
           "to": [
@@ -147,9 +137,7 @@
               "mandatory": [
                 "left_control"
               ],
-              "optional": [
-                "any"
-              ]
+              "optional": []
             }
           },
           "to": [
@@ -169,7 +157,7 @@
       ]
     },
     {
-      "description": "ctrl + hdk (only for Obsidian.app)",
+      "description": "ctrl + hdk (only for Obsidian.app)_rev02",
       "manipulators": [
         {
           "type": "basic",
@@ -179,9 +167,7 @@
               "mandatory": [
                 "left_control"
               ],
-              "optional": [
-                "any"
-              ]
+              "optional": []
             }
           },
           "to": [
@@ -206,9 +192,7 @@
               "mandatory": [
                 "left_control"
               ],
-              "optional": [
-                "any"
-              ]
+              "optional": []
             }
           },
           "to": [
@@ -233,9 +217,7 @@
               "mandatory": [
                 "left_control"
               ],
-              "optional": [
-                "any"
-              ]
+              "optional": []
             }
           },
           "to": [

--- a/public/json/obsidian_emacs_vim-insert.json
+++ b/public/json/obsidian_emacs_vim-insert.json
@@ -11,8 +11,7 @@
             "modifiers": {
               "mandatory": [
                 "left_control"
-              ],
-              "optional": []
+              ]
             }
           },
           "to": [
@@ -36,8 +35,7 @@
             "modifiers": {
               "mandatory": [
                 "left_control"
-              ],
-              "optional": []
+              ]
             }
           },
           "to": [
@@ -61,8 +59,7 @@
             "modifiers": {
               "mandatory": [
                 "left_control"
-              ],
-              "optional": []
+              ]
             }
           },
           "to": [
@@ -86,8 +83,7 @@
             "modifiers": {
               "mandatory": [
                 "left_control"
-              ],
-              "optional": []
+              ]
             }
           },
           "to": [
@@ -111,8 +107,7 @@
             "modifiers": {
               "mandatory": [
                 "left_control"
-              ],
-              "optional": []
+              ]
             }
           },
           "to": [
@@ -136,8 +131,7 @@
             "modifiers": {
               "mandatory": [
                 "left_control"
-              ],
-              "optional": []
+              ]
             }
           },
           "to": [
@@ -166,8 +160,7 @@
             "modifiers": {
               "mandatory": [
                 "left_control"
-              ],
-              "optional": []
+              ]
             }
           },
           "to": [
@@ -191,8 +184,7 @@
             "modifiers": {
               "mandatory": [
                 "left_control"
-              ],
-              "optional": []
+              ]
             }
           },
           "to": [
@@ -216,8 +208,7 @@
             "modifiers": {
               "mandatory": [
                 "left_control"
-              ],
-              "optional": []
+              ]
             }
           },
           "to": [


### PR DESCRIPTION
Deleted `"optional":  "any"` in modifiers,
to avoid working when users press anything other than the control key.
