### PR TITLE
Add Powerpoint-specific modifiers

### DIFF
--- a/public/extra_descriptions/powerpoint.json.html
+++ b/public/extra_descriptions/powerpoint.json.html
@@ -1,0 +1,15 @@
+<link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
+
+<p style="margin-top: 20px; font-weight: bold">
+  Description
+</p>
+<p>
+  While <button>CTRL + a</button> already works as "go to the beginning of the line"
+  in PowerPoint by default, Microsoft decided that <button>CTRL + e</button> will be
+  used to change text alignment of the current line to "center", which is unhelpful.
+</p>
+<p>
+  With this complex mod, <button>CTRL + e</button> will now "go to the end of the line".
+  That means both key combinations serve their Emacs-inspired purpose, balance is
+  restored, and all's good with the world.
+</p>

--- a/public/groups.json
+++ b/public/groups.json
@@ -666,6 +666,10 @@
         {
           "path": "json/ncspot.json",
           "extra_description_path": "extra_descriptions/ncspot.json.html"
+        },
+        {
+          "path": "json/powerpoint.json",
+          "extra_description_path": "extra_descriptions/powerpoint.json.html"
         }
       ]
     },

--- a/public/json/powerpoint.json
+++ b/public/json/powerpoint.json
@@ -1,0 +1,1 @@
+{"title":"Improved PowerPoint Keyboard Shortcuts","rules":[{"description":"(CTRL + e) is (⌘ + Right Arrow)","manipulators":[{"type":"basic","from":{"key_code":"e","modifiers":{"mandatory":["control"]}},"to":[{"key_code":"right_arrow","modifiers":["left_command"]}],"conditions":[{"type":"frontmost_application_if","bundle_identifiers":["^com\\.microsoft\\.Powerpoint$"]}]}]}]}

--- a/src/json/powerpoint.json.js
+++ b/src/json/powerpoint.json.js
@@ -1,0 +1,43 @@
+// JavaScript should be written in ECMAScript 5.1.
+
+const karabiner = require('../lib/karabiner')
+
+function main() {
+  console.log(
+    JSON.stringify(
+      {
+        "title": "Improved PowerPoint Keyboard Shortcuts",
+        "rules": [
+          {
+            "description": "(CTRL + e) is (⌘ + Right Arrow)",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "e",
+                  "modifiers": {
+                    "mandatory": ["control"]
+                  }
+                },
+                "to": [
+                  {
+                    "key_code": "right_arrow",
+                    "modifiers": ["left_command"]
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_if",
+                    "bundle_identifiers": karabiner.bundleIdentifiers.microsoftPowerpoint,
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    )
+  )
+}
+
+main()

--- a/src/lib/karabiner.js
+++ b/src/lib/karabiner.js
@@ -52,12 +52,11 @@ const rawBundleIdentifers = {
 
   loginwindow: ['^com\\.apple\\.loginwindow$'],
 
-  microsoftOffice: [
-    // --- Comment to prevent line combination by Prettier ---
-    '^com\\.microsoft\\.Excel$',
-    '^com\\.microsoft\\.Powerpoint$',
-    '^com\\.microsoft\\.Word$',
-  ],
+  microsoftExcel: ['^com\\.microsoft\\.Excel$'],
+
+  microsoftPowerpoint: ['^com\\.microsoft\\.Powerpoint$'],
+
+  microsoftWord: ['^com\\.microsoft\\.Word$'],
 
   remoteDesktop: [
     // com.microsoft.rdc
@@ -162,7 +161,14 @@ exports.bundleIdentifiers = {
   gitGUI: rawBundleIdentifers.gitGUI,
   jetbrainsIDE: rawBundleIdentifers.jetbrainsIDE,
   loginwindow: rawBundleIdentifers.loginwindow,
-  microsoftOffice: rawBundleIdentifers.microsoftOffice,
+  microsoftOffice: [].concat(
+    rawBundleIdentifers.microsoftExcel,
+    rawBundleIdentifers.microsoftPowerpoint,
+    rawBundleIdentifers.microsoftWord
+  ),
+  microsoftExcel: rawBundleIdentifers.microsoftExcel,
+  microsoftPowerpoint: rawBundleIdentifers.microsoftPowerpoint,
+  microsoftExcel: rawBundleIdentifers.microsoftWord,
   remoteDesktop: rawBundleIdentifers.remoteDesktop,
   terminal: rawBundleIdentifers.terminal,
   vi: rawBundleIdentifers.vi,


### PR DESCRIPTION
At the moment there's only `CTRL + e` means `Command + Right Arrow`, which makes it behave like the Emacs shortcut. `CTRL + a` already works as expected in PowerPoint.