### PR TITLE
pay attention to the filename format

### DIFF
--- a/src/json/README.md
+++ b/src/json/README.md
@@ -10,3 +10,11 @@ The output files are saved to public/json.
 -   .js (nodejs is required)
 -   .rb
 -   .erb
+
+## Supported filename format
+
+To generate JSON files successfully, the filename must match `*.json.<file-extension>`. 
+
+- *\** : your self-defined name
+- *.json* : must add `.json` before filename extension
+- *.file-extension* : `.js` or `.rb` or `.erb`


### PR DESCRIPTION
`.json` must be added to the filename before filename extension (`.js`, `.rb`, `.erb`)

This info is important for users who make their own JSON generator.