### PR TITLE
Added Pause to CMD+§ for Win-keyboard

### DIFF
--- a/public/json/dk_pause_to_cmd-non_us_backslash.json
+++ b/public/json/dk_pause_to_cmd-non_us_backslash.json
@@ -1,0 +1,27 @@
+{
+    "title": "DK: Switch Pause key of Win keyboard to CMD+§ (CMD+non_us_backslash), that can be used as Punto Switcher App hotkey.",
+    "rules": [
+        {
+            "description": "DK: Pause -> CMD+§",
+            "manipulators": [
+                {
+                    "from": {
+                        "key_code": "pause",
+                        "modifiers": {
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "non_us_backslash",
+                            "modifiers": "command"
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Remap Pause key of Win-keyboard to CMD+§ that can be used as Punto Switcher App hotkey on MacOs