### PR TITLE
add pc style copy (shift+insert) as there already is paste in this file

### DIFF
--- a/public/json/pc_shortcuts.json
+++ b/public/json/pc_shortcuts.json
@@ -445,7 +445,34 @@
       ]
     },
     {
-      "description": "PC-Style Paste(Shift+Insert) for JIS keyboard",
+      "description": "PC-Style Copy (Ctrl+Insert) for JIS/PC keyboard",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "insert",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "c",
+              "modifiers": [
+                "left_command"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "PC-Style Paste (Shift+Insert) for JIS/PC keyboard",
       "manipulators": [
         {
           "type": "basic",


### PR DESCRIPTION
there is also the file `public/json/PC-Style_Shortcuts_Copy_Ctrl_Insert.json` which includes only this modification. Maybe in order to prevent duplicates, this file could be deleted. 
Or one could also think it the other way and move the snippet containing paste to this file. 
But since this belongs to PC-style modifications nevertheless, I would suggest having both snippets included in the `pc_shortcuts.json` file.