### PR TITLE
fix(rules): Remove comment from groups JSON file

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -268,7 +268,7 @@
         },
         {
           "path": "json/set_num_lock.json",
-          "extra_description_path": "extra_descriptions/set_num_lock.html" // optional
+          "extra_description_path": "extra_descriptions/set_num_lock.html"
         },
         {
           "path": "json/pc_shortcuts.json"


### PR DESCRIPTION
Comments are not valid JSON. Removing what appears to be a copy and paste error.