### PR TITLE
Add eisuufn.json

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -873,6 +873,9 @@
           "path": "json/russian-keyboard-remapping.json"
         },
         {
+          "path": "json/eisuufn.json"
+        },
+        {
           "path": "json/kanafn.json"
         },
         {

--- a/public/json/eisuufn.json
+++ b/public/json/eisuufn.json
@@ -1,0 +1,54 @@
+{
+  "title": "EisuuFN",
+  "rules": [
+    {
+      "description": "EisuuFN: japanese_eisuu to fn unlesss alone",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "japanese_eisuu",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "fn",
+              "lazy": true
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "japanese_eisuu"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "japanese_pc_nfer",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "fn",
+              "lazy": true
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "japanese_eisuu"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
EisuuFN is similar to SpaceFN and KanaFN, but more comfortable for Japanese keyboard users; the Eisuu key is in a thumb-friendly position on Japanese keyboards, and this setting also allows the FN key to be placed on the left side.