### PR TITLE
add complex modifications for fn keys in VSCode

### DIFF
--- a/public/json/vscode_swapfn.json
+++ b/public/json/vscode_swapfn.json
@@ -1,5 +1,5 @@
 {
-    "title": "VSCode",
+    "title": "VSCode fn keys",
     "rules": [
         {
 	"description": "Swap fn keys in VSCode",

--- a/public/json/vscode_swapfn.json
+++ b/public/json/vscode_swapfn.json
@@ -1,0 +1,322 @@
+{
+    "title": "VSCode",
+    "rules": [
+        {
+	"description": "Swap fn keys in VSCode",
+            "manipulators": [
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.microsoft\\.VSCode",
+                                "^com\\.microsoft\\.VSCodeInsiders"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f1",
+                        "modifiers":{
+                            "optional": ["shift"]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "f1",
+                            "modifiers": [
+                                "fn"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.microsoft\\.VSCode",
+                                "^com\\.microsoft\\.VSCodeInsiders"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f2",
+                        "modifiers":{
+                            "optional": ["shift"]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "f2",
+                            "modifiers": [
+                                "fn"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.microsoft\\.VSCode",
+                                "^com\\.microsoft\\.VSCodeInsiders"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f3",
+                        "modifiers":{
+                            "optional": ["shift"]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "f3",
+                            "modifiers": [
+                                "fn"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.microsoft\\.VSCode",
+                                "^com\\.microsoft\\.VSCodeInsiders"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f4",
+                        "modifiers":{
+                            "optional": ["shift"]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "f4",
+                            "modifiers": [
+                                "fn"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.microsoft\\.VSCode",
+                                "^com\\.microsoft\\.VSCodeInsiders"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f5",
+                        "modifiers":{
+                            "optional": ["shift"]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "f5",
+                            "modifiers": [
+                                "fn"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.microsoft\\.VSCode",
+                                "^com\\.microsoft\\.VSCodeInsiders"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f6",
+                        "modifiers":{
+                            "optional": ["shift"]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "f6",
+                            "modifiers": [
+                                "fn"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.microsoft\\.VSCode",
+                                "^com\\.microsoft\\.VSCodeInsiders"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f7",
+                        "modifiers":{
+                            "optional": ["shift"]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "f7",
+                            "modifiers": [
+                                "fn"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.microsoft\\.VSCode",
+                                "^com\\.microsoft\\.VSCodeInsiders"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f8",
+                        "modifiers":{
+                            "optional": ["shift"]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "f8",
+                            "modifiers": [
+                                "fn"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.microsoft\\.VSCode",
+                                "^com\\.microsoft\\.VSCodeInsiders"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f9",
+                        "modifiers":{
+                            "optional": ["shift"]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "f9",
+                            "modifiers": [
+                                "fn"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.microsoft\\.VSCode",
+                                "^com\\.microsoft\\.VSCodeInsiders"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f10",
+                        "modifiers":{
+                            "optional": ["shift"]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "f10",
+                            "modifiers": [
+                                "fn"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.microsoft\\.VSCode",
+                                "^com\\.microsoft\\.VSCodeInsiders"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f11",
+                        "modifiers":{
+                            "optional": ["shift"]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "f11",
+                            "modifiers": [
+                                "fn"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.microsoft\\.VSCode",
+                                "^com\\.microsoft\\.VSCodeInsiders"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f12",
+                        "modifiers":{
+                            "optional": ["shift"]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "f12",
+                            "modifiers": [
+                                "fn"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
added a complex modification for fn keys to word as fn key is pressed in VSCode. shift+fn is also included. useful for debugging.