### PR TITLE
Add German Characters (Umlauts and Eszett) with Caps Lock

### DIFF
--- a/public/extra_descriptions/german_umlauts_caps.html
+++ b/public/extra_descriptions/german_umlauts_caps.html
@@ -11,6 +11,7 @@
 <h5>What Keyboards are Supported</h5>
 <p>Any keyboard with the standard Latin characterset is supported. The purpose of this modification is to enable use of the German characters on a keyboard that doesn't have them.</p>
 <p>As long as you have a Caps Lock key, as well as [aous], you're good to go.</p>
+<p>That said, it's limited to ANSI or ISO keyboards with an English input language.</p>
 
 <h5>Motivation</h5>
 

--- a/public/extra_descriptions/german_umlauts_caps.html
+++ b/public/extra_descriptions/german_umlauts_caps.html
@@ -6,7 +6,11 @@
 <p>Use the Caps Lock key as a modifier key, but for getting access to the German letters.</p>
 <p>Easy access to äöü, ÄÖÜ, and ß.</p>
 <p>All of the rules are toggleable on/off</p>
-<p>Be aware, there is a rule to disable use of the Caps Lock key. This can be imported disabled if desired.</p>
+<p>BE AWARE, there is a rule to disable use of the Caps Lock key.</p>
+
+<h5>What Keyboards are Supported</h5>
+<p>Any keyboard with the standard Latin characterset is supported. The purpose of this modification is to enable use of the German characters on a keyboard that doesn't have them.</p>
+<p>As long as you have a Caps Lock key, as well as [aous], you're good to go.</p>
 
 <h5>Motivation</h5>
 

--- a/public/extra_descriptions/german_umlauts_caps.html
+++ b/public/extra_descriptions/german_umlauts_caps.html
@@ -1,0 +1,61 @@
+<link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
+
+<hr>
+
+<h4>Description</h4>
+<p>Use the Caps Lock key as a modifier key, but for getting access to the German letters.</p>
+<p>Easy access to äöü, ÄÖÜ, and ß.</p>
+<p>All of the rules are toggleable on/off</p>
+<p>Be aware, there is a rule to disable use of the Caps Lock key. This can be imported disabled if desired.</p>
+
+<h5>Motivation</h5>
+
+<p>I don't like the press-and-hold default system for getting access to the German characters. On Windows, I had used AutoHotKey to create a script that disables the caps lock key, and uses it as amodifier to get access to the characters. I ported that over to my new macOS machine.</p>
+
+<h5>Key Map</h5>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">Key</th>
+      <th scope="col">Maps To</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>CapsLock + a</td>
+      <td>ä</td>
+    </tr>
+    <tr>
+      <td>CapsLock + o</td>
+      <td>ö</td>
+    </tr>
+    <tr>
+      <td>CapsLock + u</td>
+      <td>ü</td>
+    </tr>
+    <tr>
+      <td>CapsLock + s</td>
+      <td>ß</td>
+    </tr>
+    <tr>
+      <td>CapsLock + Shift + a</td>
+      <td>Ä</td>
+    </tr>
+    <tr>
+      <td>CapsLock + Shift + o</td>
+      <td>Ö</td>
+    </tr>
+    <tr>
+      <td>CapsLock + Shift + u</td>
+      <td>Ü</td>
+    </tr>
+  </tbody>
+</table>
+
+<h5>Changelog</h5>
+
+<dl>
+  <dt>Revision 1</dt>
+  <dd>Original version.</dd>
+</dl>

--- a/public/groups.json
+++ b/public/groups.json
@@ -160,6 +160,10 @@
         },
         {
           "path": "json/reasonable_change.json"
+        },
+        {
+          "path": "json/german_umlauts_caps.json",
+          "extra_description_path": "extra_descriptions/german_umlauts_caps.html"
         }
       ]
     },

--- a/public/json/german_umlauts_caps.json
+++ b/public/json/german_umlauts_caps.json
@@ -7,6 +7,20 @@
         {
           "description": "Set a variable to true/false depending on if caps lock is pressed/lifted.",
           "type": "basic",
+          "conditions": [
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": ["ansi", "iso"]
+            },
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                    "language": "^en$"
+                }
+              ]
+            }
+          ],
           "from": {
             "key_code": "caps_lock",
             "modifiers": {
@@ -35,6 +49,20 @@
         {
           "description": "Disable the caps lock key entirely.",
           "type": "basic",
+          "conditions": [
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": ["ansi", "iso"]
+            },
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                    "language": "^en$"
+                }
+              ]
+            }
+          ],
           "from": {
             "key_code": "caps_lock",
             "modifiers": {
@@ -79,6 +107,18 @@
               "type": "variable_if",
               "name": "caps_lock pressed",
               "value": 1
+            },
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": ["ansi", "iso"]
+            },
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                    "language": "^en$"
+                }
+              ]
             }
           ]
         },
