### PR TITLE
Update windows_shortcuts_on_macos.json

### DIFF
--- a/public/json/windows_shortcuts_on_macos.json
+++ b/public/json/windows_shortcuts_on_macos.json
@@ -306,10 +306,9 @@
                     },
                     "to": [
                         {
-                            "key_code": "z",
+                            "key_code": "y",
                             "modifiers": [
-                                "left_command",
-                                "left_shift"
+                                "left_command"
                             ]
                         }
                     ],


### PR DESCRIPTION
Fixed incorrect setting for command Ctrl+Y => Cmd+Shift+Y (Redo):
- Changed z to y.
- Left shift modifier removed.