### PR TITLE
fix tenkey numbers to use the keypad_[0-9] keys

### DIFF
--- a/public/json/caps_tenkey_mode.json
+++ b/public/json/caps_tenkey_mode.json
@@ -64,7 +64,7 @@
       ]
     },
     {
-      "description": "CAPS Tenkey: if TenkeyMode ON m,.jkluio maps to 1234567890",
+      "description": "CAPS Tenkey: if TenkeyMode ON m,.jkluio maps to keypad_[1234567890]",
       "manipulators": [
         {
           "type": "basic",
@@ -80,7 +80,7 @@
             }
           },
           "to": {
-            "key_code": "1"
+            "key_code": "keypad_1"
           },
           "conditions": [
             {
@@ -104,7 +104,7 @@
             }
           },
           "to": {
-            "key_code": "2"
+            "key_code": "keypad_2"
           },
           "conditions": [
             {
@@ -128,7 +128,7 @@
             }
           },
           "to": {
-            "key_code": "3"
+            "key_code": "keypad_3"
           },
           "conditions": [
             {
@@ -152,7 +152,7 @@
             }
           },
           "to": {
-            "key_code": "4"
+            "key_code": "keypad_4"
           },
           "conditions": [
             {
@@ -176,7 +176,7 @@
             }
           },
           "to": {
-            "key_code": "5"
+            "key_code": "keypad_5"
           },
           "conditions": [
             {
@@ -200,7 +200,7 @@
             }
           },
           "to": {
-            "key_code": "6"
+            "key_code": "keypad_6"
           },
           "conditions": [
             {
@@ -224,7 +224,7 @@
             }
           },
           "to": {
-            "key_code": "7"
+            "key_code": "keypad_7"
           },
           "conditions": [
             {
@@ -248,7 +248,7 @@
             }
           },
           "to": {
-            "key_code": "8"
+            "key_code": "keypad_8"
           },
           "conditions": [
             {
@@ -272,7 +272,7 @@
             }
           },
           "to": {
-            "key_code": "9"
+            "key_code": "keypad_9"
           },
           "conditions": [
             {
@@ -296,7 +296,7 @@
             }
           },
           "to": {
-            "key_code": "0"
+            "key_code": "keypad_0"
           },
           "conditions": [
             {

--- a/src/json/caps_tenkey_mode.json.rb
+++ b/src/json/caps_tenkey_mode.json.rb
@@ -2,16 +2,16 @@ require 'json'
 require_relative '../lib/karabiner.rb'
 
 TENKEY_MAPPING = {
-  'm'=> '1',
-  'comma'=> '2',
-  'period'=> '3',
-  'j'=> '4',
-  'k'=> '5',
-  'l'=> '6',
-  'u'=> '7',
-  'i'=> '8',
-  'o'=> '9',
-  'spacebar'=> '0'
+  'm'=> 'keypad_1',
+  'comma'=> 'keypad_2',
+  'period'=> 'keypad_3',
+  'j'=> 'keypad_4',
+  'k'=> 'keypad_5',
+  'l'=> 'keypad_6',
+  'u'=> 'keypad_7',
+  'i'=> 'keypad_8',
+  'o'=> 'keypad_9',
+  'spacebar'=> 'keypad_0'
 }
 
 ARITHMETIC_SYMBOLS_MAPPING = {
@@ -58,7 +58,7 @@ end
 
 def tenkey_mapping
   {
-    description: 'CAPS Tenkey: if TenkeyMode ON m,.jkluio' ' maps to 1234567890',
+    description: 'CAPS Tenkey: if TenkeyMode ON m,.jkluio' ' maps to keypad_[1234567890]',
     manipulators: map_keys(TENKEY_MAPPING, conditions: tenkey_mode_on)
   }
 end


### PR DESCRIPTION
This fixes the mapping for things like games and emulators that specifically want the keypad number keys