### PR TITLE
Add exclusions for parsec to windows_shortcuts_on_macos.json

### DIFF
--- a/public/json/windows_shortcuts_on_macos.json
+++ b/public/json/windows_shortcuts_on_macos.json
@@ -58,7 +58,8 @@
                                 "^co\\.zeit\\.hyperterm$",
                                 "^co\\.zeit\\.hyper$",
                                 "^io\\.alacritty$",
-                                "^net\\.kovidgoyal\\.kitty$"
+                                "^net\\.kovidgoyal\\.kitty$",
+                                "^tv\\.parsec\\.www$"
                             ]
                         }
                     ]
@@ -117,7 +118,8 @@
                                 "^co\\.zeit\\.hyperterm$",
                                 "^co\\.zeit\\.hyper$",
                                 "^io\\.alacritty$",
-                                "^net\\.kovidgoyal\\.kitty$"
+                                "^net\\.kovidgoyal\\.kitty$",
+                                "^tv\\.parsec\\.www$"
                             ]
                         }
                     ]
@@ -176,7 +178,8 @@
                                 "^co\\.zeit\\.hyperterm$",
                                 "^co\\.zeit\\.hyper$",
                                 "^io\\.alacritty$",
-                                "^net\\.kovidgoyal\\.kitty$"
+                                "^net\\.kovidgoyal\\.kitty$",
+                                "^tv\\.parsec\\.www$"
                             ]
                         }
                     ]
@@ -219,7 +222,8 @@
                                 "^co\\.zeit\\.hyperterm$",
                                 "^co\\.zeit\\.hyper$",
                                 "^io\\.alacritty$",
-                                "^net\\.kovidgoyal\\.kitty$"
+                                "^net\\.kovidgoyal\\.kitty$",
+                                "^tv\\.parsec\\.www$"
                             ],
                             "type": "frontmost_application_unless"
                         }
@@ -283,7 +287,8 @@
                                 "^co\\.zeit\\.hyperterm$",
                                 "^co\\.zeit\\.hyper$",
                                 "^io\\.alacritty$",
-                                "^net\\.kovidgoyal\\.kitty$"
+                                "^net\\.kovidgoyal\\.kitty$",
+                                "^tv\\.parsec\\.www$"
                             ],
                             "type": "frontmost_application_unless"
                         }
@@ -348,7 +353,8 @@
                                 "^co\\.zeit\\.hyperterm$",
                                 "^co\\.zeit\\.hyper$",
                                 "^io\\.alacritty$",
-                                "^net\\.kovidgoyal\\.kitty$"
+                                "^net\\.kovidgoyal\\.kitty$",
+                                "^tv\\.parsec\\.www$"
                             ],
                             "type": "frontmost_application_unless"
                         }
@@ -412,7 +418,8 @@
                                 "^co\\.zeit\\.hyperterm$",
                                 "^co\\.zeit\\.hyper$",
                                 "^io\\.alacritty$",
-                                "^net\\.kovidgoyal\\.kitty$"
+                                "^net\\.kovidgoyal\\.kitty$",
+                                "^tv\\.parsec\\.www$"
                             ],
                             "type": "frontmost_application_unless"
                         }
@@ -476,7 +483,8 @@
                                 "^co\\.zeit\\.hyperterm$",
                                 "^co\\.zeit\\.hyper$",
                                 "^io\\.alacritty$",
-                                "^net\\.kovidgoyal\\.kitty$"
+                                "^net\\.kovidgoyal\\.kitty$",
+                                "^tv\\.parsec\\.www$"
                             ],
                             "type": "frontmost_application_unless"
                         }
@@ -540,7 +548,8 @@
                                 "^co\\.zeit\\.hyperterm$",
                                 "^co\\.zeit\\.hyper$",
                                 "^io\\.alacritty$",
