### PR TITLE
CMD + e to paste without formatting

### DIFF
--- a/CmdEpastewithoutFormatting.json
+++ b/CmdEpastewithoutFormatting.json
@@ -1,0 +1,31 @@
+{
+  "title": "Command + e to paste without formatting",
+  "rules": [
+    {
+      "description": "Command + e does special paste without formatting, equivalent to. cmd+opt+shift+v.",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "e",
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "v",
+              "modifiers": [
+                "left_command",
+                "left_option",
+                "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This replaces OPT+CMD+SHIFT+v