### PR TITLE
Keypad comma to period

### DIFF
--- a/public/extra_descriptions/keypad_comma_to_period_json.html
+++ b/public/extra_descriptions/keypad_comma_to_period_json.html
@@ -1,0 +1,11 @@
+<link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
+
+<p style="margin-top: 20px; font-weight: bold">
+  Version 1.0
+</p>
+<p>On Belgian keyboard layout, the keypad period gives a comma. This modification allows getting a period in place of a comma.
+</p>
+<p>More information:</p>
+	<ul>
+	 	<li><a href="https://github.com/maxcharlier/KE-complex_modifications">Raise an issue on the fork.</a></li>
+	</ul>

--- a/public/groups.json
+++ b/public/groups.json
@@ -140,6 +140,10 @@
         {
           "path": "json/fn_wasdqerf.json",
           "extra_description_path": "extra_descriptions/fn_wasdqerf.html"
+        },
+        {
+          "path": "json/keypad_comma_to_period.json",
+          "extra_description_path": "extra_descriptions/keypad_comma_to_period_json.html"
         }
       ]
     },

--- a/public/json/keypad_comma_to_period.json
+++ b/public/json/keypad_comma_to_period.json
@@ -1,0 +1,29 @@
+{
+  "title": "Keypad comma to period",
+  "rules": [
+    {
+      "description": "Keypad Period to Comma+shift (period) Belgian Keyboard",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "keypad_period"
+          },
+          "to": [
+            {
+              "repeat": true,
+              "key_code": "comma",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {}
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
On Belgian keyboard layout, the keypad period gives a comma. This modification allows getting a period in place of a comma.

Hidutil utility does not allow remapping this key as we have to use two keys to get the period. Also, keybinds file allows remapping the key but are not supported by all software such as JetBrain IDE.