### PR TITLE
Treat Dictation as F5

### DIFF
--- a/public/json/never_dictattion.json
+++ b/public/json/never_dictattion.json
@@ -1,0 +1,26 @@
+{
+  "title": "Treat Dictation as F5",
+  "rules": [
+    {
+      "description": "Always treat the dictation media key as if it was just F5. Helps to totally disable the dictation popup for keyboards that don't handle the function keys correctly.",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "consumer_key_code": "dictation",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f5"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
My external keyboard sends `consumer_key_code` set to `dictation` when hitting the F5 key even when the "Use F1, F2, etc. keys as standard function keys" is set to true. This is a rule that converts that to `F5` since I never use dictation and I'm sick of having to hold the `fn` button while using debuggers.