### PR TITLE
Added new rule set for Keychron K6

### DIFF
--- a/public/extra_descriptions/keychron_k6_useful_escape_caps_lock.json.html
+++ b/public/extra_descriptions/keychron_k6_useful_escape_caps_lock.json.html
@@ -7,7 +7,7 @@
 </p>
 
 <p>
-  It also adds the Hyper Key mod (⌃⌥⇧⌘) to Caps Lock when held for creating complex hotkeys that are easy to input. Caps Lock still works by simply pressing the key once.
+  It also adds the Hyper Key mod (⌃⌥⇧⌘) to Caps Lock when held for creating complex hotkeys that are easy to input. Caps Lock still works by simply pressing the key alone.
 </p>
 
 <div style="background: #F5F7F9; display: inline-block; padding: 10px; font-style: italic;">
@@ -25,8 +25,9 @@
   <li>Unmodified Esc: Escape</li>
   <li>Left Shift + Esc: ~ (tilde)</li>
   <li>Right Shift + Esc: ` (grave)</li>
-  <li>Control + Esc: Control + ` (iTerm hotkey)</li>
+  <li>Control + Esc: Control + `</li>
   <li>Command + Esc: ⌘ + ` (app window cycle)</li>
   <li>Caps Lock (held): ⌃⌥⇧⌘ (Hyper Key)</li>
-  <li>Caps Lock (pressed): Regular Caps Lock</li>
+  <li>Caps Lock (alone): Regular Caps Lock</li>
+  <li>Hyper Key + Esc: Shift + Escape</li>
 </ul>

--- a/public/extra_descriptions/keychron_k6_useful_escape_caps_lock.json.html
+++ b/public/extra_descriptions/keychron_k6_useful_escape_caps_lock.json.html
@@ -1,0 +1,32 @@
+<link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
+
+<h1 style="border-bottom: 1px solid #D4D9E0;">Keychron K6 Useful Escape & Caps Lock Hyper Mod</h1>
+
+<p>
+  This rule adds Escape hotkeys for Keychron K6 users to maintain muscle memory between the built-in MacBook keyboard and the K6.
+</p>
+
+<p>
+  It also adds the Hyper Key mod (⌃⌥⇧⌘) to Caps Lock when held for creating complex hotkeys that are easy to input. Caps Lock still works by simply pressing the key once.
+</p>
+
+<div style="background: #F5F7F9; display: inline-block; padding: 10px; font-style: italic;">
+  Some rules are borrowed from @sourabhv with slight tweaks:
+  <div style="margin: 15px 0 15px 25px;">
+    <b>Left Shift + Esc </b>acts as<b> ~</b><br />
+    <b>Control + Escape </b>acts as<b> Control + `</b>
+  </div>
+  This matches the key positioning for users who also use the built-in keyboard.
+</div>
+
+<p>Full list of modifications:</p>
+
+<ul>
+  <li>Unmodified Esc: Escape</li>
+  <li>Left Shift + Esc: ~ (tilde)</li>
+  <li>Right Shift + Esc: ` (grave)</li>
+  <li>Control + Esc: Control + ` (iTerm hotkey)</li>
+  <li>Command + Esc: ⌘ + ` (app window cycle)</li>
+  <li>Caps Lock (held): ⌃⌥⇧⌘ (Hyper Key)</li>
+  <li>Caps Lock (pressed): Regular Caps Lock</li>
+</ul>

--- a/public/groups.json
+++ b/public/groups.json
@@ -1528,6 +1528,10 @@
         },
         {
           "path": "json/keychron_k6_remap_page_down_page_up.json"
+        },
+        {
+          "path": "json/keychron_k6_useful_escape_caps_lock.json",
+          "extra_description_path": "extra_descriptions/keychron_k6_useful_escape_caps_lock.json.html"
         }
       ]
     },

--- a/public/json/keychron_k6_useful_escape_caps_lock.json
+++ b/public/json/keychron_k6_useful_escape_caps_lock.json
@@ -15,6 +15,10 @@
                             "mandatory":
                             [
                                 "left_shift"
+                            ],
+                            "optional":
+                            [
+                                "caps_lock"
                             ]
                         }
                     },
@@ -46,13 +50,18 @@
                             "mandatory":
                             [
                                 "right_shift"
+                            ],
+                            "optional":
+                            [
+                                "caps_lock"
                             ]
                         }
                     },
                     "to":
                     [
                         {
-                            "key_code": "grave_accent_and_tilde"
+                            "key_code": "grave_accent_and_tilde",
+                            "repeat": false
                         }
                     ],
                     "type": "basic"
@@ -60,7 +69,7 @@
             ]
         },
         {
-            "description": "Control + Esc: Control + ` (iTerm hotkey)",
+            "description": "Control + Esc: Control + `",
             "manipulators":
             [
                 {
@@ -72,6 +81,10 @@
                             "mandatory":
                             [
                                 "control"
+                            ],
+                            "optional":
+                            [
+                                "caps_lock"
                             ]
                         }
                     },
@@ -102,6 +115,10 @@
                             "mandatory":
                             [
                                 "command"
+                            ],
+                            "optional":
+                            [
+                                "caps_lock"
                             ]
                         }
                     },
