### PR TITLE
Mapping JIKL to arrow keys, including many modifiers

### DIFF
--- a/public/json/command_jikl_to_command_arrow_keys_and_command_shift_jikl_to_command_shift_arrow_keys.json
+++ b/public/json/command_jikl_to_command_arrow_keys_and_command_shift_jikl_to_command_shift_arrow_keys.json
@@ -1,125 +1,130 @@
 {
-  "description": "Change ⌘(jikl) to ⌘(←↑↓→) keys and ⌘⇧(jikl) to ⌘⇧(←↑↓→) keys",
-  "manipulators": [
+  "title": "Change ⌘(jikl) to ⌘(←↑↓→) keys and ⌘⇧(jikl) to ⌘⇧(←↑↓→) keys",
+  "rules": [
     {
-      "from": {
-        "key_code": "j",
-        "modifiers": {
-          "mandatory": ["left_command"]
-        }
-      },
-      "to": [
+      "description": "Change ⌘(jikl) to ⌘(←↑↓→) keys and ⌘⇧(jikl) to ⌘⇧(←↑↓→) keys",
+      "manipulators": [
         {
-          "key_code": "left_arrow",
-          "modifiers": ["left_command"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "i",
-        "modifiers": {
-          "mandatory": ["left_command"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "mandatory": ["left_command"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow",
+              "modifiers": ["left_command"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "up_arrow",
-          "modifiers": ["left_command"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "k",
-        "modifiers": {
-          "mandatory": ["left_command"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": ["left_command"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow",
+              "modifiers": ["left_command"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "down_arrow",
-          "modifiers": ["left_command"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "l",
-        "modifiers": {
-          "mandatory": ["left_command"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "k",
+            "modifiers": {
+              "mandatory": ["left_command"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "down_arrow",
+              "modifiers": ["left_command"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "right_arrow",
-          "modifiers": ["left_command"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "j",
-        "modifiers": {
-          "mandatory": ["left_command", "left_shift"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "mandatory": ["left_command"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow",
+              "modifiers": ["left_command"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "left_arrow",
-          "modifiers": ["left_command", "left_shift"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "i",
-        "modifiers": {
-          "mandatory": ["left_command", "left_shift"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "mandatory": ["left_command", "left_shift"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow",
+              "modifiers": ["left_command", "left_shift"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "up_arrow",
-          "modifiers": ["left_command", "left_shift"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "k",
-        "modifiers": {
-          "mandatory": ["left_command", "left_shift"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": ["left_command", "left_shift"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow",
+              "modifiers": ["left_command", "left_shift"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "down_arrow",
-          "modifiers": ["left_command", "left_shift"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "l",
-        "modifiers": {
-          "mandatory": ["left_command", "left_shift"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "k",
+            "modifiers": {
+              "mandatory": ["left_command", "left_shift"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "down_arrow",
+              "modifiers": ["left_command", "left_shift"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "right_arrow",
-          "modifiers": ["left_command", "left_shift"]
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "mandatory": ["left_command", "left_shift"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow",
+              "modifiers": ["left_command", "left_shift"]
+            }
+          ],
+          "type": "basic"
         }
-      ],
-      "type": "basic"
+      ]
     }
   ]
 }

--- a/public/json/command_jikl_to_command_arrow_keys_and_command_shift_jikl_to_command_shift_arrow_keys.json
+++ b/public/json/command_jikl_to_command_arrow_keys_and_command_shift_jikl_to_command_shift_arrow_keys.json
@@ -1,0 +1,125 @@
+{
+  "description": "Change ⌘(jikl) to ⌘(←↑↓→) keys and ⌘⇧(jikl) to ⌘⇧(←↑↓→) keys",
+  "manipulators": [
+    {
+      "from": {
+        "key_code": "j",
+        "modifiers": {
+          "mandatory": ["left_command"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "left_arrow",
+          "modifiers": ["left_command"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "i",
+        "modifiers": {
+          "mandatory": ["left_command"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "up_arrow",
+          "modifiers": ["left_command"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "k",
+        "modifiers": {
+          "mandatory": ["left_command"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "down_arrow",
+          "modifiers": ["left_command"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "l",
+        "modifiers": {
+          "mandatory": ["left_command"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "right_arrow",
+          "modifiers": ["left_command"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "j",
+        "modifiers": {
+          "mandatory": ["left_command", "left_shift"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "left_arrow",
+          "modifiers": ["left_command", "left_shift"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "i",
+        "modifiers": {
+          "mandatory": ["left_command", "left_shift"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "up_arrow",
+          "modifiers": ["left_command", "left_shift"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "k",
+        "modifiers": {
+          "mandatory": ["left_command", "left_shift"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "down_arrow",
+          "modifiers": ["left_command", "left_shift"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "l",
+        "modifiers": {
+          "mandatory": ["left_command", "left_shift"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "right_arrow",
+          "modifiers": ["left_command", "left_shift"]
+        }
+      ],
+      "type": "basic"
+    }
+  ]
+}

--- a/public/json/control_jikl_to_control_arrow_keys_and_command_option_jikl_to_command_option_arrow_keys_and_command_control_jikl_to_command_jikl.json
+++ b/public/json/control_jikl_to_control_arrow_keys_and_command_option_jikl_to_command_option_arrow_keys_and_command_control_jikl_to_command_jikl.json
@@ -1,0 +1,185 @@
+{
+  "description": "Change ^(jikl) to ^(←↑↓→) keys, ⌘⌥(jikl) to ⌘⌥(←↑↓→) keys, and ⌘^(jikl) to ⌘(jikl) keys",
+  "manipulators": [
+    {
+      "from": {
+        "key_code": "j",
+        "modifiers": {
+          "mandatory": ["left_control"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "left_arrow",
+          "modifiers": ["left_control"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "i",
+        "modifiers": {
+          "mandatory": ["left_control"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "up_arrow",
+          "modifiers": ["left_control"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "k",
+        "modifiers": {
+          "mandatory": ["left_control"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "down_arrow",
+          "modifiers": ["left_control"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "l",
+        "modifiers": {
+          "mandatory": ["left_control"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "right_arrow",
+          "modifiers": ["left_control"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "j",
+        "modifiers": {
+          "mandatory": ["left_command", "left_option"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "left_arrow",
+          "modifiers": ["left_command", "left_option"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "i",
+        "modifiers": {
+          "mandatory": ["left_command", "left_option"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "up_arrow",
+          "modifiers": ["left_command", "left_option"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "k",
+        "modifiers": {
+          "mandatory": ["left_command", "left_option"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "down_arrow",
+          "modifiers": ["left_command", "left_option"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "l",
+        "modifiers": {
+          "mandatory": ["left_command", "left_option"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "right_arrow",
+          "modifiers": ["left_command", "left_option"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "j",
+        "modifiers": {
+          "mandatory": ["left_command", "left_control"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "j",
+          "modifiers": ["left_command"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "i",
+        "modifiers": {
+          "mandatory": ["left_command", "left_control"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "i",
+          "modifiers": ["left_command"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "k",
+        "modifiers": {
+          "mandatory": ["left_command", "left_control"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "k",
+          "modifiers": ["left_command"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "l",
+        "modifiers": {
+          "mandatory": ["left_command", "left_control"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "l",
+          "modifiers": ["left_command"]
+        }
+      ],
+      "type": "basic"
+    }
+  ]
+}

--- a/public/json/control_jikl_to_control_arrow_keys_and_command_option_jikl_to_command_option_arrow_keys_and_command_control_jikl_to_command_jikl.json
+++ b/public/json/control_jikl_to_control_arrow_keys_and_command_option_jikl_to_command_option_arrow_keys_and_command_control_jikl_to_command_jikl.json
@@ -1,185 +1,190 @@
 {
-  "description": "Change ^(jikl) to ^(←↑↓→) keys, ⌘⌥(jikl) to ⌘⌥(←↑↓→) keys, and ⌘^(jikl) to ⌘(jikl) keys",
-  "manipulators": [
+  "title": "Change ^(jikl) to ^(←↑↓→) keys, ⌘⌥(jikl) to ⌘⌥(←↑↓→) keys, and ⌘^(jikl) to ⌘(jikl) keys",
+  "rules": [
     {
-      "from": {
-        "key_code": "j",
-        "modifiers": {
-          "mandatory": ["left_control"]
-        }
-      },
-      "to": [
+      "description": "Change ^(jikl) to ^(←↑↓→) keys, ⌘⌥(jikl) to ⌘⌥(←↑↓→) keys, and ⌘^(jikl) to ⌘(jikl) keys",
+      "manipulators": [
         {
-          "key_code": "left_arrow",
-          "modifiers": ["left_control"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "i",
-        "modifiers": {
-          "mandatory": ["left_control"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "mandatory": ["left_control"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow",
+              "modifiers": ["left_control"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "up_arrow",
-          "modifiers": ["left_control"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "k",
-        "modifiers": {
-          "mandatory": ["left_control"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": ["left_control"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow",
+              "modifiers": ["left_control"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "down_arrow",
-          "modifiers": ["left_control"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "l",
-        "modifiers": {
-          "mandatory": ["left_control"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "k",
+            "modifiers": {
+              "mandatory": ["left_control"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "down_arrow",
+              "modifiers": ["left_control"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "right_arrow",
-          "modifiers": ["left_control"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "j",
-        "modifiers": {
-          "mandatory": ["left_command", "left_option"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "mandatory": ["left_control"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow",
+              "modifiers": ["left_control"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "left_arrow",
-          "modifiers": ["left_command", "left_option"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "i",
-        "modifiers": {
-          "mandatory": ["left_command", "left_option"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "mandatory": ["left_command", "left_option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow",
+              "modifiers": ["left_command", "left_option"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "up_arrow",
-          "modifiers": ["left_command", "left_option"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "k",
-        "modifiers": {
-          "mandatory": ["left_command", "left_option"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": ["left_command", "left_option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow",
+              "modifiers": ["left_command", "left_option"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "down_arrow",
-          "modifiers": ["left_command", "left_option"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "l",
-        "modifiers": {
-          "mandatory": ["left_command", "left_option"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "k",
+            "modifiers": {
+              "mandatory": ["left_command", "left_option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "down_arrow",
+              "modifiers": ["left_command", "left_option"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "right_arrow",
-          "modifiers": ["left_command", "left_option"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "j",
-        "modifiers": {
-          "mandatory": ["left_command", "left_control"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "mandatory": ["left_command", "left_option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow",
+              "modifiers": ["left_command", "left_option"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "j",
-          "modifiers": ["left_command"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "i",
-        "modifiers": {
-          "mandatory": ["left_command", "left_control"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "mandatory": ["left_command", "left_control"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j",
+              "modifiers": ["left_command"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "i",
-          "modifiers": ["left_command"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "k",
-        "modifiers": {
-          "mandatory": ["left_command", "left_control"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": ["left_command", "left_control"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "i",
+              "modifiers": ["left_command"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "k",
-          "modifiers": ["left_command"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "l",
-        "modifiers": {
-          "mandatory": ["left_command", "left_control"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "k",
+            "modifiers": {
+              "mandatory": ["left_command", "left_control"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k",
+              "modifiers": ["left_command"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "l",
-          "modifiers": ["left_command"]
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "mandatory": ["left_command", "left_control"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "l",
+              "modifiers": ["left_command"]
+            }
+          ],
+          "type": "basic"
         }
-      ],
-      "type": "basic"
+      ]
     }
   ]
 }

--- a/public/json/control_shift_jikl_to_shift_arrow_keys.json
+++ b/public/json/control_shift_jikl_to_shift_arrow_keys.json
@@ -1,0 +1,65 @@
+{
+  "description": "Change ^⇧(jikl) to ⇧(←↑↓→) keys",
+  "manipulators": [
+    {
+      "from": {
+        "key_code": "j",
+        "modifiers": {
+          "mandatory": ["left_control", "left_shift"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "left_arrow",
+          "modifiers": ["left_shift"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "i",
+        "modifiers": {
+          "mandatory": ["left_control", "left_shift"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "up_arrow",
+          "modifiers": ["left_shift"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "k",
+        "modifiers": {
+          "mandatory": ["left_control", "left_shift"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "down_arrow",
+          "modifiers": ["left_shift"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "l",
+        "modifiers": {
+          "mandatory": ["left_control", "left_shift"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "right_arrow",
+          "modifiers": ["left_shift"]
+        }
+      ],
+      "type": "basic"
+    }
+  ]
+}

--- a/public/json/control_shift_jikl_to_shift_arrow_keys.json
+++ b/public/json/control_shift_jikl_to_shift_arrow_keys.json
@@ -1,65 +1,70 @@
 {
-  "description": "Change ^⇧(jikl) to ⇧(←↑↓→) keys",
-  "manipulators": [
+  "title": "Change ^⇧(jikl) to ⇧(←↑↓→) keys",
+  "rules": [
     {
-      "from": {
-        "key_code": "j",
-        "modifiers": {
-          "mandatory": ["left_control", "left_shift"]
-        }
-      },
-      "to": [
+      "description": "Change ^⇧(jikl) to ⇧(←↑↓→) keys",
+      "manipulators": [
         {
-          "key_code": "left_arrow",
-          "modifiers": ["left_shift"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "i",
-        "modifiers": {
-          "mandatory": ["left_control", "left_shift"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "mandatory": ["left_control", "left_shift"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow",
+              "modifiers": ["left_shift"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "up_arrow",
-          "modifiers": ["left_shift"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "k",
-        "modifiers": {
-          "mandatory": ["left_control", "left_shift"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": ["left_control", "left_shift"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow",
+              "modifiers": ["left_shift"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "down_arrow",
-          "modifiers": ["left_shift"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "l",
-        "modifiers": {
-          "mandatory": ["left_control", "left_shift"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "k",
+            "modifiers": {
+              "mandatory": ["left_control", "left_shift"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "down_arrow",
+              "modifiers": ["left_shift"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "right_arrow",
-          "modifiers": ["left_shift"]
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "mandatory": ["left_control", "left_shift"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow",
+              "modifiers": ["left_shift"]
+            }
+          ],
+          "type": "basic"
         }
-      ],
-      "type": "basic"
+      ]
     }
   ]
 }

--- a/public/json/hyper_jikl_to_arrow_keys.json
+++ b/public/json/hyper_jikl_to_arrow_keys.json
@@ -1,0 +1,65 @@
+{
+  "description": "Change hyper-(jikl) to (←↑↓→) keys",
+  "manipulators": [
+    {
+      "from": {
+        "key_code": "j",
+        "modifiers": {
+          "mandatory": ["left_command", "left_option", "left_control", "left_shift"],
+          "optional": ["any"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "left_arrow"
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "i",
+        "modifiers": {
+          "mandatory": ["left_command", "left_option", "left_control", "left_shift"],
+          "optional": ["any"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "up_arrow"
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "k",
+        "modifiers": {
+          "mandatory": ["left_command", "left_option", "left_control", "left_shift"],
+          "optional": ["any"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "down_arrow"
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "l",
+        "modifiers": {
+          "mandatory": ["left_command", "left_option", "left_control", "left_shift"],
+          "optional": ["any"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "right_arrow"
+        }
+      ],
+      "type": "basic"
+    }
+  ]
+}

--- a/public/json/hyper_jikl_to_arrow_keys.json
+++ b/public/json/hyper_jikl_to_arrow_keys.json
@@ -1,65 +1,70 @@
 {
-  "description": "Change hyper-(jikl) to (←↑↓→) keys",
-  "manipulators": [
+  "title": "Change hyper-(jikl) to (←↑↓→) keys",
+  "rules": [
     {
-      "from": {
-        "key_code": "j",
-        "modifiers": {
-          "mandatory": ["left_command", "left_option", "left_control", "left_shift"],
-          "optional": ["any"]
-        }
-      },
-      "to": [
+      "description": "Change hyper-(jikl) to (←↑↓→) keys",
+      "manipulators": [
         {
-          "key_code": "left_arrow"
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "i",
-        "modifiers": {
-          "mandatory": ["left_command", "left_option", "left_control", "left_shift"],
-          "optional": ["any"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "mandatory": ["left_command", "left_option", "left_control", "left_shift"],
+              "optional": ["any"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow"
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "up_arrow"
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "k",
-        "modifiers": {
-          "mandatory": ["left_command", "left_option", "left_control", "left_shift"],
-          "optional": ["any"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": ["left_command", "left_option", "left_control", "left_shift"],
+              "optional": ["any"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow"
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "down_arrow"
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "l",
-        "modifiers": {
-          "mandatory": ["left_command", "left_option", "left_control", "left_shift"],
-          "optional": ["any"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "k",
+            "modifiers": {
+              "mandatory": ["left_command", "left_option", "left_control", "left_shift"],
+              "optional": ["any"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "down_arrow"
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "right_arrow"
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "mandatory": ["left_command", "left_option", "left_control", "left_shift"],
+              "optional": ["any"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow"
+            }
+          ],
+          "type": "basic"
         }
-      ],
-      "type": "basic"
+      ]
     }
   ]
 }

--- a/public/json/option_jikl_to_option_arrow_keys_and_option_shift_jikl_to_option_shift_arrow_keys.json
+++ b/public/json/option_jikl_to_option_arrow_keys_and_option_shift_jikl_to_option_shift_arrow_keys.json
@@ -1,0 +1,125 @@
+{
+  "description": "Change ⌥(jikl) to ⌥(←↑↓→) keys and ⌥⇧(jikl) to ⌥⇧(←↑↓→) keys",
+  "manipulators": [
+    {
+      "from": {
+        "key_code": "j",
+        "modifiers": {
+          "mandatory": ["left_option"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "left_arrow",
+          "modifiers": ["left_option"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "i",
+        "modifiers": {
+          "mandatory": ["left_option"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "up_arrow",
+          "modifiers": ["left_option"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "k",
+        "modifiers": {
+          "mandatory": ["left_option"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "down_arrow",
+          "modifiers": ["left_option"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "l",
+        "modifiers": {
+          "mandatory": ["left_option"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "right_arrow",
+          "modifiers": ["left_option"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "j",
+        "modifiers": {
+          "mandatory": ["left_option", "left_shift"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "left_arrow",
+          "modifiers": ["left_option", "left_shift"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "i",
+        "modifiers": {
+          "mandatory": ["left_option", "left_shift"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "up_arrow",
+          "modifiers": ["left_option", "left_shift"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "k",
+        "modifiers": {
+          "mandatory": ["left_option", "left_shift"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "down_arrow",
+          "modifiers": ["left_option", "left_shift"]
+        }
+      ],
+      "type": "basic"
+    },
+    {
+      "from": {
+        "key_code": "l",
+        "modifiers": {
+          "mandatory": ["left_option", "left_shift"]
+        }
+      },
+      "to": [
+        {
+          "key_code": "right_arrow",
+          "modifiers": ["left_option", "left_shift"]
+        }
+      ],
+      "type": "basic"
+    }
+  ]
+}

--- a/public/json/option_jikl_to_option_arrow_keys_and_option_shift_jikl_to_option_shift_arrow_keys.json
+++ b/public/json/option_jikl_to_option_arrow_keys_and_option_shift_jikl_to_option_shift_arrow_keys.json
@@ -1,125 +1,130 @@
 {
-  "description": "Change ⌥(jikl) to ⌥(←↑↓→) keys and ⌥⇧(jikl) to ⌥⇧(←↑↓→) keys",
-  "manipulators": [
+  "title": "Change ⌥(jikl) to ⌥(←↑↓→) keys and ⌥⇧(jikl) to ⌥⇧(←↑↓→) keys",
+  "rules": [
     {
-      "from": {
-        "key_code": "j",
-        "modifiers": {
-          "mandatory": ["left_option"]
-        }
-      },
-      "to": [
+      "description": "Change ⌥(jikl) to ⌥(←↑↓→) keys and ⌥⇧(jikl) to ⌥⇧(←↑↓→) keys",
+      "manipulators": [
         {
-          "key_code": "left_arrow",
-          "modifiers": ["left_option"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "i",
-        "modifiers": {
-          "mandatory": ["left_option"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "mandatory": ["left_option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow",
+              "modifiers": ["left_option"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "up_arrow",
-          "modifiers": ["left_option"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "k",
-        "modifiers": {
-          "mandatory": ["left_option"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": ["left_option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow",
+              "modifiers": ["left_option"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "down_arrow",
-          "modifiers": ["left_option"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "l",
-        "modifiers": {
-          "mandatory": ["left_option"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "k",
+            "modifiers": {
+              "mandatory": ["left_option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "down_arrow",
+              "modifiers": ["left_option"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "right_arrow",
-          "modifiers": ["left_option"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "j",
-        "modifiers": {
-          "mandatory": ["left_option", "left_shift"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "mandatory": ["left_option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow",
+              "modifiers": ["left_option"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "left_arrow",
-          "modifiers": ["left_option", "left_shift"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "i",
-        "modifiers": {
-          "mandatory": ["left_option", "left_shift"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "mandatory": ["left_option", "left_shift"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow",
+              "modifiers": ["left_option", "left_shift"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "up_arrow",
-          "modifiers": ["left_option", "left_shift"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "k",
-        "modifiers": {
-          "mandatory": ["left_option", "left_shift"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": ["left_option", "left_shift"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow",
+              "modifiers": ["left_option", "left_shift"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "down_arrow",
-          "modifiers": ["left_option", "left_shift"]
-        }
-      ],
-      "type": "basic"
-    },
-    {
-      "from": {
-        "key_code": "l",
-        "modifiers": {
-          "mandatory": ["left_option", "left_shift"]
-        }
-      },
-      "to": [
+          "from": {
+            "key_code": "k",
+            "modifiers": {
+              "mandatory": ["left_option", "left_shift"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "down_arrow",
+              "modifiers": ["left_option", "left_shift"]
+            }
+          ],
+          "type": "basic"
+        },
         {
-          "key_code": "right_arrow",
-          "modifiers": ["left_option", "left_shift"]
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "mandatory": ["left_option", "left_shift"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow",
+              "modifiers": ["left_option", "left_shift"]
+            }
+          ],
+          "type": "basic"
         }
-      ],
-      "type": "basic"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Overview of added key mappings. Note that J is interchangeable with I, K, or L, and ← is interchangeable with ↑, ↓, or →.

![CleanShot 2024-01-17 at 23 27 49@2x](https://github.com/pqrs-org/KE-complex_modifications/assets/67172603/c8d755a2-f9da-44e1-b072-95c71bfd477d)