### PR TITLE
feat: Add complex modification - map right option key to underscore

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -948,6 +948,9 @@
           "path": "json/return_to_ctrl.json"
         },
         {
+          "path": "json/right_option_to_underscore.json"
+        },
+        {
           "path": "json/screenshot_f3.json"
         },
         {

--- a/public/json/right_option_to_underscore.json
+++ b/public/json/right_option_to_underscore.json
@@ -1,0 +1,25 @@
+{
+  "title": "Map Right Option Key to Underscore",
+  "rules": [
+    {
+      "description": "Map Right Option Key to Underscore",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_option",
+            "modifiers": {
+              "optional": ["any"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "hyphen",
+              "modifiers": ["left_shift"]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Hello. Added a complex modification - mapping the right option key to underscore `_`. Motivation is more efficiency when typing, such as editing things like filenames and variable names when programming, etc...