### PR TITLE
Add "Tab as a meta key" rules

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -157,6 +157,9 @@
         },
         {
           "path": "json/emacs_key_bindings_move_delete_select.json"
+        },
+        {
+          "path": "json/meta_tab.json"
         }
       ]
     },

--- a/public/json/meta_tab.json
+++ b/public/json/meta_tab.json
@@ -1,0 +1,127 @@
+{
+  "title": "Tab as a meta key for indentation/focus",
+  "rules": [
+    {
+      "description": "Tab + Arrows",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_arrow",
+            "modifiers": {
+              "optional": ["any"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "tab"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "tab pressed",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_arrow",
+            "modifiers": {
+              "optional": ["any"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "tab",
+              "modifiers": ["left_shift"]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "tab pressed",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "down_arrow",
+            "modifiers": {
+              "optional": ["any"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "tab"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "tab pressed",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "up_arrow",
+            "modifiers": {
+              "optional": ["any"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "tab",
+              "modifiers": ["left_shift"]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "tab pressed",
+              "value": 1
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "tab"
+          },
+          "parameters": {
+            "basic.to_if_alone_timeout_milliseconds": 250,
+            "basic.to_if_held_down_threshold_milliseconds": 250
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "tab pressed",
+                "value": 1
+              }
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "tab"
+            }
+          ],
+          "to_after_key_up": [
+            {
+              "set_variable": {
+                "name": "tab pressed",
+                "value": 0
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Hope others will find this as useful as I have.

It's especially useful for indenting/outdenting code in IDEs. But it's also a more intuitive way to move focus in any app.

    Tab+Left / Tab+Up    = Move focus back / Dedent
    Tab+Right / Tab+Down = Move focus forward / Indent

Treating the Tab key as a meta key makes more sense, IMO.

PS. Thanks for Karabiner!