### PR TITLE
Create rule "Backslash to forward delete"

### DIFF
--- a/public/json/backslash-to-forward-delete.json
+++ b/public/json/backslash-to-forward-delete.json
@@ -1,0 +1,69 @@
+{
+  "title": "Backslash (\\) to forward delete. (Use Fn + \\ for default behavior)",
+  "rules": [
+    {
+      "description": "Change Backslash (\\) to forward delete",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "backslash"
+          },
+          "to": [
+            {
+              "key_code": "delete_forward"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change option + \\ to delete next word",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            },
+            "key_code": "backslash"
+          },
+          "to": [
+            {
+              "key_code": "delete_forward",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change command + \\ to delete forward whole line",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            },
+            "key_code": "backslash"
+          },
+          "to": [
+            {
+              "key_code": "delete_forward",
+              "modifiers": [
+                "command"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Use Backslash (\\) to forward delete.
Use option + Backslash (\\) to delete forward a word
Use command + Backslash (\\) to delete forward a whole line

Use Fn + Backslash (\\) for it's default behavior