### PR TITLE
feat: add mapping rules for tilde and grave accent

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -107,6 +107,9 @@
           "path": "json/map_esc_grave_accent_and_tilde.json"
         },
         {
+          "path": "json/left_shift_esc_to_tilde_and_right_shift_esc_to_grave_accent.json"
+        },
+        {
           "path": "json/swap_right_cmd_with_right_option.json",
           "extra_description_path": "extra_descriptions/swap_right_cmd_with_right_option.json.html"
         },

--- a/public/json/left_shift_esc_to_tilde_and_right_shift_esc_to_grave_accent.json
+++ b/public/json/left_shift_esc_to_tilde_and_right_shift_esc_to_grave_accent.json
@@ -1,0 +1,50 @@
+{
+    "title": "Right Shift + Esc To ` | Left Shift + Esc To ~",
+    "rules": [
+      {
+        "description": "Right Shift + Esc To `",
+        "manipulators": [
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "escape",
+              "modifiers": {
+                "mandatory": [
+                  "right_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "grave_accent_and_tilde"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "description": "Left Shift + Esc To ~",
+        "manipulators": [
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "escape",
+              "modifiers": {
+                "mandatory": [
+                  "left_shift"
+                ]
+              }
+            },
+            "to": [
+              {
+                "key_code": "grave_accent_and_tilde",
+                "modifiers": [
+                  "shift"
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }


### PR DESCRIPTION
User Case:
HHKB Japanese layout with ANSI setup makes it impossible to enter tilde (~) and grave accent (`)

Solution:
* Map `Left Shift` + `Esc` to ~
* Map `Right Shift` + `Esc` to `