### PR TITLE
feat: Add complex modification for swapping `/` and `?` to `.` and `,` for Cyrillic layouts

### DIFF
--- a/public/extra_descriptions/cyrillic-period-and-comma.html
+++ b/public/extra_descriptions/cyrillic-period-and-comma.html
@@ -1,0 +1,5 @@
+<link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
+
+<p>
+  Probably the most frustrating experience when migrating to Mac from other operating systems for users of Cyrillic layouts is the default location of the period and comma symbols. Every time you need to put a punctuation mark you have to do so by pressing the Shift key which is extremely annoying. So, these bindings will restore their default position used in PC keyboards.
+</p>

--- a/public/groups.json
+++ b/public/groups.json
@@ -726,6 +726,10 @@
           "path": "json/russian.json"
         },
         {
+          "path": "json/cyrillic-period-and-comma.json",
+          "extra_description_path": "extra_descriptions/cyrillic-period-and-comma.html"
+        },
+        {
           "path": "json/norwegian_programming.json"
         },
         {

--- a/public/json/cyrillic-period-and-comma.json
+++ b/public/json/cyrillic-period-and-comma.json
@@ -1,0 +1,133 @@
+{
+  "title": "Swap slash(/) to period (.) and question mark (?) to comma(,) in Cyrillic layouts",
+  "rules": [
+    {
+      "description": "Map slash (/) to period (.)",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "slash"
+          },
+          "to": [
+            {
+              "key_code": "7",
+              "modifiers": [
+                "shift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Map question mark (?) to comma (,)",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "slash",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "6",
+	      "modifiers": [
+                "shift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Map comma (,) to slash (/)",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "6",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "slash"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Map period (.) to question mark (?)",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "ru"
+                }
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "7",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "slash",
+              "modifiers": [
+                "shift"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds a new complex modification. See the motivation in `public/extra_descriptions/cyrillic-period-and-comma.html`.