### PR TITLE
feat: Add LAlt option for open_terminal_window

### DIFF
--- a/public/json/open_terminal_window.json
+++ b/public/json/open_terminal_window.json
@@ -1,5 +1,5 @@
 {
-  "title": "Open a Terminal window with Ctrl-RAlt-T",
+  "title": "Open a Terminal window with Ctrl-Alt-T",
   "rules": [
     {
         "description": "Open a terminal window with Ctrl-RAlt-T",
@@ -25,7 +25,31 @@
                 "type": "basic"
             }
         ]
+    },
+    {
+        "description": "Open a terminal window with Ctrl-LAlt-T",
+        "manipulators": [
+            {
+                "from": {
+                    "key_code": "t",
+                    "modifiers": {
+                        "mandatory": [
+                            "left_control",
+                            "left_option"
+                        ],
+                        "optional": [
+                            "caps_lock"
+                        ]
+                    }
+                },
+                "to": [
+                    {
+                        "shell_command": "open -a Terminal ~"
+                    }
+                ],
+                "type": "basic"
+            }
+        ]
     }
   ]
 }
-


### PR DESCRIPTION
Extend `open_terminal_window` to have a shortcut for opening with the terminal with left Alt (like Ubuntu and some other Linux distros)