### PR TITLE
Add a rule for mapping F4 to Command+Space

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -62,6 +62,9 @@
           "path": "json/double_tap_ctrl_to_cmd.json"
         },
         {
+          "path": "json/f4_to_cmd_space.json"
+        },
+        {
           "path": "json/e0da_caps_lock.json"
         },
         {

--- a/public/json/f4_to_cmd_space.json
+++ b/public/json/f4_to_cmd_space.json
@@ -1,0 +1,29 @@
+{
+  "title": "[macOS] Map F4 to Command+Space",
+  "rules": [
+    {
+      "description": "Map F4 to Command+Space",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "f4",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "spacebar",
+              "modifiers": [
+                "command"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/f4_to_cmd_space.json.rb
+++ b/src/json/f4_to_cmd_space.json.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+
+# You can generate json by executing the following command on Terminal.
+#
+# $ ruby ./f4_to_cmd_space.json.rb
+#
+
+# Maps F4 (defaults to Spotlight search on MacOS) to Command+Space.
+# This is useful if you want F4 to use a Spotlight replacement like
+# Raycast.
+
+require 'json'
+require_relative '../lib/karabiner.rb'
+
+def main
+    puts JSON.pretty_generate(
+        'title' => '[macOS] Map F4 to Command+Space',
+        'rules' => [
+            {
+                'description' => 'Map F4 to Command+Space',
+                'manipulators' => [
+                    {
+                        'type' => 'basic',
+                        'from' => {
+                            'key_code' => 'f4',
+                            'modifiers' => Karabiner.from_modifiers,
+                        },
+                        'to' => [
+                            {
+                                'key_code' => 'spacebar',
+                                'modifiers' => ['command'],
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    )
+end
+
+main


### PR DESCRIPTION
Maps F4 (defaults to Spotlight search on MacOS) to Command+Space.
This is useful if you want F4 to use a Spotlight replacement like [Raycast](https://www.raycast.com/developers).