### PR TITLE
Improve "backtick_z_slash_as_ctrl" modification ease typing "Z"

### DIFF
--- a/public/json/backtick_z_slash_as_ctrl.json
+++ b/public/json/backtick_z_slash_as_ctrl.json
@@ -36,6 +36,23 @@
           "from": {
             "key_code": "z",
             "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "z",
+              "modifiers": "shift"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "z",
+            "modifiers": {
               "optional": [
                 "any"
               ]
@@ -51,7 +68,10 @@
             {
               "key_code": "z"
             }
-          ]
+          ],
+          "parameters": {
+            "basic.to_if_alone_timeout_milliseconds": 300
+          }
         }
       ]
     },


### PR DESCRIPTION
This improvement posts "Z" immediately if shift and z are pressed
together. This makes it easier to type "Z" quickly, instead of getting
"z" because by the time the z keypress is posted on keyup, the shift key
has already been released. With this modification, it's still possible
to type ctrl-shift-SOMEKEY, you just need to press z first and then
shift, as if you press shift first and then z, you will get keyrepeat of
z. I think ctrl-shift is a rare enough key combo that this is a good
tradeoff.

On my keyboard layout (Dvorak) ;/: is on the QWERTY z key, so this was
tripping me up a lot while trying to use Vim (typing colon enters the
command mode).

This improvement also adds a timeout of 300ms to a hold of the z key, so
that any reasonably fast keypress will post z, but a longer hold alone (for
example if you were thinking of pressing ctrl-n but changed your mind
halfway) doesn't post anything.