### PR TITLE
Add Complex Modification to Open control center with f8

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -946,6 +946,9 @@
         },
         {
           "path": "json/mouse_button4_back_mouse_button5_forward.json"
+        }.
+        {
+          "path": "json/open_control_center_with_f8.json"
         }
       ]
     },

--- a/public/groups.json
+++ b/public/groups.json
@@ -946,7 +946,7 @@
         },
         {
           "path": "json/mouse_button4_back_mouse_button5_forward.json"
-        }.
+        },
         {
           "path": "json/open_control_center_with_f8.json"
         }

--- a/public/json/open_control_center_with_f8.json
+++ b/public/json/open_control_center_with_f8.json
@@ -1,0 +1,25 @@
+{
+  "title": "Launch Control Center Using \"f8\"",
+  "rules": [
+    {
+      "description": "Map f8 button to fn+c",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "f8"
+          },
+          "to": [
+            {
+              "repeat": false,
+              "key_code": "c",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Maps the f8 button to fn+c, which is the Mac keyboard shortcut for opening the control center 