### PR TITLE
support new alacritty bundle id

### DIFF
--- a/src/json/alacritty.json.erb
+++ b/src/json/alacritty.json.erb
@@ -33,7 +33,8 @@ rules = modifiers.map do |modifier|
             conditions: [{
                 type: "frontmost_application_if",
                 bundle_identifiers: [
-                    "^io\\.alacritty$"
+                    "^io\\.alacritty$",
+                    "^org\\.alacritty$"
                 ]
             }]
         }] + key_codes.map do |key_code|
@@ -53,7 +54,8 @@ rules = modifiers.map do |modifier|
                 conditions: [{
                     type: "frontmost_application_if",
                     bundle_identifiers: [
-                        "^io\\.alacritty$"
+                        "^io\\.alacritty$",
+                        "^org\\.alacritty$"
                     ]
                 }]
             }


### PR DESCRIPTION
start from v0.11.0, alacritty change bundle id to `org.alacritty`, so update it
[alacritty v0.11](https://github.com/alacritty/alacritty/releases/tag/v0.11.0-rc1)