### PR TITLE
Add KanaFN

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -712,6 +712,9 @@
         },
         {
           "path": "json/russian-keyboard-remapping.json"
+        },
+        {
+          "path": "json/kanafn.json"
         }
       ]
     },

--- a/public/json/kanafn.json
+++ b/public/json/kanafn.json
@@ -1,0 +1,307 @@
+{
+  "title": "KanaFN (“keyexchange”-compatible)",
+  "rules": [
+    {
+      "description": "KanaFN: japanese_kana to fn unlesss alone",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "japanese_kana",
+            "modifiers": {
+              "optional": [ "any" ]
+            }
+          },
+          "to": [
+            {"key_code": "fn"}
+          ],
+          "to_if_alone": [
+            {"key_code": "japanese_kana"}
+          ]
+        }
+      ]
+    },
+
+    {
+      "description": "KanaFN: Kana+[ijkl] to Up, Left, Down, Right",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "k",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "down_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow"
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "description": "KanaFN: Kana+[h;] to Backspace, Delete",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "h",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_or_backspace"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "semicolon",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_forward"
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "description": "KanaFN: Kana+[op] to Page Up, Page Down",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "o",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "page_up"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "p",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "page_down"
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "description": "KanaFN: Kana+[,.] to Home, End",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "comma",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "home"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "period",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "end"
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "description": "KanaFN: Kana+N to Enter",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "n",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "return_or_enter"
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "description": "Optional: spacebar to fn unlesss alone",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "spacebar",
+            "modifiers": {
+              "optional": [ "any" ]
+            }
+          },
+          "to": [
+            {"key_code": "fn"}
+          ],
+          "to_if_alone": [
+            {"key_code": "spacebar"}
+          ]
+        }
+      ]
+    },
+
+    {
+      "description": "Optional: japanese_eisuu to left_option unlesss alone",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "japanese_eisuu",
+            "modifiers": {
+              "optional": [ "any" ]
+            }
+          },
+          "to": [
+            {"key_code": "left_option"}
+          ],
+          "to_if_alone": [
+            {"key_code": "japanese_eisuu"}
+          ]
+        }
+      ]
+    }
+
+  ]
+}


### PR DESCRIPTION
KanaFN is similar to SpaceFN but more comfortable for Japanese keyboard users, because Kana key is placed more thumb friendly position on Japanese keyboard.

Provides those settings below:
- KanaFN: japanese_kana to fn unlesss alone
- KanaFN: Kana+[ijkl] to Up, Left, Down, Right
- KanaFN: Kana+[h;] to Backspace, Delete
- KanaFN: Kana+[op] to Page Up, Page Down
- KanaFN: Kana+[,.] to Home, End
- KanaFN: Kana+N to Enter
- Optional: spacebar to fn unlesss alone
- Optional: japanese_eisuu to left_option unlesss alone

