### PR TITLE
Add rule: Use F12 to show/hide iTerm (Quake-style "instant terminal")

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -549,6 +549,9 @@
         },
         {
           "path": "json/ms_teams_ptt.json"
+        },
+        {
+          "path": "json/f12-show-hide-iterm.json"
         }
       ]
     },

--- a/public/json/f12-show-hide-iterm.json
+++ b/public/json/f12-show-hide-iterm.json
@@ -1,0 +1,72 @@
+{
+  "title": "Use F12 to show/hide iTerm (Quake-style \"instant terminal\")",
+  "rules": [
+    {
+      "description": "Launch/show iTerm if it is not in foreground",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "f12",
+            "modifiers": {
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "shell_command": "open '/Applications/iTerm.app'"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "^com\\.googlecode\\.iterm2$"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Minimize iTerm if it is in foreground",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "f12",
+            "modifiers": {
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "m",
+              "modifiers": [
+                "command"
+              ]
+            },
+            {
+              "key_code": "tab",
+              "modifiers": [
+                "command"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.googlecode\\.iterm2$"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Perhaps a very specific use case, but the general launch/hide functionality might come in handy for others.

The F12 key can be a bit problematic, but is personal muscle memory from my time with [YuaKuake and Guake](http://freesoftwaremagazine.com/articles/how_to_use_quake-style_terminals_on_GNU_Linux/).