### PR TITLE
Added a json allowing the use of a single keystroke for tildes and backticks with the French PC keyboard layout

### DIFF
--- a/public/json/french_pc_single_stroke_keys.json
+++ b/public/json/french_pc_single_stroke_keys.json
@@ -1,0 +1,80 @@
+{
+  "title": "Make tilde and backticks work with one keystroke on French PC key layout.",
+  "rules": [
+    {
+      "description": "One stroke tilde.",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "input_source_id": "^com\\.apple\\.keylayout\\.French-PC$"
+                }
+              ],
+              "type": "input_source_if"
+            }
+          ],
+          "from": {
+            "key_code": "2",
+            "modifiers": {
+              "mandatory": [
+                "right_option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "2",
+              "modifiers": [
+                "right_option"
+              ]
+            },
+            {
+              "key_code": "right_arrow"
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "One stroke backtick.",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "input_source_id": "^com\\.apple\\.keylayout\\.French-PC$"
+                }
+              ],
+              "type": "input_source_if"
+            }
+          ],
+          "from": {
+            "key_code": "7",
+            "modifiers": {
+              "mandatory": [
+                "right_option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "7",
+              "modifiers": [
+                "right_option"
+              ]
+            },
+            {
+              "key_code": "right_arrow"
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+ 
+  ]
+}


### PR DESCRIPTION
Using a keyboard layout from a language with accents (French, Spanish, ...), when accents keys (tildes, backticks, etc.) are pressed macOS will wait for the next letter to maybe 'merge' them (ex: pressing backtick then `e` makes `è`). If it cannot merge them, it will sometimes have a strange behavior, like doubling the tilde/backtick, which is very annoying.

I added a JSON that prevents macOS from waiting a key after typing a backtick or a tilde using the French PC layout, by pressing the right arrow right after.