### PR TITLE
Add korean_swap_won_and_backtick.json

### DIFF
--- a/public/json/korean_swap_won_and_backtick.json
+++ b/public/json/korean_swap_won_and_backtick.json
@@ -1,0 +1,66 @@
+{
+    "title": "Swap Won (₩) and backtick (`) in Korean layout.",
+    "rules": [
+      {
+        "description": "Change Won (₩) to backtick (`).",
+        "manipulators": [
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "language": "ko"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "grave_accent_and_tilde"
+            },
+            "to": [
+              {
+                "key_code": "grave_accent_and_tilde",
+                "modifiers": [
+                  "left_option",
+                  "right_option"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "description": "Change backtick (`) to Won (₩).",
+        "manipulators": [
+          {
+            "conditions": [
+              {
+                "type": "input_source_if",
+                "input_sources": [
+                  {
+                    "language": "ko"
+                  }
+                ]
+              }
+            ],
+            "type": "basic",
+            "from": {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": {
+                "mandatory": [
+                    "option"
+                ]
+              }
+            },
+            "to_if_alone": [
+              {
+                "key_code": "grave_accent_and_tilde"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }


### PR DESCRIPTION
There was similar rule: "Change Won (₩) to grave accent (`) in Korean layout" but there was no way to 'swap' between them. I wanted to type "₩" with option key down.

I made typing <\`> to be <left_option + right_option + \`>, and <option + \`> to be <\`> so that both works well even though applied simultaneously.