### PR TITLE
Disable Neo complex modification in warp terminal

### DIFF
--- a/public/json/neo2.json
+++ b/public/json/neo2.json
@@ -14340,7 +14340,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -14393,7 +14394,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -14446,7 +14448,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -14499,7 +14502,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -14552,7 +14556,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -14610,7 +14615,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -14663,7 +14669,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -14716,7 +14723,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -14769,7 +14777,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -14822,7 +14831,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -14875,7 +14885,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -14928,7 +14939,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -14981,7 +14993,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -15034,7 +15047,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -15087,7 +15101,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -15140,7 +15155,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -15193,7 +15209,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -15246,7 +15263,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -15299,7 +15317,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -15352,7 +15371,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -15405,7 +15425,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -15458,7 +15479,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -15511,7 +15533,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -15564,7 +15587,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -15617,7 +15641,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -15670,7 +15695,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -15723,7 +15749,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -15776,7 +15803,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -15829,7 +15857,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -15882,7 +15911,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -15935,7 +15965,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -15988,7 +16019,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -16041,7 +16073,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -16094,7 +16127,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -16147,7 +16181,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -16200,7 +16235,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]
@@ -16253,7 +16289,8 @@
               "bundle_identifiers": [
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
-                "com.googlecode.iterm2"
+                "com.googlecode.iterm2",
+                "dev.warp.Warp-Stable"
               ]
             }
           ]

--- a/src/json/neo2.json.erb
+++ b/src/json/neo2.json.erb
@@ -30,7 +30,8 @@
         $is_not_excluded_app = { "type" => "frontmost_application_unless", "bundle_identifiers" => [
             "com.apple.Terminal",
             "org.gnu.Emacs",
-            "com.googlecode.iterm2"
+            "com.googlecode.iterm2",
+            "dev.warp.Warp-Stable"
         ]}
 
         def neo2_layer4(condition)


### PR DESCRIPTION
In the [Warp Terminal](https://www.warp.dev/) the complex modification "Prevent problematic keys from being treated as option key shortcuts" inserts extra spaces, when pressing e.g. "/".