### PR TITLE
Mouse3(button) as Command+Tab for Application Switcher

### DIFF
--- a/public/extra_descriptions/mouse3_app_switcher.json.html
+++ b/public/extra_descriptions/mouse3_app_switcher.json.html
@@ -1,0 +1,31 @@
+<!-- <link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" /> -->
+
+<h4>Quick Application Switcher with Mouse Button 3</h4>
+
+<p>Use Mouse Button 3(middle mouse button) to "Command-Tab" Switch
+  Applications</p>
+
+<h5>Motivation</h5>
+
+<p>
+    Occasionally it could be more convenient to rapidly switch
+    between two apps with a simple click of the mouse button.
+    This also allows such convenience as selection with the mouse while
+    using common keyboard shortcuts (e.g. cut/copy/paste)
+
+    (creator's side note: This was also spurred by a sense of
+    repetitive use issues of using the Command+Tab key combination
+    frequently)
+</p>
+
+<h5>How to use</h5>
+
+<p>
+    Use karabiner-elements to map the Mouse 3 (single click,
+    does not repeat) to "Command-Tab" equivalent.
+    Install this extension under tab 'Complex modifications'.
+</p>
+
+<p>
+    Will only switch back and forth between two most recent Applications
+</p>

--- a/public/groups.json
+++ b/public/groups.json
@@ -1347,6 +1347,10 @@
           "path": "json/mouse_345_mac_desktop_switcher.json"
         },
         {
+          "path": "json/mouse3_app_switcher.json",
+          "extra_description_path": "extra_descriptions/mouse3_app_switcher.json.html"
+        },
+        {
           "path": "json/r_cmd_to_l_ctrl_and_space.json",
           "extra_description_path": "extra_descriptions/r_cmd_to_l_ctrl_and_space.json.html"
         },

--- a/public/json/mouse3_app_switcher.json
+++ b/public/json/mouse3_app_switcher.json
@@ -1,0 +1,25 @@
+{
+  "title": "Mac Mouse 3 Application switcher",
+  "rules": [
+    {
+      "description": "Mouse 3 App Switcher",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "pointing_button": "button3"
+          },
+          "to": [
+            {
+              "repeat": false,
+              "key_code": "tab",
+              "modifiers": [
+                "right_gui"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Will cause mouse3 to Application Switch (Command-Tab) in macOS, quickly switch between two most recently used Open applications