### PR TITLE
Change input cmd + shift for Mac

### DIFF
--- a/public/extra_descriptions/cmd_shift_to_ctrl_option_space.json.html
+++ b/public/extra_descriptions/cmd_shift_to_ctrl_option_space.json.html
@@ -1,0 +1,12 @@
+<link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
+
+<h5>Windows stlyle language change for Mac.</h5>
+<p>
+  Cmd + Shift (Alt + Shift on Windows) to Ctrl + Option + Space
+</p>
+
+<h5>Notes</h5>
+<p>
+  Make sure your shortcut for "Select next source in Input menu" is set to ⌃⌥Space
+  <br>Check Setting &gt; Keyboard &gt; Shortcuts &gt; Input Sources
+</p>

--- a/public/groups.json
+++ b/public/groups.json
@@ -788,6 +788,10 @@
         },
         {
           "path": "json/azerty_windows_like_combinations.json"
+        },
+        {
+          "path": "json/cmd_shift_to_ctrl_option_space.json",
+          "extra_description_path": "extra_descriptions/cmd_shift_to_ctrl_option_space.json.html"
         }
       ]
     },

--- a/public/json/cmd_shift_to_ctrl_option_space.json
+++ b/public/json/cmd_shift_to_ctrl_option_space.json
@@ -1,0 +1,29 @@
+{
+  "title": "Windows stlyle input change Alt + Shift for Mac",
+  "rules": [
+    {
+      "description": "Cmd + Shift to Ctrl + Option + Space",
+      "manipulators": [
+        {
+          "from": {
+              "key_code": "left_shift",
+              "modifiers": {
+                "mandatory": ["left_command"]
+              } 
+          },
+          "to_if_alone": [
+              {
+                  "key_code": "spacebar",
+                  "modifiers": [
+                    "left_control",
+                    "left_option"
+                  ]
+              }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ] 
+}
+


### PR DESCRIPTION
Language switch as the default Windows shortcut Alt + Shift (Cmd + Shift on Mac). Might be helpful since you cannot use two modifiers in macOS settings.