### PR TITLE
add a config for VSCode/Cursor & 1Password

### DIFF
--- a/public/json/1password_vscode_and_cursor_split_pane_compat.json
+++ b/public/json/1password_vscode_and_cursor_split_pane_compat.json
@@ -1,0 +1,41 @@
+{
+  "title": "VSCode, Cursor, & 1Password Compat",
+  "rules": [
+    {
+      "description": "Change cmd+backslach to cmd+f11 if pressed in VSCode or Cursor",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "com\\.microsoft\\.VSCode",
+                "com\\.microsoft\\.VSCodeInsiders"
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "backslash",
+            "modifiers": { "optional": ["any"], "mandatory": ["left_gui"] }
+          },
+          "to": [{ "key_code": "f11", "modifiers": ["left_gui"] }],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "file_paths": ["/Cursor.app$", "/Cursor$"]
+            }
+          ],
+          "from": {
+            "key_code": "backslash",
+            "modifiers": { "optional": ["any"], "mandatory": ["left_gui"] }
+          },
+          "to": [{ "key_code": "f11", "modifiers": ["left_gui"] }],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This config makes the `cmd + \` key command redirect to `cmd + F11` whenever VSCode or Cursor are the frontmost applications. 

There's already a similar community rule for _just_ VSCode, but I've started using Cursor and want the same thing.
