### PR TITLE
Launch Terminal with F4

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -5,6 +5,9 @@
       "id": "modifier-keys",
       "files": [
         {
+          "path": "json/f4-to-launch-terminal.json"
+        },
+        {
             "path": "json/cmd+fn+delete_forward_delete_line.json"
         },
         {

--- a/public/json/f4-to-launch-terminal.json
+++ b/public/json/f4-to-launch-terminal.json
@@ -1,0 +1,29 @@
+{
+  "title": "Launch a new Terminal window with F4 (replace MacOS default Spotlight)",
+  "maintainers": [
+    "jinyoungch0i"
+  ],
+  "rules": [
+    {
+      "description": "Launch a new Terminal window with F4 (replace macOS default Spotlight)",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "f4",
+            "modifiers": {
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "shell_command": "open -a Terminal ~"
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/f4-to-launch-terminal.json.js
+++ b/src/json/f4-to-launch-terminal.json.js
@@ -1,0 +1,49 @@
+// JavaScript should be written in ECMAScript 5.1.
+
+function main() {
+
+    const rules = [
+        {
+            description: "Launch a new Terminal window with F4 (replace macOS default Spotlight)",
+            manipulators: [
+                {
+                    from: {
+                        key_code: "f4",
+                        modifiers: {
+                            optional: [
+                                "caps_lock"
+                            ]
+                        }
+                    },
+                    to: [
+                        {
+                            "shell_command": "open -a Terminal ~"
+                        }
+                    ],
+                    type: "basic"
+                }
+            ]
+        }
+    ]
+
+    const json = {
+        title: 'Launch a new Terminal window with F4 (replace MacOS default Spotlight)',
+        maintainers: ["jinyoungch0i"],
+        rules: rules.map(function (rule) {
+            return {
+                description: rule.description,
+                manipulators: rule.manipulators || []
+            }
+        })
+    }
+
+  console.log(
+    JSON.stringify(
+      json,
+      null,
+      '  '
+    )
+  )
+}
+
+main()


### PR DESCRIPTION
Hi @tekezo! 👋🏼

I wanted to define a custom rule to switch out the default functionality of F4 to launch a new Terminal window. Thought it might be useful to others, so creating this PR to make this rule importable.

(Also minor but I noticed that the default macOS behaviour for `F6` (turn on `🌙 Do Not Disturb`) hasn't yet been mapped in [Karabiner Elements](https://github.com/pqrs-org/Karabiner-Elements/blob/10b1bc537dbd0befd9d0af315c9857477d8581b5/NEWS.md?plain=1#L231) and instead mapped to `f6`; wondering if that's so since the feature is relatively new/bit of a hassle to implement? 🙂)


