### PR TITLE
Add a modernized version of Apple Music.app-only media key control

### DIFF
--- a/public/extra_descriptions/media_key_only_control_itunes.html
+++ b/public/extra_descriptions/media_key_only_control_itunes.html
@@ -4,10 +4,15 @@
   Description
 </p>
 <p>
-  From Mac OS High Sierra, Apple added new feature that media keys can control not only iTunes,
-  but also safari, chrome (youtube, facebook video), spotify, or other media players. <br />
-  This would be annoying feature to someone who wanted to media keys only works for iTunes player, as before.
-  If you want to make media key (F7,F8,F9) only control iTunes, enable this option.
+  Since Mac OS High Sierra, Apple changed how media keys work. Now they not only control iTunes,
+  but also Safari, Chrome (YouTube, Facebook Video), Spotify, or other media players. It depends
+  on which application is in the foreground.<br />
+  The new default behavior might be annoying to someone who expects media keys to only control
+  iTunes, as before. If you want to make media keys (F7,F8,F9) only control iTunes, enable this
+  mod.<br />
+  Use the regular F7-F9 modifiers provided here unless you enabled the "Use F1, F2, etc. keys as
+  standard function keys" option in System Preferences. In this case use the Fn+F7 ... Fn+F9
+  modifiers.
 </p>
 
 <p style="margin-top: 20px; font-weight: bold">

--- a/public/extra_descriptions/media_key_only_control_music_app.html
+++ b/public/extra_descriptions/media_key_only_control_music_app.html
@@ -1,0 +1,23 @@
+<link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
+
+<p style="margin-top: 20px; font-weight: bold">
+  Description
+</p>
+<p>
+  Since Mac OS High Sierra, media keys (⏪, ⏯, ⏩) on Apple keyboards not only control
+  Apple Music.app, but also Safari, Chrome (YouTube, Facebook Video), Spotify, or other media
+  players. It depends on which application is in the foreground.<br />
+  This defeats the purpose of those keys as the application you want to control is already in
+  focus. Making those keys only control Music.app has the advantage of being able to, say,
+  pause music when you want to watch a video on YouTube in the foreground.<br />
+  Use the regular ⏪, ⏯, ⏩ modifiers provided here unless you enabled the "Use F1, F2, etc. keys as
+  standard function keys" option in System Preferences. In this case use the Fn+⏪, Fn+⏯, Fn+⏩
+  modifiers.
+</p>
+
+<p style="margin-top: 20px; font-weight: bold">
+  Source Reference
+</p>
+<p>
+  <a href="https://apple.stackexchange.com/a/300903">https://apple.stackexchange.com/a/300903</a>
+</p>

--- a/public/groups.json
+++ b/public/groups.json
@@ -922,6 +922,10 @@
           "extra_description_path": "extra_descriptions/media_key_only_control_itunes.html"
         },
         {
+          "path": "json/media_key_only_control_music_app.json",
+          "extra_description_path": "extra_descriptions/media_key_only_control_music_app.html"
+        },
+        {
           "path": "json/modifiers_to_arrows.json"
         },
         {

--- a/public/json/media_key_only_control_music_app.json
+++ b/public/json/media_key_only_control_music_app.json
@@ -1,0 +1,136 @@
+{
+    "title": "Media key only control Apple Music.app",
+    "rules": [
+        {
+            "description": "(back track/rewind) key should only control Music.",
+            "manipulators": [
+                {
+                    "from": {
+                        "key_code": "f7"
+                    },
+                    "to_if_alone": [
+                        {
+                            "shell_command": "osascript -e 'tell application \"Music\" to back track'"
+                        }
+                    ],
+                    "to_if_held_down": [
+                        {
+                            "shell_command": "osascript -e 'tell application \"Music\" to rewind'"
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "(play/pause) key should only control Music.",
+            "manipulators": [
+                {
+                    "from": {
+                        "key_code": "f8"
+                    },
+                    "to": [
+                        {
+                            "shell_command": "osascript -e 'tell application \"Music\" to playpause'"
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "(next track, fast forward) key should only control Music.",
+            "manipulators": [
+                {
+                    "from": {
+                        "key_code": "f9"
+                    },
+                    "to_if_alone": [
+                        {
+                            "shell_command": "osascript -e 'tell application \"Music\" to next track'"
+                        }
+                    ],
+                    "to_if_held_down": [
+                        {
+                            "shell_command": "osascript -e 'tell application \"Music\" to fast forward'"
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "Fn+(back track, rewind) key should only control Music.",
+            "manipulators": [
+                {
+                    "from": {
+                        "key_code": "f7",
+                        "modifiers": {
+                            "mandatory": [
+                                "fn"
+                            ]
+                        }
+                    },
+                    "to_if_alone": [
+                        {
+                            "shell_command": "osascript -e 'tell application \"Music\" to back track'"
+                        }
+                    ],
+                    "to_if_held_down": [
+                        {
+                            "shell_command": "osascript -e 'tell application \"Music\" to rewind'"
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "Fn+(play/pause) key should only control Music.",
+            "manipulators": [
+                {
+                    "from": {
+                        "key_code": "f8",
+                        "modifiers": {
+                            "mandatory": [
+                                "fn"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "shell_command": "osascript -e 'tell application \"Music\" to playpause'"
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "Fn+(next track, fast forward) key should only control Music.",
+            "manipulators": [
+                {
+                    "from": {
+                        "key_code": "f9",
+                        "modifiers": {
+                            "mandatory": [
+                                "fn"
+                            ]
+                        }
+                    },
+                    "to_if_alone": [
+                        {
+                            "shell_command": "osascript -e 'tell application \"Music\" to next track'"
+                        }
+                    ],
+                    "to_if_held_down": [
+                        {
+                            "shell_command": "osascript -e 'tell application \"Music\" to fast forward'"
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
There's already a `public/json/media_key_only_control_itunes.json` modifier but it's got two problems:
- the application to control is no longer called "iTunes" so it doesn't work
- it refers to keys as F7 - F9 keys which is meaningless for Touch Bar controls

This PR introduces a new modifier that works with Apple Music and provides refined docs.