@@ -107,6 +147,18 @@
               "type": "variable_if",
               "name": "caps_lock pressed",
               "value": 1
+            },
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": ["ansi", "iso"]
+            },
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                    "language": "^en$"
+                }
+              ]
             }
           ]
         },
@@ -135,6 +187,18 @@
               "type": "variable_if",
               "name": "caps_lock pressed",
               "value": 1
+            },
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": ["ansi", "iso"]
+            },
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                    "language": "^en$"
+                }
+              ]
             }
           ]
         }
@@ -176,6 +240,18 @@
               "type": "variable_if",
               "name": "caps_lock pressed",
               "value": 1
+            },
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": ["ansi", "iso"]
+            },
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                    "language": "^en$"
+                }
+              ]
             }
           ]
         },
@@ -212,6 +288,18 @@
               "type": "variable_if",
               "name": "caps_lock pressed",
               "value": 1
+            },
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": ["ansi", "iso"]
+            },
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                    "language": "^en$"
+                }
+              ]
             }
           ]
         },
@@ -248,6 +336,18 @@
               "type": "variable_if",
               "name": "caps_lock pressed",
               "value": 1
+            },
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": ["ansi", "iso"]
+            },
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                    "language": "^en$"
+                }
+              ]
             }
           ]
         }
@@ -275,6 +375,18 @@
               "type": "variable_if",
               "name": "caps_lock pressed",
               "value": 1
+            },
+            {
+              "type": "keyboard_type_if",
+              "keyboard_types": ["ansi", "iso"]
+            },
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                    "language": "^en$"
+                }
+              ]
             }
           ]
         }

--- a/public/json/german_umlauts_caps.json
+++ b/public/json/german_umlauts_caps.json
@@ -1,0 +1,284 @@
+{
+  "title": "Use Caps Lock for German Umlauts and Eszett",
+  "rules": [
+    {
+      "description": "Use the caps lock key state for other rules",
+      "manipulators": [
+        {
+          "description": "Set a variable to true/false depending on if caps lock is pressed/lifted.",
+          "type": "basic",
+          "from": {
+            "key_code": "caps_lock",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "caps_lock pressed",
+                "value": 1
+              }
+            }
+          ],
+          "to_after_key_up": [
+            {
+              "set_variable": {
+                "name": "caps_lock pressed",
+                "value": 0
+              }
+            }
+          ]
+        },
+        {
+          "description": "Disable the caps lock key entirely.",
+          "type": "basic",
+          "from": {
+            "key_code": "caps_lock",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to_if_alone": [
+            {
+              "key_code": "vk_none"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Convert Caps Lock with [aou] to [äöü]",
+      "manipulators": [
+        {
+          "description": "Caps+a = ä",
+          "type": "basic",
+          "from": {
+            "key_code": "a"
+          },
+          "to": [
+            {
+              "key_code": "u",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "a"
+            },
+            {
+              "key_code": "vk_none"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "caps_lock pressed",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Caps+o = ö",
+          "type": "basic",
+          "from": {
+            "key_code": "o"
+          },
+          "to": [
+            {
+              "key_code": "u",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "o"
+            },
+            {
+              "key_code": "vk_none"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "caps_lock pressed",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Caps+u = ü",
+          "type": "basic",
+          "from": {
+            "key_code": "u"
+          },
+          "to": [
+            {
+              "key_code": "u",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "u"
+            },
+            {
+              "key_code": "vk_none"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "caps_lock pressed",
+              "value": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Convert Caps Lock (in combination with Shift) with [aou] to [ÄÖÜ]",
+      "manipulators": [
+        {
+          "description": "Caps+shift+a = Ä",
+          "type": "basic",
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "u",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "a",
+              "modifiers": [
+                "left_shift"
+              ]
+            },
+            {
+              "key_code": "vk_none"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "caps_lock pressed",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Caps+shift+o = Ö",
+          "type": "basic",
+          "from": {
+            "key_code": "o",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "u",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "o",
+              "modifiers": [
+                "left_shift"
+              ]
+            },
+            {
+              "key_code": "vk_none"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "caps_lock pressed",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "description": "Caps+shift+u = Ü",
+          "type": "basic",
+          "from": {
+            "key_code": "u",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "u",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "u",
+              "modifiers": [
+                "left_shift"
+              ]
+            },
+            {
+              "key_code": "vk_none"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "caps_lock pressed",
+              "value": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Convert Caps Lock with [s] to [ß] (Eszett)",
+      "manipulators": [
+        {
+          "description": "Caps+s = ß",
+          "type": "basic",
+          "from": {
+            "key_code": "s"
+          },
+          "to": [
+            {
+              "key_code": "s",
+              "modifiers": [
+                "left_option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "caps_lock pressed",
+              "value": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add a new Complex Modification that hosts a set of different rules.
Use the Caps Lock key as a modifier key, but for getting access to the German letters. Easy access to äöü, ÄÖÜ, and ß.