@@ -131,7 +148,7 @@
                         {
                             "optional":
                             [
-                                "any"
+                                "caps_lock"
                             ]
                         }
                     },
@@ -144,14 +161,52 @@
                                 "left_command",
                                 "left_control",
                                 "left_option"
-                            ]
+                            ],
+                            "lazy": true
                         }
                     ],
                     "to_if_alone":
                     [
                         {
-                            "repeat": false,
-                            "key_code": "caps_lock"
+                            "key_code": "caps_lock",
+                            "repeat": false
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "Hyper Key + Esc: Shift + Escape",
+            "manipulators":
+            [
+                {
+                    "from":
+                    {
+                        "key_code": "escape",
+                        "modifiers":
+                        {
+                            "mandatory":
+                            [
+                                "left_shift",
+                                "left_command",
+                                "left_control",
+                                "left_option"
+                            ],
+                            "optional":
+                            [
+                                "caps_lock"
+                            ]
+                        }
+                    },
+                    "to":
+                    [
+                        {
+                            "key_code": "escape",
+                            "modifiers":
+                            [
+                                "shift"
+                            ]
                         }
                     ],
                     "type": "basic"

--- a/public/json/keychron_k6_useful_escape_caps_lock.json
+++ b/public/json/keychron_k6_useful_escape_caps_lock.json
@@ -1,0 +1,162 @@
+{
+    "title": "Keychron K6 Useful Escape & Caps Lock Hyper Mod",
+    "rules":
+    [
+        {
+            "description": "Left Shift + Esc: ~ (tilde)",
+            "manipulators":
+            [
+                {
+                    "from":
+                    {
+                        "key_code": "escape",
+                        "modifiers":
+                        {
+                            "mandatory":
+                            [
+                                "left_shift"
+                            ]
+                        }
+                    },
+                    "to":
+                    [
+                        {
+                            "key_code": "grave_accent_and_tilde",
+                            "modifiers":
+                            [
+                                "shift"
+                            ],
+                            "repeat": false
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "Right Shift + Esc: ` (grave)",
+            "manipulators":
+            [
+                {
+                    "from":
+                    {
+                        "key_code": "escape",
+                        "modifiers":
+                        {
+                            "mandatory":
+                            [
+                                "right_shift"
+                            ]
+                        }
+                    },
+                    "to":
+                    [
+                        {
+                            "key_code": "grave_accent_and_tilde"
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "Control + Esc: Control + ` (iTerm hotkey)",
+            "manipulators":
+            [
+                {
+                    "from":
+                    {
+                        "key_code": "escape",
+                        "modifiers":
+                        {
+                            "mandatory":
+                            [
+                                "control"
+                            ]
+                        }
+                    },
+                    "to":
+                    [
+                        {
+                            "key_code": "grave_accent_and_tilde",
+                            "modifiers":
+                            [
+                                "control"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "Command + Esc: ⌘ + ` (app window cycle)",
+            "manipulators":
+            [
+                {
+                    "from":
+                    {
+                        "key_code": "escape",
+                        "modifiers":
+                        {
+                            "mandatory":
+                            [
+                                "command"
+                            ]
+                        }
+                    },
+                    "to":
+                    [
+                        {
+                            "key_code": "grave_accent_and_tilde",
+                            "modifiers":
+                            [
+                                "command"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "Caps Lock (held): ⌃⌥⇧⌘ (Hyper Key)",
+            "manipulators":
+            [
+                {
+                    "from":
+                    {
+                        "key_code": "caps_lock",
+                        "modifiers":
+                        {
+                            "optional":
+                            [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to":
+                    [
+                        {
+                            "key_code": "left_shift",
+                            "modifiers":
+                            [
+                                "left_command",
+                                "left_control",
+                                "left_option"
+                            ]
+                        }
+                    ],
+                    "to_if_alone":
+                    [
+                        {
+                            "repeat": false,
+                            "key_code": "caps_lock"
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
# Keychron K6 Useful Escape & Caps Lock Hyper Mod

This rule adds Escape hotkeys for Keychron K6 users to maintain muscle memory between the built-in MacBook keyboard and the K6.

It also adds the Hyper Key mod (⌃⌥⇧⌘) to Caps Lock when held for creating complex hotkeys that are easy to input. Caps Lock still works by simply pressing the key alone.

```
Some rules are borrowed from @sourabhv with slight tweaks:

    Left Shift + Esc acts as ~
    Control + Escape acts as Control + `

This matches the key positioning for users who also use the built-in keyboard.
```
_(Thanks to @sourabhv for the inspiration.)_

Full list of modifications:

- Unmodified Esc: Escape
- Left Shift + Esc: ~ (tilde)
- Right Shift + Esc: ` (grave)
- Control + Esc: Control + ` (iTerm hotkey)
- Command + Esc: ⌘ + ` (app window cycle)
- Caps Lock (held): ⌃⌥⇧⌘ (Hyper Key)
- Caps Lock (alone): Regular Caps Lock
- Hyper Key + Esc: Shift + Escape