### PR TITLE
TAB-to-mash.json

### DIFF
--- a/public/json/tab-to-mash.json
+++ b/public/json/tab-to-mash.json
@@ -2,7 +2,7 @@
   "title": "Tab to Mash When Held",
   "rules": [
     {
-      "description": "Map Tab to Mash when held",
+      "description": "Tab one shot, as normal. Mash/Hyper-lite when held (Cmd+Opt+Ctrl)",
       "manipulators": [
         {
           "type": "basic",

--- a/public/json/tab-to-mash.json
+++ b/public/json/tab-to-mash.json
@@ -1,0 +1,35 @@
+{
+  "title": "Tab to Mash When Held",
+  "rules": [
+    {
+      "description": "Map Tab to Mash when held",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "tab",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to_if_alone": [
+            {
+              "key_code": "tab"
+            }
+          ],
+          "to_if_held_down": [
+            {
+              "key_code": "left_command",
+              "modifiers": [
+                "left_control",
+                "left_option"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
TAB one shot behaves as normal.  As a modifier it becomes Cmd+Opt+Ctrl (Mash or Hyper-lite)