### PR TITLE
Mimic PC Keyboard Shift+Insert with Shift+Delete on Mac

### DIFF
--- a/public/extra_descriptions/general-shift-delete-for-insert.html
+++ b/public/extra_descriptions/general-shift-delete-for-insert.html
@@ -1,0 +1,15 @@
+<link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
+
+<ul>
+
+  <li>Mac users lack the Insert key on their keyboard and more specifically
+  they lack the  ability to perform Shift+Insert to paste contents of their
+  copy buffer. Fortunately, Mac users are able to replicate this very same
+  behavior with the key combination: Shift+Delete. Sounds counter intuitive,
+  but the Delete key on Mac keyboards is the closes to where an Insert key
+  would be on a PC keyboard, allowing this short-cut to to have a natural and
+  seamless feel. Additionally, there are likely no other key-bindings to be
+  clobbered using Shift+Delete for inserting the contents of your copy
+  buffer.</li>
+
+</ul>

--- a/public/groups.json
+++ b/public/groups.json
@@ -1109,6 +1109,10 @@
           "path": "json/shift-delete-to-delete-forward.json"
         },
         {
+          "path": "json/general-shift-delete-for-insert.json",
+          "extra_description_path": "extra_descriptions/general-shift-delete-for-insert.html"
+        },
+        {
           "path": "json/sinoridha_personal_mapping.json"
         },
         {

--- a/public/json/general-shift-delete-for-insert.json
+++ b/public/json/general-shift-delete-for-insert.json
@@ -1,0 +1,29 @@
+{
+  "title": "General - Shift + Delete to Insert Copy Buffer",
+  "rules": [
+    {
+      "description": "General - Shift + Delete to Insert Copy Buffer",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "delete_or_backspace",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "v",
+              "modifiers": [
+                "command"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
New keybindings to Mimic PC Keyboard Shift+Insert with Shift+Delete on Mac.