### PR TITLE
Add azerty_style_windows_keyboard_on_mac.json

### DIFF
--- a/public/json/azerty_style_windows_keyboard_on_mac.json
+++ b/public/json/azerty_style_windows_keyboard_on_mac.json
@@ -1,0 +1,237 @@
+{
+  "title": "Cassim's version of Windows-like combinations for French-AZERTY layout",
+  "rules": [
+      {
+      "description": "Right command and < for «",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "grave_accent_and_tilde",
+            "modifiers": {
+              "mandatory": [
+                "right_command"
+              ]
+            }
+          },
+          "to": {
+            "key_code": "7",
+            "modifiers": [
+              "left_option"
+            ]
+          },
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Right command and left shift and > for »",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "grave_accent_and_tilde",
+            "modifiers": {
+              "mandatory": [
+                "right_command",
+                "left_shift"
+              ]
+            }
+          },
+          "to": {
+            "key_code": "7",
+            "modifiers": [
+              "left_option",
+              "left_shift"
+            ]
+          },
+          "type": "basic"
+        }
+      ]
+    },
+      {
+      "description": "left command and < for «",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "grave_accent_and_tilde",
+            "modifiers": {
+              "mandatory": [
+                "left_command"
+              ]
+            }
+          },
+          "to": {
+            "key_code": "7",
+            "modifiers": [
+              "left_option"
+            ]
+          },
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "left command and option and »",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "grave_accent_and_tilde",
+            "modifiers": {
+              "mandatory": [
+                "left_command",
+                "left_shift"
+              ]
+            }
+          },
+          "to": {
+            "key_code": "7",
+            "modifiers": [
+              "left_option",
+              "left_shift"
+            ]
+          },
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Right command and 6 for | pipe",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "6",
+            "modifiers": {
+              "mandatory": [
+                "right_command"
+              ]
+            }
+          },
+          "to": {
+            "key_code": "l",
+            "modifiers": [
+              "left_option",
+              "shift"
+            ]
+          },
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Right command and 8 for \\ backslash",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "8",
+            "modifiers": {
+              "mandatory": [
+                "right_command"
+              ]
+            }
+          },
+          "to": {
+            "key_code": "period",
+            "modifiers": [
+              "left_option",
+              "shift"
+            ]
+          },
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Replace § with - hyphen",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "6"
+          },
+          "to": {
+            "key_code": "equal_sign"
+          },
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Right command and 5 for [ and right command and °) for ]",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "5",
+            "modifiers": {
+              "mandatory": [
+                "right_command"
+              ]
+            }
+          },
+          "to": {
+            "key_code": "5",
+            "modifiers": [
+              "right_option",
+              "shift"
+            ]
+          },
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "hyphen",
+            "modifiers": {
+              "mandatory": [
+                "right_command"
+              ]
+            }
+          },
+          "to": {
+            "key_code": "hyphen",
+            "modifiers": [
+              "right_option",
+              "shift"
+            ]
+          },
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Right command and 4 for { and right command and -_ for }",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "4",
+            "modifiers": {
+              "mandatory": [
+                "right_command"
+              ]
+            }
+          },
+          "to": {
+            "key_code": "5",
+            "modifiers": [
+              "right_option"
+            ]
+          },
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "equal_sign",
+            "modifiers": {
+              "mandatory": [
+                "right_command"
+              ]
+            }
+          },
+          "to": {
+            "key_code": "hyphen",
+            "modifiers": [
+              "right_option"
+            ]
+          },
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
A small new json very useful for french users on Mac. They will be able to easily use french quote « and » with a quick shortcut thanks to KE. Additionally, it also provides rules to create brackets faster []. 