### PR TITLE
Keychron K2 rules to improve US keyboard layout usage for RU users

### DIFF
--- a/public/extra_descriptions/keychron_k2-remap_us_keyboard_for_ru_mac.json.html
+++ b/public/extra_descriptions/keychron_k2-remap_us_keyboard_for_ru_mac.json.html
@@ -1,0 +1,14 @@
+<link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
+
+<h2>Keychron K2: Remap US keys for use with RU Mac</h2>
+
+<p>
+  This rule modifies Keychron K2 US-layout keyboard to be more usable on Macbook with RU-layout keyboard.
+</p>
+
+<ul>
+  <li>Use <code>cmd+~</code> instead of <code>cmd+§</code></li>
+  <li>
+    Remap app window switcher from <code>cmd+~</code> to <code>option+~</code>
+  </li>
+</ul>

--- a/public/groups.json
+++ b/public/groups.json
@@ -1331,6 +1331,10 @@
         {
           "path": "json/keychron_k2.json",
           "extra_description_path": "extra_descriptions/keychron_k2.json.html"
+        },
+        {
+          "path": "json/keychron_k2-remap_us_keyboard_for_ru_mac.json",
+          "extra_description_path": "extra_descriptions/keychron_k2-remap_us_keyboard_for_ru_mac.json.html"
         }
       ]
     },

--- a/public/json/keychron_k2-remap_us_keyboard_for_ru_mac.json
+++ b/public/json/keychron_k2-remap_us_keyboard_for_ru_mac.json
@@ -1,0 +1,45 @@
+{
+  "title": "Remap some Keychrom K2(US) keys to make it less painful to switch from Macbook(RU) keyboard",
+  "rules": [
+    {
+      "description": "Use cmd+~ instead of cmd+section_sign",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "grave_accent_and_tilde",
+            "modifiers": {
+              "mandatory": ["command"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "non_us_backslash",
+              "modifiers": ["command"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Remap app window switcher from cmd+~ to option+~",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "tab",
+            "modifiers": {
+              "mandatory": ["option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": ["command"]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/public/json/keychron_k2-remap_us_keyboard_for_ru_mac.json
+++ b/public/json/keychron_k2-remap_us_keyboard_for_ru_mac.json
@@ -6,6 +6,17 @@
       "manipulators": [
         {
           "type": "basic",
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 591,
+                  "vendor_id": 1452
+                }
+              ]
+            }
+          ],
           "from": {
             "key_code": "grave_accent_and_tilde",
             "modifiers": {
@@ -22,10 +33,21 @@
       ]
     },
     {
-      "description": "Remap app window switcher from cmd+~ to option+~",
+      "description": "Remap app window switcher from cmd+~ to option+tab",
       "manipulators": [
         {
           "type": "basic",
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "product_id": 591,
+                  "vendor_id": 1452
+                }
+              ]
+            }
+          ],
           "from": {
             "key_code": "tab",
             "modifiers": {


### PR DESCRIPTION
Modification adds two simple key remaps to keep important shortcuts as close as possible between keyboards (US <-> RU)

1. Use ``` cmd+` ``` as `cmd+§`, because they are on similar place at keyboards
2. Use `option+tab` as ``` cmd+` ```, because there is no similar key on US keyboard (_key next to left shift_), so use new shortcut