### PR TITLE
Recognize keyboard of M2 MacBooks in Neo2 rules

### DIFF
--- a/public/json/neo2.json
+++ b/public/json/neo2.json
@@ -169,8 +169,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -226,8 +228,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -289,8 +293,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -352,8 +358,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -407,8 +415,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -462,8 +472,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -517,8 +529,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -572,8 +586,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -627,8 +643,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -682,8 +700,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -737,8 +757,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -792,8 +814,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -847,8 +871,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -902,8 +928,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -957,8 +985,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -1012,8 +1042,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -1067,8 +1099,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -1122,8 +1156,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -1177,8 +1213,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -1232,8 +1270,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -1287,8 +1327,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -1342,8 +1384,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -1397,8 +1441,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -1452,8 +1498,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -1507,8 +1555,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -1562,8 +1612,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -1617,8 +1669,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -1672,8 +1726,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -1727,8 +1783,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -1782,8 +1840,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -1837,8 +1897,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -1892,8 +1954,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -1947,8 +2011,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -2002,8 +2068,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -2057,8 +2125,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -2112,8 +2182,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -2167,8 +2239,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -2222,8 +2296,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -2277,8 +2353,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -2332,8 +2410,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -2387,8 +2467,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -2442,8 +2524,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -2497,8 +2581,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -2555,8 +2641,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -2613,8 +2701,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -2670,8 +2760,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -2727,8 +2819,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -2784,8 +2878,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -2841,8 +2937,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -2898,8 +2996,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -2955,8 +3055,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -3012,8 +3114,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -3069,8 +3173,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -3126,8 +3232,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -3183,8 +3291,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -3240,8 +3350,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -3297,8 +3409,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -3354,8 +3468,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -3411,8 +3527,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -3468,8 +3586,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -3525,8 +3645,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -3582,8 +3704,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -3639,8 +3763,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -3696,8 +3822,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -3753,8 +3881,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -3810,8 +3940,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -3867,8 +3999,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -3929,8 +4063,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -3976,8 +4112,10 @@
               "type": "device_if",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -7516,8 +7654,10 @@
               "type": "device_unless",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -7573,8 +7713,10 @@
               "type": "device_unless",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -7636,8 +7778,10 @@
               "type": "device_unless",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }
@@ -7699,8 +7843,10 @@
               "type": "device_unless",
               "identifiers": [
                 {
-                  "vendor_id": 1452,
-                  "description": "Apple devices"
+                  "vendor_id": 1452
+                },
+                {
+                  "is_built_in_keyboard": true
                 }
               ]
             }

--- a/src/json/neo2.json.erb
+++ b/src/json/neo2.json.erb
@@ -11,11 +11,15 @@
             end
         end
 
+        $apple_identifiers = [
+          {"vendor_id" => 1452},
+          {"is_built_in_keyboard" => true},
+        ]
         $if_mod_4_on         = { "type" => "variable_unless", "name" => "neo2_mod_4", "value" => 0 }
         $if_mod_4_locked     = { "type" => "variable_if",     "name" => "neo2_mod_4", "value" => 2 }
         $if_mod_4_not_locked = { "type" => "variable_unless", "name" => "neo2_mod_4", "value" => 2 }
-        $is_apple_device     = { "type" => "device_if",       "identifiers" => [{"vendor_id" => 1452, "description" => "Apple devices"}]}
-        $is_not_apple_device = { "type" => "device_unless",   "identifiers" => [{"vendor_id" => 1452, "description" => "Apple devices"}]}
+        $is_apple_device     = { "type" => "device_if",       "identifiers" => $apple_identifiers }
+        $is_not_apple_device = { "type" => "device_unless",   "identifiers" => $apple_identifiers }
         $is_layout_active    = { "type" => "input_source_if", "input_sources" => [
           { "input_source_id" => "^org\\.sil\\.ukelele.keyboardlayout\\.neo.*$" }, # match any layout in the Ukelele Neo bundle
           { "input_source_id" => "^org\\.unknown\\.keylayout\\.DeutschNeo2$" },


### PR DESCRIPTION
The internal keyboard of M2 MacBooks does not seem to report a `vendor_id`. Assuming that Karabiner Elements is only used on Apple devices, the internal keyboard should also always be an Apple keyboard.

Also, remove the description condition, which I believe has no effect anyways? (And isn't listed as a possibility in the reference documentation for complex rules.)

Cp. pqrs-org/Karabiner-Elements#3139.