### PR TITLE
Add Firefox Deveoper Edition to windows-on-mac shortcuts

### DIFF
--- a/public/json/pc_shortcuts.json
+++ b/public/json/pc_shortcuts.json
@@ -155,6 +155,7 @@
                 "^org\\.alacritty$",
                 "^net\\.kovidgoyal\\.kitty$",
                 "^org\\.mozilla\\.firefox$",
+                "^org\\.mozilla\\.firefoxdeveloperedition$",
                 "^org\\.mozilla\\.nightly$",
                 "^com\\.microsoft\\.Edge",
                 "^com\\.microsoft\\.edgemac",
@@ -194,6 +195,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^org\\.mozilla\\.firefoxdeveloperedition$",
                 "^org\\.mozilla\\.nightly$",
                 "^com\\.microsoft\\.Edge",
                 "^com\\.microsoft\\.edgemac",
@@ -326,6 +328,7 @@
                 "^org\\.alacritty$",
                 "^net\\.kovidgoyal\\.kitty$",
                 "^org\\.mozilla\\.firefox$",
+                "^org\\.mozilla\\.firefoxdeveloperedition$",
                 "^org\\.mozilla\\.nightly$",
                 "^com\\.microsoft\\.Edge",
                 "^com\\.microsoft\\.edgemac",
@@ -365,6 +368,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^org\\.mozilla\\.firefoxdeveloperedition$",
                 "^org\\.mozilla\\.nightly$",
                 "^com\\.microsoft\\.Edge",
                 "^com\\.microsoft\\.edgemac",
@@ -2746,6 +2750,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^org\\.mozilla\\.firefoxdeveloperedition$",
                 "^org\\.mozilla\\.nightly$",
                 "^com\\.microsoft\\.Edge",
                 "^com\\.microsoft\\.edgemac",
@@ -2787,6 +2792,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^org\\.mozilla\\.firefoxdeveloperedition$",
                 "^org\\.mozilla\\.nightly$",
                 "^com\\.microsoft\\.Edge",
                 "^com\\.microsoft\\.edgemac",
@@ -2823,6 +2829,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^org\\.mozilla\\.firefoxdeveloperedition$",
                 "^org\\.mozilla\\.nightly$",
                 "^com\\.microsoft\\.Edge",
                 "^com\\.microsoft\\.edgemac",
@@ -2864,6 +2871,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^org\\.mozilla\\.firefoxdeveloperedition$",
                 "^org\\.mozilla\\.nightly$",
                 "^com\\.microsoft\\.Edge",
                 "^com\\.microsoft\\.edgemac",
@@ -2900,6 +2908,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^org\\.mozilla\\.firefoxdeveloperedition$",
                 "^org\\.mozilla\\.nightly$",
                 "^com\\.microsoft\\.Edge",
                 "^com\\.microsoft\\.edgemac",
@@ -2936,6 +2945,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^org\\.mozilla\\.firefoxdeveloperedition$",
                 "^org\\.mozilla\\.nightly$",
                 "^com\\.microsoft\\.Edge",
                 "^com\\.microsoft\\.edgemac",
@@ -2972,6 +2982,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^org\\.mozilla\\.firefoxdeveloperedition$",
                 "^org\\.mozilla\\.nightly$",
                 "^com\\.microsoft\\.Edge",
                 "^com\\.microsoft\\.edgemac",
@@ -3008,6 +3019,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^org\\.mozilla\\.firefoxdeveloperedition$",
                 "^org\\.mozilla\\.nightly$",
                 "^com\\.microsoft\\.Edge",
                 "^com\\.microsoft\\.edgemac",
@@ -3044,6 +3056,7 @@
               "type": "frontmost_application_if",
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^org\\.mozilla\\.firefoxdeveloperedition$",
                 "^org\\.mozilla\\.nightly$",
                 "^com\\.microsoft\\.Edge",
                 "^com\\.microsoft\\.edgemac",

--- a/public/json/rk_windows-ified_custom_mappings.json
+++ b/public/json/rk_windows-ified_custom_mappings.json
@@ -1125,6 +1125,7 @@
             {
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^org\\.mozilla\\.firefoxdeveloperedition$",
                 "^org\\.mozilla\\.nightly$",
                 "^com\\.microsoft\\.Edge",
                 "^com\\.google\\.Chrome$",
@@ -1165,6 +1166,7 @@
             {
               "bundle_identifiers": [
                 "^org\\.mozilla\\.firefox$",
+                "^org\\.mozilla\\.firefoxdeveloperedition$",
                 "^org\\.mozilla\\.nightly$",
                 "^com\\.microsoft\\.edgemac$",
                 "^com\\.google\\.Chrome$",

--- a/public/json/windows_shortcuts_on_macos.json
+++ b/public/json/windows_shortcuts_on_macos.json
@@ -1114,6 +1114,7 @@
                         {
                             "bundle_identifiers": [
                                 "^org\\.mozilla\\.firefox$",
+                                "^org\\.mozilla\\.firefoxdeveloperedition$",
                                 "^org\\.mozilla\\.nightly$",
                                 "^com\\.microsoft\\.Edge",
                                 "^com\\.google\\.Chrome$",
@@ -1154,6 +1155,7 @@
                 {
                   "bundle_identifiers": [
                     "^org\\.mozilla\\.firefox$",
+                    "^org\\.mozilla\\.firefoxdeveloperedition$",
                     "^org\\.mozilla\\.nightly$",
                     "^com\\.microsoft\\.Edge",
                     "^com\\.google\\.Chrome$",


### PR DESCRIPTION
I noticed that for most of the public rules for use on browsers (such as Ctrl+L => Cmd+L) the bundle identifiers are missing `org.mozilla.firefoxdeveloperedition`. I'm sure many of the Karabiner Elements users are also using that app for and would appreciate it being included the relevant rules. Please feel free to add any that I missed, and I would really appreciate these rules being added for posterity! Thanks 😃 