### PR TITLE
Add Rule of Ctrl + g = Escape

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -176,6 +176,9 @@
         },
         {
           "path": "json/meh_capslock.json"
+        },
+        {
+          "path": "json/ctrl-g-to-escape.json"
         }
       ]
     },

--- a/public/json/ctrl-g-to-escape.json
+++ b/public/json/ctrl-g-to-escape.json
@@ -1,0 +1,25 @@
+{
+  "title": "esc = ctrl + g",
+  "rules": [
+    {
+      "description": "Control + g => Escape",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "g",
+            "modifiers": {
+              "mandatory": ["control"],
+              "optional": ["caps_lock", "option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "escape"
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Added `keyboad-quit`, which is Emacs' way of performing escaping with Ctrl + g.