### PR TITLE
Created Smart Quote remapping for Mac

### DIFF
--- a/public/extra_descriptions/intuitive_smartquotes_mac.html
+++ b/public/extra_descriptions/intuitive_smartquotes_mac.html
@@ -1,0 +1,15 @@
+<link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
+
+<br />
+<h3>Intuitive Smart Quotes Mapping for Mac</h3>
+
+<p>Remaps smart quotes to more logical settings for Mac.  Opening and closing
+quotes now map to opening and closing brackets, and the shift modifier switches from single to double quotes.</p>
+
+<ul>
+<li>Left single quote (&lsquo;): <kbd>option</kbd>+<kbd>[</kbd>
+<li>Right single quote (&rsquo;): <kbd>option</kbd>+<kbd>]</kbd>
+<li>Left double quote (&ldquo;): <kbd>option</kbd>+<kbd>shift</kbd>+<kbd>[</kbd>
+<li>Right double quote (&rdquo;): <kbd>option</kbd>+<kbd>shift</kbd>+<kbd>]</kbd>
+</ul>
+

--- a/public/groups.json
+++ b/public/groups.json
@@ -1172,6 +1172,10 @@
         },
         {
           "path": "json/pc-insert-to-screencapture-via-clipboard.json"
+        },
+        {
+        	"path": "json/intuitive_smartquotes_mac.json",
+			"extra_description_path": "extra_descriptions/intuitive_smartquotes_mac.html"
         }
       ]
     },

--- a/public/json/intuitive_smartquotes_mac.json
+++ b/public/json/intuitive_smartquotes_mac.json
@@ -1,0 +1,105 @@
+{
+  "title": "Intuitive smart quote mapping for Mac",
+  "rules": [
+    {
+      "description": "Remap left single quote from option-] to option-[",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "open_bracket",
+			"modifiers": {
+              "mandatory": [
+                "left_option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "close_bracket",
+              "modifiers": [
+                "left_option"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Remap right single quote from option-} to option-]",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "close_bracket",
+			"modifiers": {
+              "mandatory": [
+                "left_option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "close_bracket",
+              "modifiers": [
+                "left_option",
+                "shift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Remap left double quote from option-[ to option-{",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "open_bracket",
+			"modifiers": {
+              "mandatory": [
+                "left_option",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "open_bracket",
+              "modifiers": [
+                "left_option"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Remap right double quote from option-{ to option-}",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "close_bracket",
+			"modifiers": {
+              "mandatory": [
+                "left_option",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "open_bracket",
+              "modifiers": [
+                "left_option",
+                "shift"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This is a complex modification to remap the shortcuts for smart quotes (‘’ and “”) to more logical bindings in macOS.  