### PR TITLE
Add emoji shortcut to mimic Windows 10/11 style

### DIFF
--- a/public/json/fn_period_for_emoji.json
+++ b/public/json/fn_period_for_emoji.json
@@ -1,0 +1,55 @@
+{
+  "title": "Emoji menu (command+control+space) for Windows style",
+  "rules": [
+    {
+      "description": "Fn + '.' (period) to pop-up the emoji menu (command + control + space)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "period",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "spacebar",
+              "modifiers": [
+                "left_command",
+                "left_control"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Option + '.' (period) to pop-up the emoji menu (command + control + space)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "period",
+            "modifiers": {
+              "mandatory": [
+                "left_option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "spacebar",
+              "modifiers": [
+                "left_command",
+                "left_control"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Hi, Team.

I'd like to create this PR to mimic Windows 10/11 style of calling the emoji menu. This PR has two options for it:

- To use `fn` + `period`
- To use `Option` + `period`

Please take a look and let me know.
