### PR TITLE
typo correction

### DIFF
--- a/public/json/printscreen_with_alt_or_ctrl.json
+++ b/public/json/printscreen_with_alt_or_ctrl.json
@@ -50,7 +50,7 @@
       ]
     },
     {
-      "description": "Ctrl+Printscreen key to panel capature (command+shift+5)",
+      "description": "Ctrl+Printscreen key to panel capture (command+shift+5)",
       "manipulators": [
         {
           "from": {


### PR DESCRIPTION
I find the wrong spelling.

"capature" -> "capture" 

so, typo correction PR