### PR TITLE
Excluding citrix icaviewer in some PC shortcuts

### DIFF
--- a/public/json/pc_shortcuts.json
+++ b/public/json/pc_shortcuts.json
@@ -142,6 +142,7 @@
                 "^com\\.parallels\\.vm$",
                 "^com\\.parallels\\.desktop\\.console$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
+                "^com\\.citrix\\.receiver\\.icaviewer",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
                 "^com\\.parallels\\.winapp\\.",
@@ -246,6 +247,7 @@
                 "^com\\.parallels\\.vm$",
                 "^com\\.parallels\\.desktop\\.console$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
+                "^com\\.citrix\\.receiver\\.icaviewer",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
                 "^com\\.parallels\\.winapp\\.",
@@ -307,6 +309,7 @@
                 "^com\\.parallels\\.vm$",
                 "^com\\.parallels\\.desktop\\.console$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
+                "^com\\.citrix\\.receiver\\.icaviewer",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
                 "^com\\.parallels\\.winapp\\.",
@@ -411,6 +414,7 @@
                 "^com\\.parallels\\.vm$",
                 "^com\\.parallels\\.desktop\\.console$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
+                "^com\\.citrix\\.receiver\\.icaviewer",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
                 "^com\\.parallels\\.winapp\\.",
@@ -561,6 +565,7 @@
                 "^com\\.parallels\\.vm$",
                 "^com\\.parallels\\.desktop\\.console$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
+                "^com\\.citrix\\.receiver\\.icaviewer",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
                 "^com\\.parallels\\.winapp\\.",
@@ -623,6 +628,7 @@
                 "^com\\.parallels\\.vm$",
                 "^com\\.parallels\\.desktop\\.console$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
+                "^com\\.citrix\\.receiver\\.icaviewer",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
                 "^com\\.parallels\\.winapp\\.",
@@ -685,6 +691,7 @@
                 "^com\\.parallels\\.vm$",
                 "^com\\.parallels\\.desktop\\.console$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
+                "^com\\.citrix\\.receiver\\.icaviewer",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
                 "^com\\.parallels\\.winapp\\.",
@@ -747,6 +754,7 @@
                 "^com\\.parallels\\.vm$",
                 "^com\\.parallels\\.desktop\\.console$",
                 "^org\\.virtualbox\\.app\\.VirtualBoxVM$",
+                "^com\\.citrix\\.receiver\\.icaviewer",
                 "^com\\.citrix\\.XenAppViewer$",
                 "^com\\.vmware\\.proxyApp\\.",
                 "^com\\.parallels\\.winapp\\.",
@@ -2498,9 +2506,7 @@
           "to": [
             {
               "key_code": "launchpad",
-              "modifiers": [
-
-              ]
+              "modifiers": []
             }
           ],
           "conditions": [


### PR DESCRIPTION
Excluding the Citrix Icaviewer in "PC-Style Control+Up/Down/Left/Right" and "PC-Style Home/End". 
