### PR TITLE
Space-cadet shift

### DIFF
--- a/public/json/shifts_for_parenthesis.json
+++ b/public/json/shifts_for_parenthesis.json
@@ -1,0 +1,54 @@
+{
+  "title": "Tap left shift to open and right to close parenthesis",
+  "rules": [
+    {
+      "description": "Shift_L tap -> '(', Shift_R tap -> ')'",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "left_shift",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": {
+            "key_code": "left_shift"
+          },
+          "to_if_alone": [
+            {
+              "key_code": "9",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "right_shift",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": {
+            "key_code": "right_shift"
+          },
+          "to_if_alone": [
+            {
+              "key_code": "0",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Left shift, if pressed only, for open parenthesis; right shift, if pressed only, for close parenthesis.