### PR TITLE
Add F4 to show desktop

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -1149,6 +1149,9 @@
       "id": "os-functionality",
       "files": [
         {
+          "path": "json/F4-desktop.json"
+        }
+        {
           "path": "json/search_in_dict.json"
         },
         {

--- a/public/json/F4-desktop.json
+++ b/public/json/F4-desktop.json
@@ -1,0 +1,21 @@
+{
+  "title": "Show Desktop with F4",
+  "rules": [
+    {
+      "description": "Show Desktop with F4",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "f4"
+          },
+          "to": [
+            {
+              "shell_command": "/'System/Applications/Mission Control.app/Contents/MacOS/Mission Control' 1"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
{
  "title": "Show Desktop with F4",
  "rules": [
    {
      "description": "Show Desktop with F4",
      "manipulators": [
        {
          "type": "basic",
          "from": {
            "key_code": "f4"
          },
          "to": [
            {
              "shell_command": "/'System/Applications/Mission Control.app/Contents/MacOS/Mission Control' 1"
            }
          ]
        }
      ]
    }
  ]
}
