### PR TITLE
Add configs for keyboard with trackball such as Adesso WKB-3150UB

### DIFF
--- a/public/json/emulate_mouse_clicking_and_scrolling.json
+++ b/public/json/emulate_mouse_clicking_and_scrolling.json
@@ -1,0 +1,150 @@
+{
+    "title": "Emulate mouse clicking and scrolling",
+    "rules": [
+        {
+            "description": "left-command + j to left-click",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "j",
+                        "modifiers": {
+                            "mandatory": [
+                                "left_command"
+                            ],
+                            "optional": []
+                        }
+                    },
+                    "to": [
+                        {
+                            "pointing_button": "button1"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "left-command + k to right-click",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "k",
+                        "modifiers": {
+                            "mandatory": [
+                                "left_command"
+                            ],
+                            "optional": []
+                        }
+                    },
+                    "to": [
+                        {
+                            "pointing_button": "button2"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "left-command + left-shift + j to scroll-down",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "j",
+                        "modifiers": {
+                            "mandatory": [
+                                "left_command","left_shift"
+                            ],
+                            "optional": []
+                        }
+                    },
+                    "to": [
+                        {
+                            "mouse_key": {
+                                "vertical_wheel": 64
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "left-command + left-shift + k to scroll-up",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "k",
+                        "modifiers": {
+                            "mandatory": [
+                                "left_command","left_shift"
+                            ],
+                            "optional": []
+                        }
+                    },
+                    "to": [
+                        {
+                            "mouse_key": {
+                                "vertical_wheel": -64
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "left-command + left-control + j to command + left-click",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "j",
+                        "modifiers": {
+                            "mandatory": [
+                                "left_command",
+                                "left_control"
+                            ],
+                            "optional": []
+                        }
+                    },
+                    "to": [
+                        {
+                            "pointing_button": "button1",
+                            "modifiers": [
+                                "command"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "left-command + left-control + left-shift + j to shift + left-click",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "j",
+                        "modifiers": {
+                            "mandatory": [
+                                "left_command",
+                                "left_control",
+                                "left_shift"
+                            ],
+                            "optional": []
+                        }
+                    },
+                    "to": [
+                        {
+                            "pointing_button": "button1",
+                            "modifiers": [
+                                "shift"
+                            ]
+                        }
+                    ]
+                }
+            ]
+       }
+    ]
+}

--- a/public/json/shortcut_delete_and_enter.json
+++ b/public/json/shortcut_delete_and_enter.json
@@ -1,0 +1,72 @@
+{
+    "title": "Shortcut Delete and Enter",
+    "rules": [
+        {
+            "description": "left-command + semicolon to delete_or_backspace",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": {
+                        "modifiers": {
+                            "mandatory": [
+                                "left_command"
+                            ],
+                            "optional": []
+                        },
+                        "key_code": "semicolon"
+                    },
+                    "to": [
+                        {
+                            "key_code": "delete_or_backspace"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "left-command + shift + semicolon to delete_forward",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": {
+                        "modifiers": {
+                            "mandatory": [
+                                "left_command",
+                                "left_shift"
+                            ],
+                            "optional": []
+                        },
+                        "key_code": "semicolon"
+                    },
+                    "to": [
+                        {
+                            "key_code": "delete_forward"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "left-command + quote to enter",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": {
+                        "modifiers": {
+                            "mandatory": [
+                                "left_command"
+                            ],
+                            "optional": []
+                        },
+                        "key_code": "quote"
+                    },
+                    "to": [
+                        {
+                            "key_code": "return_or_enter"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
public/json/emulate_mouse_clicking_and_scrolling.json: emulate mouse clicking and scrolling so that the right-hand thumb can stay on the trackball

public/json/shortcut_delete_and_enter.json: shortcut Delete Back/Forward and Enter so that the far keys do not need