### PR TITLE
Vi Style Arrows (MacOS Dvorak layout support)

### DIFF
--- a/src/json/vi_style_arrows_macos_dvorak_layout.json.erb
+++ b/src/json/vi_style_arrows_macos_dvorak_layout.json.erb
@@ -1,0 +1,74 @@
+{
+  "title": "Vi Style Arrows (MacOS Dvorak layout support)",
+  "rules": [
+    {
+      "description": "Change Control + h/j/k/l (j/c/v/p in MacOS Dvorak Layout) to Arrows",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "c",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "down_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "v",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "p",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Change Control + h/j/k/l (j/c/v/p in MacOS Dvorak Layout) to Arrows

<img width="780" alt="Screenshot 2022-02-20 at 07 24 11" src="https://user-images.githubusercontent.com/8963927/154828340-dbc29341-8b50-4e92-a4d2-9fba5de7c7db.png">
