### PR TITLE
Exclude some apps from layer 3 rule

### DIFF
--- a/public/json/neo2.json
+++ b/public/json/neo2.json
@@ -14188,6 +14188,14 @@
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
+              ]
             }
           ]
         },
@@ -14232,6 +14240,14 @@
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
+              ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
               ]
             }
           ]
@@ -14278,6 +14294,14 @@
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
+              ]
             }
           ]
         },
@@ -14323,6 +14347,14 @@
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
+              ]
             }
           ]
         },
@@ -14367,6 +14399,14 @@
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
+              ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
               ]
             }
           ]
@@ -14418,6 +14458,14 @@
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
+              ]
             }
           ]
         },
@@ -14462,6 +14510,14 @@
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
+              ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
               ]
             }
           ]
@@ -14508,6 +14564,14 @@
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
+              ]
             }
           ]
         },
@@ -14552,6 +14616,14 @@
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
+              ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
               ]
             }
           ]
@@ -14598,6 +14670,14 @@
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
+              ]
             }
           ]
         },
@@ -14642,6 +14722,14 @@
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
+              ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
               ]
             }
           ]
@@ -14688,6 +14776,14 @@
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
+              ]
             }
           ]
         },
@@ -14732,6 +14828,14 @@
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
+              ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
               ]
             }
           ]
@@ -14778,6 +14882,14 @@
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
+              ]
             }
           ]
         },
@@ -14822,6 +14934,14 @@
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
+              ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
               ]
             }
           ]
@@ -14868,6 +14988,14 @@
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
+              ]
             }
           ]
         },
@@ -14912,6 +15040,14 @@
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
+              ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
               ]
             }
           ]
@@ -14958,6 +15094,14 @@
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
+              ]
             }
           ]
         },
@@ -15002,6 +15146,14 @@
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
+              ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
               ]
             }
           ]
@@ -15048,6 +15200,14 @@
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
+              ]
             }
           ]
         },
@@ -15092,6 +15252,14 @@
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
+              ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
               ]
             }
           ]
@@ -15138,6 +15306,14 @@
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
+              ]
             }
           ]
         },
@@ -15182,6 +15358,14 @@
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
+              ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
               ]
             }
           ]
@@ -15228,6 +15412,14 @@
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
+              ]
             }
           ]
         },
@@ -15272,6 +15464,14 @@
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
+              ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
               ]
             }
           ]
@@ -15318,6 +15518,14 @@
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
+              ]
             }
           ]
         },
@@ -15362,6 +15570,14 @@
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
+              ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
               ]
             }
           ]
@@ -15408,6 +15624,14 @@
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
+              ]
             }
           ]
         },
@@ -15452,6 +15676,14 @@
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
+              ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
               ]
             }
           ]
@@ -15498,6 +15730,14 @@
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
+              ]
             }
           ]
         },
@@ -15542,6 +15782,14 @@
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
+              ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
               ]
             }
           ]
@@ -15588,6 +15836,14 @@
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
+              ]
             }
           ]
         },
@@ -15632,6 +15888,14 @@
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
+              ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
               ]
             }
           ]
@@ -15678,6 +15942,14 @@
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
+              ]
             }
           ]
         },
@@ -15722,6 +15994,14 @@
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
+              ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
               ]
             }
           ]
@@ -15768,6 +16048,14 @@
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
               ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
+              ]
             }
           ]
         },
@@ -15812,6 +16100,14 @@
                 {
                   "input_source_id": "^org\\.unknown\\.keylayout\\.DeutschADNW$"
                 }
+              ]
+            },
+            {
+              "type": "frontmost_application_unless",
+              "bundle_identifiers": [
+                "com.apple.Terminal",
+                "org.gnu.Emacs",
+                "com.googlecode.iterm2"
               ]
             }
           ]

--- a/src/json/neo2.json.erb
+++ b/src/json/neo2.json.erb
@@ -23,6 +23,11 @@
           { "input_source_id" => "^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$" },
           { "input_source_id" => "^org\\.unknown\\.keylayout\\.DeutschADNW$" }
         ] }
+        $is_not_excluded_app = { "type" => "frontmost_application_unless", "bundle_identifiers" => [
+            "com.apple.Terminal",
+            "org.gnu.Emacs",
+            "com.googlecode.iterm2"
+        ]}
 
         def neo2_layer4(condition)
             l4_mappings = {
@@ -261,7 +266,7 @@
               each_key(
                   source_keys_list: ["h", "s", "z", "o", "k"],
                   dest_keys_list: ["h", "s", "z", "o", "k"],
-                  conditions: [$is_layout_active],
+                  conditions: [$is_layout_active, $is_not_excluded_app],
                   from_mandatory_modifiers: ["right_option"],
                   to_modifiers: [],
                   to_pre_events: [["page_up", ["left_option", "left_shift"]]]
@@ -274,8 +279,8 @@
               each_key(
                   source_keys_list: ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "open_bracket", "semicolon", "quote", "comma", "period", "slash"],
                   dest_keys_list: ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "open_bracket", "semicolon", "quote", "comma", "period", "slash"],
-                  conditions: [$is_layout_active],
                   from_mandatory_modifiers: ["right_option"],
+                  conditions: [$is_layout_active, $is_not_excluded_app],
                   to_modifiers: [],
                   to_pre_events: [["page_up", ["left_option", "left_shift"]]]
               )


### PR DESCRIPTION
With these changes, Apple Terminal, Emacs and iTerm2 are excluded from the `Prevent all layer 3 keys from being treated as option key shortcut` and `Prevent problematic keys (?, /, #, =, and ')') from being treated as option key shortcut` rules, as with these rules enabled, extra characters would be added inside these apps when layer 3 is used.

Related: The included terminals in JetBrains IDEs still have the issue with added characters even with these changes (a tilde in that case), anyone know a fix for that?