### PR TITLE
feat: add shift key training wheels to disable incorrect shift + letter combos

### DIFF
--- a/public/json/shift_keys_training_wheels.json
+++ b/public/json/shift_keys_training_wheels.json
@@ -1,0 +1,218 @@
+{
+  "title": "Shift key training wheels",
+  "rules": [
+    {
+      "description": "Disable incorrect shift + letter combos",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "q",
+            "modifiers": { "mandatory": ["left_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "w",
+            "modifiers": { "mandatory": ["left_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "e",
+            "modifiers": { "mandatory": ["left_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "r",
+            "modifiers": { "mandatory": ["left_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "t",
+            "modifiers": { "mandatory": ["left_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "a",
+            "modifiers": { "mandatory": ["left_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "s",
+            "modifiers": { "mandatory": ["left_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "d",
+            "modifiers": { "mandatory": ["left_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "f",
+            "modifiers": { "mandatory": ["left_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "g",
+            "modifiers": { "mandatory": ["left_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "z",
+            "modifiers": { "mandatory": ["left_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "x",
+            "modifiers": { "mandatory": ["left_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "c",
+            "modifiers": { "mandatory": ["left_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "v",
+            "modifiers": { "mandatory": ["left_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "b",
+            "modifiers": { "mandatory": ["right_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "h",
+            "modifiers": { "mandatory": ["right_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "i",
+            "modifiers": { "mandatory": ["right_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "j",
+            "modifiers": { "mandatory": ["right_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "k",
+            "modifiers": { "mandatory": ["right_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "l",
+            "modifiers": { "mandatory": ["right_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "m",
+            "modifiers": { "mandatory": ["right_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "n",
+            "modifiers": { "mandatory": ["right_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "o",
+            "modifiers": { "mandatory": ["right_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "p",
+            "modifiers": { "mandatory": ["right_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "u",
+            "modifiers": { "mandatory": ["right_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "y",
+            "modifiers": { "mandatory": ["right_shift"] }
+          },
+          "to": [{ "key_code": "vk_none" }]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Modelled after [this](https://stevelosh.com/blog/2012/10/a-modern-space-cadet/#s16-shift-key-training-wheels), which is based on an outdated version of Karabiner.

Helps to break muscle memory to "unlearn over two decades of wrong typing" to keep hand on my home row while typing.