### PR TITLE
Add ADNW to supported Neo2 layouts

### DIFF
--- a/public/json/neo2.json
+++ b/public/json/neo2.json
@@ -34,6 +34,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -69,6 +72,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -104,6 +110,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -145,6 +154,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -199,6 +211,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -259,6 +274,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -319,6 +337,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -371,6 +392,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -423,6 +447,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -475,6 +502,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -527,6 +557,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -579,6 +612,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -631,6 +667,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -683,6 +722,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -735,6 +777,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -787,6 +832,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -839,6 +887,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -891,6 +942,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -943,6 +997,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -995,6 +1052,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -1047,6 +1107,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -1099,6 +1162,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -1151,6 +1217,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -1203,6 +1272,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -1255,6 +1327,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -1307,6 +1382,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -1359,6 +1437,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -1411,6 +1492,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -1463,6 +1547,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -1515,6 +1602,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -1567,6 +1657,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -1619,6 +1712,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -1671,6 +1767,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -1723,6 +1822,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -1775,6 +1877,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -1827,6 +1932,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -1879,6 +1987,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -1931,6 +2042,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -1983,6 +2097,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -2035,6 +2152,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -2087,6 +2207,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -2139,6 +2262,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -2191,6 +2317,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -2243,6 +2372,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -2295,6 +2427,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -2347,6 +2482,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -2402,6 +2540,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -2457,6 +2598,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -2511,6 +2655,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -2565,6 +2712,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -2619,6 +2769,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -2673,6 +2826,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -2727,6 +2883,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -2781,6 +2940,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -2835,6 +2997,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -2889,6 +3054,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -2943,6 +3111,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -2997,6 +3168,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -3051,6 +3225,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -3105,6 +3282,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -3159,6 +3339,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -3213,6 +3396,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -3267,6 +3453,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -3321,6 +3510,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -3375,6 +3567,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -3429,6 +3624,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -3483,6 +3681,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -3537,6 +3738,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -3591,6 +3795,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -3645,6 +3852,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -3704,6 +3914,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -3753,6 +3966,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -3802,6 +4018,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -3837,6 +4056,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -3872,6 +4094,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -3913,6 +4138,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -3958,6 +4186,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -4009,6 +4240,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -4060,6 +4294,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -4103,6 +4340,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -4146,6 +4386,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -4189,6 +4432,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -4232,6 +4478,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -4275,6 +4524,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -4318,6 +4570,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -4361,6 +4616,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -4404,6 +4662,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -4447,6 +4708,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -4490,6 +4754,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -4533,6 +4800,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -4576,6 +4846,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -4619,6 +4892,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -4662,6 +4938,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -4705,6 +4984,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -4748,6 +5030,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -4791,6 +5076,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -4834,6 +5122,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -4877,6 +5168,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -4920,6 +5214,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -4963,6 +5260,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -5006,6 +5306,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -5049,6 +5352,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -5092,6 +5398,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -5135,6 +5444,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -5178,6 +5490,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -5221,6 +5536,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -5264,6 +5582,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -5307,6 +5628,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -5350,6 +5674,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -5393,6 +5720,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -5436,6 +5766,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -5479,6 +5812,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -5522,6 +5858,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -5565,6 +5904,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -5608,6 +5950,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -5651,6 +5996,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -5694,6 +6042,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -5737,6 +6088,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -5783,6 +6137,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -5829,6 +6186,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -5874,6 +6234,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -5919,6 +6282,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -5964,6 +6330,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -6009,6 +6378,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -6054,6 +6426,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -6099,6 +6474,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -6144,6 +6522,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -6189,6 +6570,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -6234,6 +6618,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -6279,6 +6666,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -6324,6 +6714,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -6369,6 +6762,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -6414,6 +6810,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -6459,6 +6858,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -6504,6 +6906,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -6549,6 +6954,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -6594,6 +7002,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -6639,6 +7050,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -6684,6 +7098,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -6729,6 +7146,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -6774,6 +7194,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -6819,6 +7242,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -6869,6 +7295,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -6909,6 +7338,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -6949,6 +7381,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -6984,6 +7419,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -7019,6 +7457,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -7060,6 +7501,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -7114,6 +7558,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -7174,6 +7621,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -7234,6 +7684,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -7286,6 +7739,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -7329,6 +7785,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -7372,6 +7831,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -7415,6 +7877,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -7458,6 +7923,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -7501,6 +7969,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -7544,6 +8015,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -7587,6 +8061,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -7630,6 +8107,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -7673,6 +8153,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -7716,6 +8199,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -7759,6 +8245,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -7802,6 +8291,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -7845,6 +8337,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -7888,6 +8383,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -7931,6 +8429,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -7974,6 +8475,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -8017,6 +8521,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -8060,6 +8567,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -8103,6 +8613,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -8146,6 +8659,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -8189,6 +8705,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -8232,6 +8751,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -8275,6 +8797,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -8318,6 +8843,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -8361,6 +8889,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -8404,6 +8935,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -8447,6 +8981,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -8490,6 +9027,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -8533,6 +9073,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -8576,6 +9119,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -8619,6 +9165,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -8662,6 +9211,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -8705,6 +9257,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -8748,6 +9303,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -8791,6 +9349,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -8834,6 +9395,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -8877,6 +9441,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -8920,6 +9487,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -8966,6 +9536,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -9012,6 +9585,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -9057,6 +9633,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -9102,6 +9681,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -9147,6 +9729,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -9192,6 +9777,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -9237,6 +9825,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -9282,6 +9873,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -9327,6 +9921,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -9372,6 +9969,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -9417,6 +10017,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -9462,6 +10065,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -9507,6 +10113,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -9552,6 +10161,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -9597,6 +10209,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -9642,6 +10257,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -9687,6 +10305,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -9732,6 +10353,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -9777,6 +10401,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -9822,6 +10449,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -9867,6 +10497,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -9912,6 +10545,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -9957,6 +10593,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -10002,6 +10641,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -10052,6 +10694,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -10108,6 +10753,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -10159,6 +10807,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -10210,6 +10861,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -10261,6 +10915,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -10312,6 +10969,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -10363,6 +11023,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -10414,6 +11077,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -10465,6 +11131,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -10516,6 +11185,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -10567,6 +11239,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -10618,6 +11293,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -10669,6 +11347,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -10720,6 +11401,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -10771,6 +11455,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -10822,6 +11509,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -10873,6 +11563,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -10924,6 +11617,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -10975,6 +11671,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -11026,6 +11725,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -11077,6 +11779,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -11128,6 +11833,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -11179,6 +11887,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -11230,6 +11941,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -11281,6 +11995,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -11332,6 +12049,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -11383,6 +12103,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -11434,6 +12157,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -11485,6 +12211,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -11536,6 +12265,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -11587,6 +12319,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -11638,6 +12373,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -11689,6 +12427,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -11740,6 +12481,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -11791,6 +12535,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -11842,6 +12589,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -11893,6 +12643,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -11944,6 +12697,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -11995,6 +12751,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -12046,6 +12805,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -12097,6 +12859,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -12148,6 +12913,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -12199,6 +12967,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -12250,6 +13021,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -12301,6 +13075,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -12352,6 +13129,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -12403,6 +13183,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -12454,6 +13237,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -12505,6 +13291,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -12556,6 +13345,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -12607,6 +13399,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -12658,6 +13453,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -12709,6 +13507,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -12760,6 +13561,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -12811,6 +13615,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -12862,6 +13669,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -12913,6 +13723,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -12964,6 +13777,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -13015,6 +13831,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -13066,6 +13885,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -13117,6 +13939,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -13168,6 +13993,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -13219,6 +14047,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -13352,6 +14183,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -13394,6 +14228,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -13436,6 +14273,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -13478,6 +14318,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -13520,6 +14363,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -13567,6 +14413,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -13609,6 +14458,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -13651,6 +14503,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -13693,6 +14548,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -13735,6 +14593,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -13777,6 +14638,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -13819,6 +14683,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -13861,6 +14728,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -13903,6 +14773,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -13945,6 +14818,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -13987,6 +14863,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -14029,6 +14908,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -14071,6 +14953,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -14113,6 +14998,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -14155,6 +15043,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -14197,6 +15088,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -14239,6 +15133,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -14281,6 +15178,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -14323,6 +15223,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -14365,6 +15268,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -14407,6 +15313,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -14449,6 +15358,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -14491,6 +15403,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -14533,6 +15448,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -14575,6 +15493,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -14617,6 +15538,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -14659,6 +15583,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -14701,6 +15628,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -14743,6 +15673,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -14785,6 +15718,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -14827,6 +15763,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -14869,6 +15808,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             }
@@ -14911,6 +15853,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },
@@ -14987,6 +15932,9 @@
                 },
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$"
+                },
+                {
+                  "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
             },

--- a/src/json/neo2.json.erb
+++ b/src/json/neo2.json.erb
@@ -20,7 +20,8 @@
           { "input_source_id" => "^org\\.sil\\.ukelele.keyboardlayout\\.neo2?\\.deutsch\\(neo2\\)$" },
           { "input_source_id" => "^org\\.unknown\\.keylayout\\.DeutschNeo2$" },
           { "input_source_id" => "^org\\.unknown\\.keylayout\\.DeutschBone$" },
-          { "input_source_id" => "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$" }
+          { "input_source_id" => "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$" },
+          { "input_source_id" => "^org\\.unknown\\.keylayout\\.DeutschADNW$" }
         ] }
 
         def neo2_layer4(condition)


### PR DESCRIPTION
[ADNW](http://adnw.de) uses the mod layers of Neo. Therefore, it was recommended to use the Neo2 karabiner rules for ADNW. This is not working any more because the rules are only applied with Neo keyboard layouts. This PR adds the ADNW layout as a compatible layout that can be used with the rules.