### PR TITLE
Fix German Keyboard Dead Keys: Backtick, Tilde, Circumflex

### DIFF
--- a/public/json/samuelraub_fix_german_keyboard.json
+++ b/public/json/samuelraub_fix_german_keyboard.json
@@ -1,0 +1,78 @@
+{
+  "title": "Fix German Keyboard Dead Keys: Backtick, Tilde, Circumflex",
+  "rules": [
+    {
+      "description": "Fix Backtick",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "equal_sign",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "equal_sign",
+              "modifiers": [
+                "left_shift"
+              ]
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Fix Tilde",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "n",
+            "modifiers": {
+              "mandatory": [
+                "left_option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "n",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Fix Circumflex",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "non_us_backslash"
+          },
+          "to": [
+            {
+              "key_code": "non_us_backslash"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This allows to type Backtick (`), Tilde (~) and Circumflex (^) in one keystroke on german keyboards.