### PR TITLE
Magic keyboard escape key sequence (CMD+.) to mac Escape

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -1500,6 +1500,9 @@
         {
           "path": "json/macbook_disable_external_keyboard_on_open.json",
           "extra_description_path": "extra_descriptions/macbook_disable_external_keyboard_on_open.html"
+        },
+        {
+          "path": "json/command_l-and-period-to-escape.json"
         }
       ]
     },

--- a/public/json/command_l-and-period-to-escape.json
+++ b/public/json/command_l-and-period-to-escape.json
@@ -1,5 +1,5 @@
 {
-  "title": "Change Command_L + Period to Escape",
+  "title": "Change Command_L|Command_R + Period to Escape",
   "rules": [
     {
       "description": "Change Command_L + Period to Escape, to aid those who use the iPad Magic Keyboard since Command_L + Period is Escape on that keyboard.",
@@ -11,6 +11,27 @@
             "modifiers": {
               "mandatory": [
                 "left_command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "escape"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Change Command_R + Period to Escape, to aid those who use the iPad Magic Keyboard since Command_R + Period is Escape on that keyboard.",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "period",
+            "modifiers": {
+              "mandatory": [
+                "right_command"
               ]
             }
           },

--- a/public/json/command_l-and-period-to-escape.json
+++ b/public/json/command_l-and-period-to-escape.json
@@ -1,0 +1,26 @@
+{
+  "title": "Change Command_L + Period to Escape",
+  "rules": [
+    {
+      "description": "Change Command_L + Period to Escape, to aid those who use the iPad Magic Keyboard since Command_L + Period is Escape on that keyboard.",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "period",
+            "modifiers": {
+              "mandatory": [
+                "left_command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "escape"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/change_command_l-and_period_to_escape.js
+++ b/src/json/change_command_l-and_period_to_escape.js
@@ -2,7 +2,7 @@ function main() {
   console.log(
     JSON.stringify(
       {
-        title: 'Change Command_L + Period to Escape',
+        title: 'Change Command_L|Command_R + Period to Escape',
         rules: [
           {
             description: 'Change Command_L + Period to Escape, to aid those who use the iPad Magic Keyboard since Command_L + Period is Escape on that keyboard.',
@@ -13,6 +13,21 @@ function main() {
                   key_code: 'period',
                   modifiers: {
                     mandatory: ['left_command'],
+                  },
+                },
+                to: [{ key_code: 'escape' }],
+              },
+            ],
+          },
+          {
+            description: 'Change Command_R + Period to Escape, to aid those who use the iPad Magic Keyboard since Command_R + Period is Escape on that keyboard.',
+            manipulators: [
+              {
+                type: 'basic',
+                from: {
+                  key_code: 'period',
+                  modifiers: {
+                    mandatory: ['right_command'],
                   },
                 },
                 to: [{ key_code: 'escape' }],

--- a/src/json/change_command_l-and_period_to_escape.js
+++ b/src/json/change_command_l-and_period_to_escape.js
@@ -1,0 +1,30 @@
+function main() {
+  console.log(
+    JSON.stringify(
+      {
+        title: 'Change Command_L + Period to Escape',
+        rules: [
+          {
+            description: 'Change Command_L + Period to Escape, to aid those who use the iPad Magic Keyboard since Command_L + Period is Escape on that keyboard.',
+            manipulators: [
+              {
+                type: 'basic',
+                from: {
+                  key_code: 'period',
+                  modifiers: {
+                    mandatory: ['left_command'],
+                  },
+                },
+                to: [{ key_code: 'escape' }],
+              },
+            ],
+          },
+        ],
+      },
+      null,
+      '  '
+    )
+  )
+}
+
+main()


### PR DESCRIPTION
👋  First PR here so please educate me as necessary 🙏🏻

Basically, I find myself hitting Command_L+. all the time on my MBP ever since I bought a magic keyboard for my iPad, which - unsurprisingly - has Command_L+. (and Command_R+.) as a shortcut for Escape.

Update: I’ve just discovered - via https://www.idownloadblog.com/2020/05/15/escape-key-shortcut-tutorial/ - that CMD+. has been a MacOS shortcut for Escape forever 🤦🏻‍♂️ :

> While you cannot bring back a missing physical Escape key, you can replicate its functionality with a little help from a nifty universal keyboard shortcut, and here’s how:
> 
> To invoke Escape, press Command + period (.) on the keyboard.
> 
> This useful system-wide synonym for Escape works across iOS, iPadOS, and macOS. It actually dates back to classic Mac OS decades ago. With iPadOS 13.4, Apple’s brought the key combination to its tablets, providing not only feature parity in terms of the Escape command between the iPad and Mac but also a viable replacement for those who couldn’t live without it.
> 
> Note: The above keyboard shortcut may not work for all apps. To address this, you can remap the ESC key.
> 

However, when I checked this on Apple apps (App Store, Messages, Calendar), it did not perform as Escape, perhaps as noted in the final sentence of the above quote. Not on my MBP, anyway. But when I enabled my rule, it did perform as Escape, which was nice.

Hence I am unsure as to whether to proceed with this PR. I suppose the user always has the choice to not install/activate this complex mod.

Reviewers: what are your thoughts? Thanks.