-                                "^net\\.kovidgoyal\\.kitty$"
+                                "^net\\.kovidgoyal\\.kitty$",
+                                "^tv\\.parsec\\.www$"
                             ],
                             "type": "frontmost_application_unless"
                         }
@@ -599,7 +608,8 @@
                                 "^co\\.zeit\\.hyperterm$",
                                 "^co\\.zeit\\.hyper$",
                                 "^io\\.alacritty$",
-                                "^net\\.kovidgoyal\\.kitty$"
+                                "^net\\.kovidgoyal\\.kitty$",
+                                "^tv\\.parsec\\.www$"
                             ],
                             "type": "frontmost_application_unless"
                         }
@@ -663,7 +673,8 @@
                                 "^co\\.zeit\\.hyperterm$",
                                 "^co\\.zeit\\.hyper$",
                                 "^io\\.alacritty$",
-                                "^net\\.kovidgoyal\\.kitty$"
+                                "^net\\.kovidgoyal\\.kitty$",
+                                "^tv\\.parsec\\.www$"
                             ],
                             "type": "frontmost_application_unless"
                         }
@@ -720,7 +731,8 @@
                                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                                 "^com\\.citrix\\.XenAppViewer$",
                                 "^com\\.vmware\\.proxyApp\\.",
-                                "^com\\.parallels\\.winapp\\."
+                                "^com\\.parallels\\.winapp\\.",
+                                "^tv\\.parsec\\.www$"
                             ],
                             "type": "frontmost_application_unless"
                         }
@@ -757,7 +769,8 @@
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyper$",
                                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                                "^com\\.microsoft\\.rdc\\.macos$"
+                                "^com\\.microsoft\\.rdc\\.macos$",
+                                "^tv\\.parsec\\.www$"
                             ],
                             "type": "frontmost_application_unless"
                         }
@@ -789,7 +802,8 @@
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyper$",
                                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                                "^com\\.microsoft\\.rdc\\.macos$"
+                                "^com\\.microsoft\\.rdc\\.macos$",
+                                "^tv\\.parsec\\.www$"
                             ],
                             "type": "frontmost_application_unless"
                         }
@@ -827,7 +841,8 @@
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyper$",
                                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                                "^com\\.microsoft\\.rdc\\.macos$"
+                                "^com\\.microsoft\\.rdc\\.macos$",
+                                "^tv\\.parsec\\.www$"
                             ],
                             "type": "frontmost_application_unless"
                         }
@@ -867,7 +882,8 @@
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyper$",
                                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                                "^com\\.microsoft\\.rdc\\.macos$"
+                                "^com\\.microsoft\\.rdc\\.macos$",
+                                "^tv\\.parsec\\.www$"
                             ],
                             "type": "frontmost_application_unless"
                         }
@@ -899,7 +915,8 @@
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyper$",
                                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                                "^com\\.microsoft\\.rdc\\.macos$"
+                                "^com\\.microsoft\\.rdc\\.macos$",
+                                "^tv\\.parsec\\.www$"
                             ],
                             "type": "frontmost_application_unless"
                         }
@@ -937,7 +954,8 @@
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyper$",
                                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                                "^com\\.microsoft\\.rdc\\.macos$"
+                                "^com\\.microsoft\\.rdc\\.macos$",
+                                "^tv\\.parsec\\.www$"
                             ],
                             "type": "frontmost_application_unless"
                         }
@@ -977,7 +995,8 @@
                                 "^com\\.googlecode\\.iterm2$",
                                 "^co\\.zeit\\.hyper$",
                                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                                "^com\\.microsoft\\.rdc\\.macos$"
+                                "^com\\.microsoft\\.rdc\\.macos$",
+                                "^tv\\.parsec\\.www$"
                             ],
                             "type": "frontmost_application_unless"
                         }
@@ -1017,7 +1036,8 @@
                     "^com\\.googlecode\\.iterm2$",
                     "^co\\.zeit\\.hyper$",
                     "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                    "^com\\.microsoft\\.rdc\\.macos$"
