### PR TITLE
Update fn+cmd_to_eisu_and_kana.json

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -573,6 +573,9 @@
         },
         {
           "path": "json/f12-show-hide-iterm.json"
+        },
+        {
+          "path": "json/fn+cmd_to_eisu_and_kana.json"
         }
       ]
     },

--- a/public/json/fn+cmd_to_eisu_and_kana.json
+++ b/public/json/fn+cmd_to_eisu_and_kana.json
@@ -1,0 +1,47 @@
+{
+  "title": "Change fn + left_/right_command to 英数/かな (japanese_eisuu/kana)",
+  "rules": [
+    {
+      "description": "Change fn + left_command to japanese_eisuu",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_gui",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "japanese_eisuu"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change fn + right_command to japanese_kana",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_gui",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "japanese_kana"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
A keymap json to map `fn + left_/right_command to japanese_eisuu/kana`. 

This helps to mimic the JIS layout's feeling on other keyboard layouts.