### PR TITLE
add hhkb_fn_comma_period_to_ltgt.json

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -1159,6 +1159,9 @@
           "path": "json/hhkb_rctf.json"
         },
         {
+          "path": "json/hhkb_fn_comma_period_to_ltgt.json"
+        },
+        {
           "path": "json/PC-Style_Shortcuts_Copy_Ctrl_Insert.json"
         },
         {

--- a/public/json/hhkb_fn_comma_period_to_ltgt.json
+++ b/public/json/hhkb_fn_comma_period_to_ltgt.json
@@ -1,0 +1,52 @@
+{
+  "title": "HHKB mapping for programming (Fn+comma → <, Fn+period → >)",
+  "rules": [
+    {
+      "description": "Fn+comma (End) => less than (>)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "end",
+            "modifiers": {
+              "mandatory": [
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "comma",
+              "modifiers": [
+                  "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "description": "Fn+period (PgDn) => greater than (>)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "page_down",
+            "modifiers": {
+              "mandatory": [
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "period",
+              "modifiers": [
+                  "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I have added a json file "hhkb_fn_comma_period_to_ltgt.json".
This file is only for HHKB devices.
It converts Fn+comma(End) and Fn+period(PgDn) to less than(<) and greater than(>) respectively.