+                    "^com\\.microsoft\\.rdc\\.macos$",
+                    "^tv\\.parsec\\.www$"
                   ],
                   "type": "frontmost_application_unless"
                 }
@@ -1057,7 +1077,8 @@
                     "^com\\.googlecode\\.iterm2$",
                     "^co\\.zeit\\.hyper$",
                     "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
-                    "^com\\.microsoft\\.rdc\\.macos$"
+                    "^com\\.microsoft\\.rdc\\.macos$",
+                    "^tv\\.parsec\\.www$"
                   ],
                   "type": "frontmost_application_unless"
                 }
@@ -1201,7 +1222,8 @@
                                 "^co\\.zeit\\.hyperterm$",
                                 "^co\\.zeit\\.hyper$",
                                 "^io\\.alacritty$",
-                                "^net\\.kovidgoyal\\.kitty$"
+                                "^net\\.kovidgoyal\\.kitty$",
+                                "^tv\\.parsec\\.www$"
                             ],
                             "type": "frontmost_application_unless"
                         }
@@ -1341,7 +1363,8 @@
                                 "^co\\.zeit\\.hyperterm$",
                                 "^co\\.zeit\\.hyper$",
                                 "^io\\.alacritty$",
-                                "^net\\.kovidgoyal\\.kitty$"
+                                "^net\\.kovidgoyal\\.kitty$",
+                                "^tv\\.parsec\\.www$"
                             ],
                             "type": "frontmost_application_unless"
                         }
@@ -1400,7 +1423,8 @@
                                 "^co\\.zeit\\.hyperterm$",
                                 "^co\\.zeit\\.hyper$",
                                 "^io\\.alacritty$",
-                                "^net\\.kovidgoyal\\.kitty$"
+                                "^net\\.kovidgoyal\\.kitty$",
+                                "^tv\\.parsec\\.www$"
                             ],
                             "type": "frontmost_application_unless"
                         }
@@ -1480,7 +1504,8 @@
                                 "^co\\.zeit\\.hyperterm$",
                                 "^co\\.zeit\\.hyper$",
                                 "^io\\.alacritty$",
-                                "^net\\.kovidgoyal\\.kitty$"
+                                "^net\\.kovidgoyal\\.kitty$",
+                                "^tv\\.parsec\\.www$"
                             ]
                         }
                     ]
@@ -1535,7 +1560,8 @@
                                 "^co\\.zeit\\.hyperterm$",
                                 "^co\\.zeit\\.hyper$",
                                 "^io\\.alacritty$",
-                                "^net\\.kovidgoyal\\.kitty$"
+                                "^net\\.kovidgoyal\\.kitty$",
+                                "^tv\\.parsec\\.www$"
                             ]
                         }
                     ]
@@ -1595,7 +1621,8 @@
                                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                                 "^com\\.citrix\\.XenAppViewer$",
                                 "^com\\.vmware\\.proxyApp\\.",
-                                "^com\\.parallels\\.winapp\\."
+                                "^com\\.parallels\\.winapp\\.",
+                                "^tv\\.parsec\\.www$"
                             ],
                             "type": "frontmost_application_unless"
                         }
@@ -1647,7 +1674,8 @@
                                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
                                 "^com\\.citrix\\.XenAppViewer$",
                                 "^com\\.vmware\\.proxyApp\\.",
-                                "^com\\.parallels\\.winapp\\."
+                                "^com\\.parallels\\.winapp\\.",
+                                "^tv\\.parsec\\.www$"
                             ],
                             "type": "frontmost_application_unless"
                         }


### PR DESCRIPTION
Add exclusions for [Parsec](https://parsec.app/) since it essentially the same thing as RDP. The app is a high performance remote desktop app used for connecting to other computers. The most common use case is to connect to a Windows computer to play games, but can also be used for normal remote desktop activities.