### PR TITLE
A rule to reconfigure Russian keyboard from Mac layout to Windows layout

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -696,6 +696,9 @@
         {
           "path": "json/rdp-japanese-us.json",
           "extra_description_path": "extra_descriptions/rdp-japanese-us.json.html"
+        },
+        {
+          "path": "json/russian-keyboard-remapping.json"
         }
       ]
     },

--- a/public/json/russian-keyboard-remapping.json
+++ b/public/json/russian-keyboard-remapping.json
@@ -1,0 +1,567 @@
+{
+  "title": "Russian Keyboard Remapping",
+  "rules": [
+    {
+      "description": "Remap keys in Russian to Windows layout for non-Mac keyboards",
+      "manipulators": [
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_unless",
+              "identifiers": [
+                {
+                  "vendor_id": 1452
+                }
+              ]
+            },
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "4",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [{
+            "key_code": "8",
+            "modifiers": ["shift"]
+          }]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_unless",
+              "identifiers": [
+                {
+                  "vendor_id": 1452
+                }
+              ]
+            },
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "5",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [{
+            "key_code": "4",
+            "modifiers": ["shift"]
+          }]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_unless",
+              "identifiers": [
+                {
+                  "vendor_id": 1452
+                }
+              ]
+            },
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "6",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [{
+            "key_code": "5",
+            "modifiers": ["shift"]
+          }]
+        },        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_unless",
+              "identifiers": [
+                {
+                  "vendor_id": 1452
+                }
+              ]
+            },
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "7",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [{
+            "key_code": "slash",
+            "modifiers": ["shift"]
+          }]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_unless",
+              "identifiers": [
+                {
+                  "vendor_id": 1452
+                }
+              ]
+            },
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "8",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [{
+            "key_code": "8",
+            "modifiers": ["option"]
+          }]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_unless",
+              "identifiers": [
+                {
+                  "vendor_id": 1452
+                }
+              ]
+            },
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "slash",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [{
+            "key_code": "6",
+            "modifiers": ["shift"]
+          }]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_unless",
+              "identifiers": [
+                {
+                  "vendor_id": 1452
+                }
+              ]
+            },
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "slash"
+          },
+          "to": [{
+            "key_code": "7",
+            "modifiers": ["shift"]
+          }]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_unless",
+              "identifiers": [
+                {
+                  "vendor_id": 1452
+                }
+              ]
+            },
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "grave_accent_and_tilde",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [{
+            "key_code": "backslash"
+          }]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_unless",
+              "identifiers": [
+                {
+                  "vendor_id": 1452
+                }
+              ]
+            },
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "non_us_pound",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [{
+            "key_code": "slash"
+          }]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_unless",
+              "identifiers": [
+                {
+                  "vendor_id": 1452
+                }
+              ]
+            },
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "non_us_pound"
+          },
+          "to": [{
+            "key_code": "keypad_slash"
+          }]
+        }
+      ]
+    },
+    {
+      "description": "Remap keys in Russian to Windows layout for all keyboards",
+      "manipulators": [
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "4",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [{
+            "key_code": "8",
+            "modifiers": ["shift"]
+          }]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "5",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [{
+            "key_code": "4",
+            "modifiers": ["shift"]
+          }]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "6",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [{
+            "key_code": "5",
+            "modifiers": ["shift"]
+          }]
+        },        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "7",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [{
+            "key_code": "slash",
+            "modifiers": ["shift"]
+          }]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "8",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [{
+            "key_code": "8",
+            "modifiers": ["option"]
+          }]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "slash",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [{
+            "key_code": "6",
+            "modifiers": ["shift"]
+          }]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "slash"
+          },
+          "to": [{
+            "key_code": "7",
+            "modifiers": ["shift"]
+          }]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "grave_accent_and_tilde",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [{
+            "key_code": "backslash"
+          }]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "non_us_pound",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [{
+            "key_code": "slash"
+          }]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "non_us_pound"
+          },
+          "to": [{
+            "key_code": "keypad_slash"
+          }]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Mac layout for Russian language looks like this:
![image](https://user-images.githubusercontent.com/4946730/144670927-7525888e-04bc-4f6c-a76c-f5b264108caf.png)

It is a pain for ex-non-mac-user to type symbols like . or , in unusual place. Also, as far as I know, Mac doesn't support different layouts for different inputs, so it would be even more frustrating to use external non-mac keyboard, like this one:
![image](https://user-images.githubusercontent.com/4946730/144671351-bbf0b0fd-5b1b-44f2-b968-275cc09bb163.png)

This PR is an attempt to make external keyboard more pleasant to use in Mac. There are two rules, each remaps punctuation and some special symbols to alternative ("windows") key combination. The only difference is that one rule works for non-Mac keyboards ("I want external keyboard to behave like I used to, but Ma Laptop keyboard should work as intended"), while another works for all keyboards ("I touch type well and don't want to learn new layout").

Unfortunately I hasn't found a way to emit backslash in Russian layout, and remapped it to keypad_slash.

Tested with MacBook Pro Retina 15" A1398 and Dell keyboard KB212-B.