### PR TITLE
Logitech MX keyboard (connected via USB dongle). 

### DIFF
--- a/public/json/Logitech_dongle_Swap_left_cmd_with_left_option.json
+++ b/public/json/Logitech_dongle_Swap_left_cmd_with_left_option.json
@@ -1,7 +1,7 @@
 {
   "title": "Logitech dongle - Swap left cmd with left option",
   "maintainers": [
-    "devnoname120"
+    "DamianJ"
   ],
   "rules": [{
     "description": "Logitech dongle - Swap left cmd with left option",

--- a/public/json/Logitech_dongle_Swap_left_cmd_with_left_option.json
+++ b/public/json/Logitech_dongle_Swap_left_cmd_with_left_option.json
@@ -1,0 +1,43 @@
+{
+  "title": "Logitech dongle - Swap left cmd with left option",
+  "maintainers": [
+    "devnoname120"
+  ],
+  "rules": [{
+    "description": "Logitech dongle - Swap left cmd with left option",
+    "manipulators": [
+        {
+            "from": {
+                "key_code": "left_option",
+                "modifiers": {
+                    "optional": [
+                        "any"
+                    ]
+                }
+            },
+            "to": [
+                {
+                    "key_code": "left_command"
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "left_command",
+                "modifiers": {
+                    "optional": [
+                        "any"
+                    ]
+                }
+            },
+            "to": [
+                {
+                    "key_code": "left_option"
+                }
+            ],
+            "type": "basic"
+        }
+    ]
+  }]
+}

--- a/public/json/Logitech_dongle_Swap_right_cmd_with_right_option.json
+++ b/public/json/Logitech_dongle_Swap_right_cmd_with_right_option.json
@@ -1,0 +1,43 @@
+{
+  "title": "Logitech dongle - Swap right cmd with right option",
+  "maintainers": [
+    "devnoname120"
+  ],
+  "rules": [{
+    "description": "Logitech dongle - Swap right cmd with right option",
+    "manipulators": [
+        {
+            "from": {
+                "key_code": "right_control",
+                "modifiers": {
+                    "optional": [
+                        "any"
+                    ]
+                }
+            },
+            "to": [
+                {
+                    "key_code": "right_command"
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "from": {
+                "key_code": "right_command",
+                "modifiers": {
+                    "optional": [
+                        "any"
+                    ]
+                }
+            },
+            "to": [
+                {
+                    "key_code": "right_control"
+                }
+            ],
+            "type": "basic"
+        }
+    ]
+  }]
+}


### PR DESCRIPTION
Add modification for Logitech MX keyboard (connected via USB dongle):

1. Swap left cmd with left option 
2. Swap right cmd with right option keys