### PR TITLE
Add VSCode exception to auto_close_brackets_and_quotes

### DIFF
--- a/public/json/auto_close_brackets_and_quotes.json
+++ b/public/json/auto_close_brackets_and_quotes.json
@@ -33,6 +33,7 @@
                 "com.github.atom",
                 "com.googlecode.iterm2",
                 "com.jetbrains.pycharm",
+                "com.microsoft.VSCode",
                 "com.visualstudio.code.oss"
               ]
             }
@@ -60,6 +61,7 @@
                 "com.github.atom",
                 "com.googlecode.iterm2",
                 "com.jetbrains.pycharm",
+                "com.microsoft.VSCode",
                 "com.visualstudio.code.oss"
               ]
             }
@@ -91,6 +93,7 @@
                 "com.github.atom",
                 "com.googlecode.iterm2",
                 "com.jetbrains.pycharm",
+                "com.microsoft.VSCode",
                 "com.visualstudio.code.oss"
               ]
             }
@@ -118,6 +121,7 @@
                 "com.github.atom",
                 "com.googlecode.iterm2",
                 "com.jetbrains.pycharm",
+                "com.microsoft.VSCode",
                 "com.visualstudio.code.oss"
               ]
             }
@@ -145,6 +149,7 @@
                 "com.github.atom",
                 "com.googlecode.iterm2",
                 "com.jetbrains.pycharm",
+                "com.microsoft.VSCode",
                 "com.visualstudio.code.oss"
               ]
             }
@@ -176,6 +181,7 @@
                 "com.github.atom",
                 "com.googlecode.iterm2",
                 "com.jetbrains.pycharm",
+                "com.microsoft.VSCode",
                 "com.visualstudio.code.oss"
               ]
             }
@@ -207,6 +213,7 @@
                 "com.github.atom",
                 "com.googlecode.iterm2",
                 "com.jetbrains.pycharm",
+                "com.microsoft.VSCode",
                 "com.visualstudio.code.oss"
               ]
             }
@@ -238,6 +245,7 @@
                 "com.github.atom",
                 "com.googlecode.iterm2",
                 "com.jetbrains.pycharm",
+                "com.microsoft.VSCode",
                 "com.visualstudio.code.oss"
               ]
             }
@@ -269,6 +277,7 @@
                 "com.github.atom",
                 "com.googlecode.iterm2",
                 "com.jetbrains.pycharm",
+                "com.microsoft.VSCode",
                 "com.visualstudio.code.oss"
               ]
             }
@@ -313,6 +322,7 @@
                 "com.github.atom",
                 "com.googlecode.iterm2",
                 "com.jetbrains.pycharm",
+                "com.microsoft.VSCode",
                 "com.visualstudio.code.oss"
               ]
             }
@@ -341,6 +351,7 @@
                 "com.github.atom",
                 "com.googlecode.iterm2",
                 "com.jetbrains.pycharm",
+                "com.microsoft.VSCode",
                 "com.visualstudio.code.oss"
               ]
             }
@@ -380,6 +391,7 @@
                 "com.github.atom",
                 "com.googlecode.iterm2",
                 "com.jetbrains.pycharm",
+                "com.microsoft.VSCode",
                 "com.visualstudio.code.oss"
               ]
             }
@@ -408,6 +420,7 @@
                 "com.github.atom",
                 "com.googlecode.iterm2",
                 "com.jetbrains.pycharm",
+                "com.microsoft.VSCode",
                 "com.visualstudio.code.oss"
               ]
             }
@@ -436,6 +449,7 @@
                 "com.github.atom",
                 "com.googlecode.iterm2",
                 "com.jetbrains.pycharm",
+                "com.microsoft.VSCode",
                 "com.visualstudio.code.oss"
               ]
             }
@@ -475,6 +489,7 @@
                 "com.github.atom",
                 "com.googlecode.iterm2",
                 "com.jetbrains.pycharm",
+                "com.microsoft.VSCode",
                 "com.visualstudio.code.oss"
               ]
             }
@@ -515,6 +530,7 @@
                 "com.github.atom",
                 "com.googlecode.iterm2",
                 "com.jetbrains.pycharm",
+                "com.microsoft.VSCode",
                 "com.visualstudio.code.oss"
               ]
             }
@@ -555,6 +571,7 @@
                 "com.github.atom",
                 "com.googlecode.iterm2",
                 "com.jetbrains.pycharm",
+                "com.microsoft.VSCode",
                 "com.visualstudio.code.oss"
               ]
             }
@@ -594,6 +611,7 @@
                 "com.github.atom",
                 "com.googlecode.iterm2",
                 "com.jetbrains.pycharm",
+                "com.microsoft.VSCode",
                 "com.visualstudio.code.oss"
               ]
             }


### PR DESCRIPTION
Adds Microsoft's editor VSCode `com.microsoft.VSCode` to the conditional exceptions of `public/json/auto_close_brackets_and_quotes.json`, so closing brackets and quotes are not automagically added in that editor.