### PR TITLE
map right control+['/; to arrow keys

### DIFF
--- a/public/json/hhkb_arrows_for_realforce_r3.json
+++ b/public/json/hhkb_arrows_for_realforce_r3.json
@@ -1,0 +1,78 @@
+{
+  "title": "HHKB arrows for RealForce R3",
+  "rules": [
+    {
+      "description": "Right control + ['/; to Arrow keys",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "mandatory": [
+                "right_control"
+              ]
+            },
+            "key_code": "open_bracket"
+          },
+          "to": [
+            {
+              "repeat": true,
+              "key_code": "up_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "mandatory": [
+                "right_control"
+              ]
+            },
+            "key_code": "quote"
+          },
+          "to": [
+            {
+              "repeat": true,
+              "key_code": "right_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "mandatory": [
+                "right_control"
+              ]
+            },
+            "key_code": "semicolon"
+          },
+          "to": [
+            {
+              "repeat": true,
+              "key_code": "left_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "mandatory": [
+                "right_control"
+              ]
+            },
+            "key_code": "slash"
+          },
+          "to": [
+            {
+              "repeat": true,
+              "key_code": "down_arrow"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds the HHKB styled arrow keys (fn+[, fn+', fn+/, fn+;) to RealForce R3 (control+[, control+', control+/, control+;).