### PR TITLE
Use Right Shift + numbers as Function keys

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -173,6 +173,9 @@
         },
         {
           "path": "json/meh_capslock.json"
+        },
+        {
+          "path": "json/right_shift_plus_numbers_to_function_keys.json"
         }
       ]
     },

--- a/public/json/right_shift_plus_numbers_to_function_keys.json
+++ b/public/json/right_shift_plus_numbers_to_function_keys.json
@@ -1,0 +1,298 @@
+{
+  "title": "RShift + Numbers to F-keys",
+  "rules": [
+    {
+      "description": "RShift + Numbers to F-keys",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "1",
+            "modifiers": {
+              "mandatory": ["right_shift"],
+              "optional": [
+                "fn",
+                "left_gui",
+                "left_control",
+                "left_alt",
+                "right_gui",
+                "right_control",
+                "right_alt",
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f1"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "2",
+            "modifiers": {
+              "mandatory": ["right_shift"],
+              "optional": [
+                "fn",
+                "left_gui",
+                "left_control",
+                "left_alt",
+                "right_gui",
+                "right_control",
+                "right_alt",
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f2"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "3",
+            "modifiers": {
+              "mandatory": ["right_shift"],
+              "optional": [
+                "fn",
+                "left_gui",
+                "left_control",
+                "left_alt",
+                "right_gui",
+                "right_control",
+                "right_alt",
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f3"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "4",
+            "modifiers": {
+              "mandatory": ["right_shift"],
+              "optional": [
+                "fn",
+                "left_gui",
+                "left_control",
+                "left_alt",
+                "right_gui",
+                "right_control",
+                "right_alt",
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f4"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "5",
+            "modifiers": {
+              "mandatory": ["right_shift"],
+              "optional": [
+                "fn",
+                "left_gui",
+                "left_control",
+                "left_alt",
+                "right_gui",
+                "right_control",
+                "right_alt",
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f5"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "6",
+            "modifiers": {
+              "mandatory": ["right_shift"],
+              "optional": [
+                "fn",
+                "left_gui",
+                "left_control",
+                "left_alt",
+                "right_gui",
+                "right_control",
+                "right_alt",
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f6"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "7",
+            "modifiers": {
+              "mandatory": ["right_shift"],
+              "optional": [
+                "fn",
+                "left_gui",
+                "left_control",
+                "left_alt",
+                "right_gui",
+                "right_control",
+                "right_alt",
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f7"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "8",
+            "modifiers": {
+              "mandatory": ["right_shift"],
+              "optional": [
+                "fn",
+                "left_gui",
+                "left_control",
+                "left_alt",
+                "right_gui",
+                "right_control",
+                "right_alt",
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f8"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "9",
+            "modifiers": {
+              "mandatory": ["right_shift"],
+              "optional": [
+                "fn",
+                "left_gui",
+                "left_control",
+                "left_alt",
+                "right_gui",
+                "right_control",
+                "right_alt",
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f9"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "0",
+            "modifiers": {
+              "mandatory": ["right_shift"],
+              "optional": [
+                "fn",
+                "left_gui",
+                "left_control",
+                "left_alt",
+                "right_gui",
+                "right_control",
+                "right_alt",
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f10"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "hyphen",
+            "modifiers": {
+              "mandatory": ["right_shift"],
+              "optional": [
+                "fn",
+                "left_gui",
+                "left_control",
+                "left_alt",
+                "right_gui",
+                "right_control",
+                "right_alt",
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f11"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "equal_sign",
+            "modifiers": {
+              "mandatory": ["right_shift"],
+              "optional": [
+                "fn",
+                "left_gui",
+                "left_control",
+                "left_alt",
+                "right_gui",
+                "right_control",
+                "right_alt",
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f12"
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
On 60%-style keyboards, you usually use a function key + number keys to emulate F1, F2, ..., F12 keys.
On macOS specifically this will normally mean that you can use this combination for *either* actual function keys *or* media keys.
Assuming that the System Preferences are set to use F-keys as media keys, this rule allows you to use right shift + number keys as regular F1 - F12 function keys.