### PR TITLE
home symbol `~` in Alt Gr 4

### DIFF
--- a/public/json/personal_javier_monton.json
+++ b/public/json/personal_javier_monton.json
@@ -35,6 +35,26 @@
           "type": "basic"
         }
       ]
+    },
+    {
+      "description": "~ (home symbol) in Alt Gr 4",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "4",
+            "modifiers": {
+              "mandatory": ["right_option"]
+            }
+          },
+          "to": {
+            "key_code": "semicolon",
+            "modifiers": [
+              "right_option"
+            ]
+          },
+          "type": "basic"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
(right_option + 4) as (right_option + semicolon). 

This should write `~` using right_option + 4 (or Alt Gr + 4)

This is where the symbol is in common Spanish keyboards