### PR TITLE
remap: modify button2 to run after key up

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -1379,6 +1379,9 @@
         },
         {
           "path": "json/om_application_launcher.json"
+        },
+        {
+          "path": "json/fix-ghost-select-in-context-menu.json"
         }
       ]
     },

--- a/public/json/fix-ghost-select-in-context-menu.json
+++ b/public/json/fix-ghost-select-in-context-menu.json
@@ -1,0 +1,29 @@
+{
+  "title": "Fix ghost select in context menu",
+  "rules": [
+    {
+      "description": "Fix ghost select in context menu",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "bundle_identifiers": [
+                "^cc\\.ffitch\\.shottr$"
+              ],
+              "type": "frontmost_application_unless"
+            }
+          ],
+          "from": {
+            "pointing_button": "button2"
+          },
+          "to_after_key_up": [
+            {
+              "pointing_button": "button2"
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
 This fixes ghost select in context menu. When you are holding right click button and move mouse in the context menu, then release the button, it will click the selected item. It could be annoying if someone right click, move the cursor right and release the button quickly. It will do the unexpected select and click.