### PR TITLE
Fix the bundleIdentifier of Microsoft Word

### DIFF
--- a/src/lib/karabiner.js
+++ b/src/lib/karabiner.js
@@ -168,7 +168,7 @@ exports.bundleIdentifiers = {
   ),
   microsoftExcel: rawBundleIdentifers.microsoftExcel,
   microsoftPowerpoint: rawBundleIdentifers.microsoftPowerpoint,
-  microsoftExcel: rawBundleIdentifers.microsoftWord,
+  microsoftWord: rawBundleIdentifers.microsoftWord,
   remoteDesktop: rawBundleIdentifers.remoteDesktop,
   terminal: rawBundleIdentifers.terminal,
   vi: rawBundleIdentifers.vi,


### PR DESCRIPTION
The identifier of Microsoft Word is incorrectly defined as ``microsoftExcel``.