### PR TITLE
Add rule : make tilde (~), backtick (`) and circumflex accent (^) with one keystroke Mac FR keyboard.

### DIFF
--- a/public/json/one_keystroke_tilde_backtick_circumflex_mac_fr.json
+++ b/public/json/one_keystroke_tilde_backtick_circumflex_mac_fr.json
@@ -1,0 +1,77 @@
+{
+    "title": "Make tilde (~), backtick (`) and accent circumflex ^ work with one keystroke Mac FR AINSI.",
+    "rules": [
+      {
+        "description": "Tilde one keystroke.",
+        "manipulators": [
+          {
+            "type": "basic",
+            "from": {
+              "modifiers": {
+                "mandatory": [
+                  "left_alt"
+                ]
+              },
+              "key_code": "n"
+            },
+            "to": [
+              {
+                "repeat": false,
+                "key_code": "n",
+                "modifiers": [
+                  "left_alt"
+                ]
+              },
+              {
+                "repeat": false,
+                "key_code": "spacebar"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "description": "Backtick one keystroke.",
+        "manipulators": [
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "backslash"
+            },
+            "to": [
+              {
+                "repeat": false,
+                "key_code": "backslash"
+              },
+              {
+                "repeat": false,
+                "key_code": "spacebar"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "description": "Accent circumflex one keystroke.",
+        "manipulators": [
+          {
+            "type": "basic",
+            "from": {
+              "key_code": "open_bracket"
+            },
+            "to": [
+              {
+                "repeat": false,
+                "key_code": "open_bracket"
+              },
+              {
+                "repeat": false,
+                "key_code": "spacebar"
+              }
+            ]
+          }
+        ]
+      }
+  
+    ]
+  }

--- a/public/json/one_keystroke_tilde_backtick_circumflex_mac_fr.json
+++ b/public/json/one_keystroke_tilde_backtick_circumflex_mac_fr.json
@@ -1,5 +1,5 @@
 {
-    "title": "Make tilde (~), backtick (`) and accent circumflex ^ work with one keystroke Mac FR AINSI.",
+    "title": "Make tilde (~), backtick (`) and accent circumflex ^ work with one keystroke Mac FR.",
     "rules": [
       {
         "description": "Tilde one keystroke.",
@@ -24,7 +24,7 @@
               },
               {
                 "repeat": false,
-                "key_code": "spacebar"
+                "key_code": "right_arrow"
               }
             ]
           }
@@ -45,7 +45,7 @@
               },
               {
                 "repeat": false,
-                "key_code": "spacebar"
+                "key_code": "right_arrow"
               }
             ]
           }
@@ -66,7 +66,7 @@
               },
               {
                 "repeat": false,
-                "key_code": "spacebar"
+                "key_code": "right_arrow"
               }
             ]
           }


### PR DESCRIPTION
On mac with a French keyboard, you normally have to type `spacebar` or `right_arrow` to confirm the usage of `n`,`` ` ``and `^` keys.  
This is a personnal rule I made, hope it helps others !