### PR TITLE
Add: Language Switch Rule for EN/JP/KR using Print Screen, Scroll Lock, and Application keys

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -888,6 +888,9 @@
         },
         {
           "path": "json/iso_pt-pt_keyboard.json"
+        },
+        {
+          "path": "json/print_screen-EN-scroll_lock-JP-pause-KR.json"
         }
       ]
     },

--- a/public/json/print_screen-EN-scroll_lock-JP-pause-KR.json
+++ b/public/json/print_screen-EN-scroll_lock-JP-pause-KR.json
@@ -1,0 +1,64 @@
+{
+  "title": "Switch EN/JP/KR with print_screen, scroll_lock, and application",
+  "rules": [
+    {
+      "description": "print_screen to English, scroll_lock to Japanese, application to Korean",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "print_screen",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "select_input_source": {
+                "language": "en"
+              }
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "scroll_lock",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "select_input_source": {
+                "language": "ja"
+              }
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "pause",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "select_input_source": {
+                "language": "ko"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
this is modification from left_cmd-EN-right_cmd-CH-right_option-JA.json

thanx