### PR TITLE
Add public/json/printscreen_command+shift+5.json

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -1033,7 +1033,7 @@
       "id": "os-functionality",
       "files": [
         {
-          "path": "json/printscreen_command+shift+5.json"
+          "path": "json/printscreen_command+shift+5.json" 
         },
         {
           "path": "json/mouse_motion_to_scroll.json"

--- a/public/groups.json
+++ b/public/groups.json
@@ -5,9 +5,6 @@
       "id": "modifier-keys",
       "files": [
         {
-          "path": "json/printscreen_command+shift+5.json"
-        },
-        {
           "path": "json/disable_wifidiagnostics.json"
         },
         {
@@ -1035,6 +1032,9 @@
       "name": "OS Functionality",
       "id": "os-functionality",
       "files": [
+        {
+          "path": "json/printscreen_command+shift+5.json"
+        },
         {
           "path": "json/mouse_motion_to_scroll.json"
         },

--- a/public/groups.json
+++ b/public/groups.json
@@ -5,6 +5,9 @@
       "id": "modifier-keys",
       "files": [
         {
+          "path": "json/printscreen_command+shift+5.json"
+        },
+        {
           "path": "json/disable_wifidiagnostics.json"
         },
         {

--- a/public/json/printscreen_command+shift+5.json
+++ b/public/json/printscreen_command+shift+5.json
@@ -1,0 +1,23 @@
+{
+  "title": "<Macos> Simple PrintScreen to Command+Shift+5",
+  "rules": [
+    {
+      "description": "Print Screen to Command+Shift+5",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "print_screen"
+          },
+          "to": {
+            "key_code": "5",
+            "modifiers": [
+              "left_command",
+              "left_shift"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/public/json/printscreen_command+shift+5.json
+++ b/public/json/printscreen_command+shift+5.json
@@ -7,7 +7,10 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "print_screen"
+            "key_code": "print_screen",
+            "modifiers": {
+              "optional": [ "caps_lock" ]
+            }
           },
           "to": {
             "key_code": "5",


### PR DESCRIPTION
Simply map PrintScreen key on windows keyboard to macOS's command+shift+5 shortcut.