### PR TITLE
Add keymap to prevent exiting fullscreen on escape

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -846,6 +846,9 @@
           "path": "json/esc_to_eng_ime.json"
         },
         {
+          "path": "json/esc_to_shift_esc.json"
+        },
+        {
           "path": "json/escape.json"
         },
         {

--- a/public/json/esc_to_shift_esc.json
+++ b/public/json/esc_to_shift_esc.json
@@ -1,0 +1,24 @@
+{
+  "title": "Prevent exiting full screen on pressing ESC",
+  "rules": [
+    {
+      "description": "Remaps escape to shift-escape",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "escape"
+          },
+          "to": [
+            {
+              "key_code": "escape",
+              "modifiers": [
+                "shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This keymap prevents exiting full screen on escape while (seemingly) retaining other escape functions. I have tested escape function retention with full screen videos in safari and firefox, text input boxes, and vim in iTerm 2. The prevention of full screen exit seems to work across all apps that supported it.

This is similar to #109, but with two differences:

- It works across all apps
- It uses `shift-escape` instead of `option-escape`. Using `option` didn't prevent exiting for me on macOS Catalina.

