### PR TITLE
Add ericom blaze RDP Client to list of bundles

### DIFF
--- a/public/json/remote-desktop.json
+++ b/public/json/remote-desktop.json
@@ -48,7 +48,8 @@
             {
               "type": "frontmost_application_if",
               "bundle_identifiers": [
-                "com\\.microsoft\\.rdc\\.mac"
+                "com\\.microsoft\\.rdc\\.mac",
+                "com\\.ericom\\.blazeclient"
               ]
             }
           ]

--- a/public/json/remote-desktop.json
+++ b/public/json/remote-desktop.json
@@ -23,7 +23,8 @@
             {
               "type": "frontmost_application_if",
               "bundle_identifiers": [
-                "com\\.microsoft\\.rdc\\.mac"
+                "com\\.microsoft\\.rdc\\.mac",
+                "com\\.ericom\\.blazeclient"
               ]
             }
           ]
@@ -71,7 +72,8 @@
             {
               "type": "frontmost_application_if",
               "bundle_identifiers": [
-                "com\\.microsoft\\.rdc\\.mac"
+                "com\\.microsoft\\.rdc\\.mac",
+                "com\\.ericom\\.blazeclient"
               ]
             }
           ]
@@ -95,12 +97,12 @@
             {
               "type": "frontmost_application_if",
               "bundle_identifiers": [
-                "com\\.microsoft\\.rdc\\.mac"
+                "com\\.microsoft\\.rdc\\.mac",
+                "com\\.ericom\\.blazeclient"
               ]
             }
           ]
         }
-
       ]
     }
   ]


### PR DESCRIPTION
Add ericom blaze RDP Client to the list of bundles. This is a minor change consisting merely of adding a bundle identifier for another RDP client that is commonly used in the industry.