### PR TITLE
Remap PC-Keyboard Alt/Cmd to Ctrl/Alt in RDP sessions

### DIFF
--- a/public/json/rdp_pckb_alt-cmd_to_ctr-alt.json
+++ b/public/json/rdp_pckb_alt-cmd_to_ctr-alt.json
@@ -1,0 +1,72 @@
+{
+  "title": "Remap PC-Keyboard Alt/Cmd to Ctrl/Alt in RDP sessions.",
+  "rules": [
+    {
+      "description": "Mac OSX RDP: RAW Key Opt to Ctrl",
+      "manipulators": [
+        {
+          "type": "basic",
+          "parameters": {
+            "basic.simultaneous_threshold_milliseconds": 500
+          },
+          "from": {
+            "key_code": "left_alt"
+          },
+          "to": [
+            {
+              "key_code": "left_control"
+            }
+          ],
+          "conditions": [
+            {
+              "bundle_identifiers": [
+                "^com\\.microsoft\\.rdc$",
+                "^com\\.microsoft\\.rdc\\.mac$",
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.rdc\\.osx\\.beta$",
+                "^com\\.thinomenon\\.RemoteDesktopConnection$",
+                "^com\\.teamviewer\\.TeamViewer$"
+              ],
+              "type": "frontmost_application_if"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Mac OSX RDP: RAW Key Cmd to Alt",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_gui"
+          },
+          "conditions": [
+            {
+              "type": "frontmost_application_if"
+            }
+          ],
+          "to": [
+            {
+              "repeat": false,
+              "key_code": "left_alt"
+            }
+          ],
+          "conditions": [
+            {
+              "bundle_identifiers": [
+                "^com\\.microsoft\\.rdc$",
+                "^com\\.microsoft\\.rdc\\.mac$",
+                "^com\\.microsoft\\.rdc\\.macos$",
+                "^com\\.microsoft\\.rdc\\.osx\\.beta$",
+                "^com\\.thinomenon\\.RemoteDesktopConnection$",
+                "^com\\.teamviewer\\.TeamViewer$"
+              ],
+              "type": "frontmost_application_if"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/public/json/rdp_pckb_alt-cmd_to_ctr-alt.json
+++ b/public/json/rdp_pckb_alt-cmd_to_ctr-alt.json
@@ -6,9 +6,6 @@
       "manipulators": [
         {
           "type": "basic",
-          "parameters": {
-            "basic.simultaneous_threshold_milliseconds": 500
-          },
           "from": {
             "key_code": "left_alt"
           },
@@ -41,11 +38,6 @@
           "from": {
             "key_code": "left_gui"
           },
-          "conditions": [
-            {
-              "type": "frontmost_application_if"
-            }
-          ],
           "to": [
             {
               "repeat": false,


### PR DESCRIPTION
This commit use for PC Keyboard, it arraged like LCtrl > LWin > LAlt. I want remap it to Ctrl > Alt > Ctrl in Windows RDP. keep MacOS hot key habit and disable Win on left hand.
