### PR TITLE
fixed ctrl_arrows_to_option_arrows so option+arrow acts like ctrl+arrow

### DIFF
--- a/public/json/ctrl_arrows_to_option_arrows.json
+++ b/public/json/ctrl_arrows_to_option_arrows.json
@@ -98,7 +98,7 @@
             "key_code": "right_arrow",
             "modifiers": {
               "mandatory": [
-                "control"
+                "option"
               ],
               "optional": [
                 "any"
@@ -109,7 +109,7 @@
             {
               "key_code": "right_arrow",
               "modifiers": [
-                "command"
+                "control"
               ]
             }
           ]
@@ -120,7 +120,7 @@
             "key_code": "left_arrow",
             "modifiers": {
               "mandatory": [
-                "control"
+                "option"
               ],
               "optional": [
                 "any"
@@ -131,7 +131,7 @@
             {
               "key_code": "left_arrow",
               "modifiers": [
-                "command"
+                "control"
               ]
             }
           ]
@@ -142,7 +142,7 @@
             "key_code": "up_arrow",
             "modifiers": {
               "mandatory": [
-                "control"
+                "option"
               ],
               "optional": [
                 "any"
@@ -153,7 +153,7 @@
             {
               "key_code": "up_arrow",
               "modifiers": [
-                "command"
+                "control"
               ]
             }
           ]
@@ -164,7 +164,7 @@
             "key_code": "down_arrow",
             "modifiers": {
               "mandatory": [
-                "control"
+                "option"
               ],
               "optional": [
                 "any"
@@ -175,7 +175,7 @@
             {
               "key_code": "down_arrow",
               "modifiers": [
-                "command"
+                "control"
               ]
             }
           ]

--- a/src/json/ctrl_arrows_to_option_arrows.json.erb
+++ b/src/json/ctrl_arrows_to_option_arrows.json.erb
@@ -26,23 +26,23 @@
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("right_arrow", ["control"], ["any"]) %>,
-                    "to": <%= to([["right_arrow", ["command"]]]) %>
+                    "from": <%= from("right_arrow", ["option"], ["any"]) %>,
+                    "to": <%= to([["right_arrow", ["control"]]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("left_arrow", ["control"], ["any"]) %>,
-                    "to": <%= to([["left_arrow", ["command"]]]) %>
+                    "from": <%= from("left_arrow", ["option"], ["any"]) %>,
+                    "to": <%= to([["left_arrow", ["control"]]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("up_arrow", ["control"], ["any"]) %>,
-                    "to": <%= to([["up_arrow", ["command"]]]) %>
+                    "from": <%= from("up_arrow", ["option"], ["any"]) %>,
+                    "to": <%= to([["up_arrow", ["control"]]]) %>
                 },
                 {
                     "type": "basic",
-                    "from": <%= from("down_arrow", ["control"], ["any"]) %>,
-                    "to": <%= to([["down_arrow", ["command"]]]) %>
+                    "from": <%= from("down_arrow", ["option"], ["any"]) %>,
+                    "to": <%= to([["down_arrow", ["control"]]]) %>
                 }
             ]
         }


### PR DESCRIPTION
For some reason the rule was remapping ctrl+arrow twice instead of properly swapping.