### PR TITLE
capslock as esc, without delay

### DIFF
--- a/public/json/capslock_as_esc.json
+++ b/public/json/capslock_as_esc.json
@@ -1,0 +1,25 @@
+{
+  "title": "CapsLock as ESC",
+  "rules": [
+    {
+      "description": "CapsLock as ESC, without delay",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "caps_lock",
+            "modifiers": {
+              "optional": ["any"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "escape",
+              "lazy": false
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
All other configuration seem to have a slight delay before recognizing capslock as esc. This is because these other configurations have special behavior when capslock is pressed together with some other key.

But if you use vim, then esc must be recognized instantly.