### PR TITLE
add modifier keys with ijkl to arrow keys

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -5,13 +5,13 @@
       "id": "modifier-keys",
       "files": [
         {
-            "path": "json/cmd+fn+delete_forward_delete_line.json"
+          "path": "json/cmd+fn+delete_forward_delete_line.json"
         },
         {
-            "path": "json/caps_lock_doubleSidedRemap.json"
+          "path": "json/caps_lock_doubleSidedRemap.json"
         },
         {
-            "path": "json/lily58_default_arrows.json"
+          "path": "json/lily58_default_arrows.json"
         },
         {
           "path": "json/caps_lock_twice.json"
@@ -210,6 +210,9 @@
         {
           "path": "json/ru_keyboard_remapping_small_yu-on-close_bracket.json",
           "extra_description_path": "extra_descriptions/ru_keyboard_remapping_small_yu-on-close_bracket.json.html"
+        },
+        {
+          "path": "json/combine_two_modifier_keys_with_ijkl_to_arrow_keys.json"
         }
       ]
     },
@@ -1281,9 +1284,9 @@
         {
           "path": "json/fine_volume_control.json"
         },
-	{
-   	  "path": "json/fine_brightness_control.json"
-	},
+        {
+          "path": "json/fine_brightness_control.json"
+        },
         {
           "path": "json/command_q.json"
         },

--- a/public/json/combine_two_modifier_keys_with_ijkl_to_arrow_keys.json
+++ b/public/json/combine_two_modifier_keys_with_ijkl_to_arrow_keys.json
@@ -1,0 +1,78 @@
+{
+  "title": "Combine Two Modifier keys + i/j/k/l to arrow keys",
+  "rules": [
+    {
+      "description": "Combine Left Control + Left Shift + i/j/k/l to Arrows",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": [
+                "left_control",
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "mandatory": [
+                "left_control",
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "k",
+            "modifiers": {
+              "mandatory": [
+                "left_control",
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "down_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "mandatory": [
+                "left_control",
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Combine two modifier keys with i/j/k/l to perform as arrow keys.

ex)
Left Control + Left Shift + i/j/k/l