### PR TITLE
Adding a new Citrix modifier to remove Fn key from functional keys

### DIFF
--- a/public/json/citrix_remove_fn.json
+++ b/public/json/citrix_remove_fn.json
@@ -1,0 +1,309 @@
+{
+    "title": "Citrix Receiver/Workspace remove Fn key from Functional (F*) keys",
+    "rules": [
+        {
+            "description": "Remove Fn from F* keys in Citrix",
+            "manipulators": [
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.citrix\\.XenAppViewer$",
+                                "^com\\.citrix\\.receiver\\.icaviewer\\.mac$"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f1"
+                    },
+                    "to": [
+                        {
+                            "key_code": "f1",
+                            "modifiers": [
+                                "fn"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.citrix\\.XenAppViewer$",
+                                "^com\\.citrix\\.receiver\\.icaviewer\\.mac$"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f1"
+                    },
+                    "to": [
+                        {
+                            "key_code": "f1",
+                            "modifiers": [
+                                "fn"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.citrix\\.XenAppViewer$",
+                                "^com\\.citrix\\.receiver\\.icaviewer\\.mac$"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f2"
+                    },
+                    "to": [
+                        {
+                            "key_code": "f2",
+                            "modifiers": [
+                                "fn"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.citrix\\.XenAppViewer$",
+                                "^com\\.citrix\\.receiver\\.icaviewer\\.mac$"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f3"
+                    },
+                    "to": [
+                        {
+                            "key_code": "f3",
+                            "modifiers": [
+                                "fn"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.citrix\\.XenAppViewer$",
+                                "^com\\.citrix\\.receiver\\.icaviewer\\.mac$"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f4"
+                    },
+                    "to": [
+                        {
+                            "key_code": "f4",
+                            "modifiers": [
+                                "fn"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.citrix\\.XenAppViewer$",
+                                "^com\\.citrix\\.receiver\\.icaviewer\\.mac$"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f5"
+                    },
+                    "to": [
+                        {
+                            "key_code": "f5",
+                            "modifiers": [
+                                "fn"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.citrix\\.XenAppViewer$",
+                                "^com\\.citrix\\.receiver\\.icaviewer\\.mac$"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f6"
+                    },
+                    "to": [
+                        {
+                            "key_code": "f6",
+                            "modifiers": [
+                                "fn"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.citrix\\.XenAppViewer$",
+                                "^com\\.citrix\\.receiver\\.icaviewer\\.mac$"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f7"
+                    },
+                    "to": [
+                        {
+                            "key_code": "f7",
+                            "modifiers": [
+                                "fn"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.citrix\\.XenAppViewer$",
+                                "^com\\.citrix\\.receiver\\.icaviewer\\.mac$"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f8"
+                    },
+                    "to": [
+                        {
+                            "key_code": "f8",
+                            "modifiers": [
+                                "fn"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.citrix\\.XenAppViewer$",
+                                "^com\\.citrix\\.receiver\\.icaviewer\\.mac$"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f9"
+                    },
+                    "to": [
+                        {
+                            "key_code": "f9",
+                            "modifiers": [
+                                "fn"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.citrix\\.XenAppViewer$",
+                                "^com\\.citrix\\.receiver\\.icaviewer\\.mac$"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f10"
+                    },
+                    "to": [
+                        {
+                            "key_code": "f10",
+                            "modifiers": [
+                                "fn"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.citrix\\.XenAppViewer$",
+                                "^com\\.citrix\\.receiver\\.icaviewer\\.mac$"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f11"
+                    },
+                    "to": [
+                        {
+                            "key_code": "f11",
+                            "modifiers": [
+                                "fn"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.citrix\\.XenAppViewer$",
+                                "^com\\.citrix\\.receiver\\.icaviewer\\.mac$"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f12"
+                    },
+                    "to": [
+                        {
+                            "key_code": "f12",
+                            "modifiers": [
+                                "fn"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
When using Citrix with Windows machine, I often need to use F* keys. I would like to be able to use windows keys the same way while in Citrix without changing system settings