### PR TITLE
Fix Neo2 layer 4 rules

### DIFF
--- a/public/json/neo2.json
+++ b/public/json/neo2.json
@@ -1515,7 +1515,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -1543,7 +1543,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -1571,7 +1571,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -1599,7 +1599,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -1627,7 +1627,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -1655,7 +1655,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -1683,7 +1683,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -1711,7 +1711,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -1739,7 +1739,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -1767,7 +1767,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -1795,7 +1795,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -1823,7 +1823,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -1851,7 +1851,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -1879,7 +1879,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -1917,7 +1917,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -1951,7 +1951,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -1985,7 +1985,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2019,7 +2019,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2053,7 +2053,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2087,7 +2087,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2121,7 +2121,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2155,7 +2155,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2189,7 +2189,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2223,7 +2223,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2257,7 +2257,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2291,7 +2291,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2325,7 +2325,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2359,7 +2359,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2393,7 +2393,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2427,7 +2427,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2461,7 +2461,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2495,7 +2495,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2529,7 +2529,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2563,7 +2563,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2597,7 +2597,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2631,7 +2631,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2665,7 +2665,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2699,7 +2699,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2733,7 +2733,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2767,7 +2767,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2801,7 +2801,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2835,7 +2835,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2869,7 +2869,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2903,7 +2903,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2937,7 +2937,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -2971,7 +2971,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3005,7 +3005,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3039,7 +3039,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3073,7 +3073,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3107,7 +3107,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3141,7 +3141,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3175,7 +3175,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3209,7 +3209,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3243,7 +3243,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3277,7 +3277,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3311,7 +3311,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3345,7 +3345,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3379,7 +3379,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3413,7 +3413,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3447,7 +3447,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_1",
+              "key_code": "z",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3567,7 +3567,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3590,7 +3590,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3613,7 +3613,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3636,7 +3636,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3659,7 +3659,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3687,7 +3687,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3710,7 +3710,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3733,7 +3733,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3756,7 +3756,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3779,7 +3779,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3802,7 +3802,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3825,7 +3825,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3848,7 +3848,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3871,7 +3871,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3894,7 +3894,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3917,7 +3917,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3940,7 +3940,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3963,7 +3963,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -3986,7 +3986,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -4009,7 +4009,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -4032,7 +4032,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -4055,7 +4055,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -4078,7 +4078,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -4101,7 +4101,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -4124,7 +4124,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -4147,7 +4147,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -4170,7 +4170,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -4193,7 +4193,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -4216,7 +4216,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -4239,7 +4239,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -4262,7 +4262,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -4285,7 +4285,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -4308,7 +4308,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -4331,7 +4331,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -4354,7 +4354,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -4377,7 +4377,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"
@@ -4400,7 +4400,7 @@
           },
           "to": [
             {
-              "key_code": "keypad_2",
+              "key_code": "a",
               "modifiers": [
                 "left_option",
                 "left_shift"

--- a/src/json/neo2.json.erb
+++ b/src/json/neo2.json.erb
@@ -138,7 +138,7 @@
                     dest_keys_list: l4_dead_key_mappings,
                     conditions: [$if_mod_4_on],
                     to_modifiers: ["left_shift"],
-                    to_pre_events: [["keypad_1", ["left_option", "left_shift"]]]
+                    to_pre_events: [["z", ["left_option", "left_shift"]]]
                 )
             ) %>
         },
@@ -163,7 +163,7 @@
                     conditions: [$if_mod_4_on],
                     from_mandatory_modifiers: ["right_option"],
                     to_modifiers: ["left_shift", "left_option"],
-                    to_pre_events: [["keypad_1", ["left_option", "left_shift"]]]
+                    to_pre_events: [["z", ["left_option", "left_shift"]]]
                 )
             ) %>
         },
@@ -203,7 +203,7 @@
                   dest_keys_list: ["h", "s", "z", "o", "k"],
                   from_mandatory_modifiers: ["right_option"],
                   to_modifiers: [],
-                  to_pre_events: [["keypad_2", ["left_option", "left_shift"]]]
+                  to_pre_events: [["a", ["left_option", "left_shift"]]]
               )
           ) %>
         },
@@ -215,7 +215,7 @@
                   dest_keys_list: ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "open_bracket", "semicolon", "quote", "comma", "period", "slash"],
                   from_mandatory_modifiers: ["right_option"],
                   to_modifiers: [],
-                  to_pre_events: [["keypad_2", ["left_option", "left_shift"]]]
+                  to_pre_events: [["a", ["left_option", "left_shift"]]]
               )
           ) %>
         },


### PR DESCRIPTION
Partially reverts 436d4f944a2a58b8295244a20f52a488a6c5c596 which changed
the `to_pre_events` keys for unclear reasons.

Fixes #1057.

# Todo

* [ ] Update the "extra description" as the rule names in there are not update and the list is incomplete.