### PR TITLE
Add rule to replace Dictation by Mutify hotkey to mute/unmute mic

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -496,6 +496,9 @@
         },
         {
           "path": "json/clickup.json"
+        },
+        {
+          "path": "json/dictation-to-mutify.json"
         }
       ]
     },

--- a/public/json/dictation-to-mutify.json
+++ b/public/json/dictation-to-mutify.json
@@ -1,0 +1,30 @@
+{
+  "title": "Dictation to Mutify",
+  "rules": [
+    {
+      "description": "Dictation key (F5 action) to trigger Mutify mute/unmute (⇧⌘0) action. Most useful for Macs without Touchbar.",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "f5",
+            "modifiers": {
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "0",
+              "modifiers": [
+                "left_command",
+                "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Mutify is an app that exposes shortcut to mute/unmute system microphone. [Mutify Homepage](https://mutify.app)
New Macs (without touchbar) have assigned Dictation function on F5 button with "mic" icon on key, so assigning Mutify trigger shortcut to that key seems most reasonable.