### PR TITLE
Modifications for CIDOO 75 Pro

### DIFF
--- a/public/extra_descriptions/cidoo_v75_pro_escape_mod.json.html
+++ b/public/extra_descriptions/cidoo_v75_pro_escape_mod.json.html
@@ -1,0 +1,37 @@
+<link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
+
+<h1 style="border-bottom: 1px solid #D4D9E0;">CIDOO V75 Pro — Escape & Tilde Swap Mod w/ Hyper Key</h1>
+
+<p>
+  This rule is for the <b>CIDOO V75 Pro</b> and designed to mimic the <b>Keychron K6</b>.
+</p>
+
+<p>
+  ⚠️ This rule assumes the <b>Escape (Esc)</b> and <b>Tilde (~)</b> keys <u>have been physically swapped</u> and reconfigured as such in <a href="https://usevia.app/" target="_blank">VIA</a>.
+</p>
+
+<p>
+  It also adds the Hyper Key mod (⌃⌥⇧⌘) to Caps Lock when held (tap for regular Caps Lock).
+</p>
+
+<div style="background: #F5F7F9; display: inline-block; padding: 10px; font-style: italic;">
+  <p>
+    This is built upon my existing <a href="https://ke-complex-modifications.pqrs.org/#keychron_k6_useful_escape_caps_lock" target="_blank">Keychron K6 rules</a>.
+  </p>
+  <p>
+    This matches the key positioning for users who also use the built-in MacBook keyboard.
+  </p>
+</div>
+
+<p>Full list of modifications:</p>
+
+<ul>
+  <li>Unmodified Esc: Escape</li>
+  <li>Left Shift + Esc: ~ (tilde)</li>
+  <li>Right Shift + Esc: ` (grave)</li>
+  <li>Control + Esc: Control + `</li>
+  <li>Command + Esc: ⌘ + ` (app window cycle)</li>
+  <li>Caps Lock (held): ⌃⌥⇧⌘ (Hyper Key)</li>
+  <li>Caps Lock (alone): Regular Caps Lock</li>
+  <li>Hyper Key + Esc: Shift + Escape</li>
+</ul>

--- a/public/json/cidoo_v75_pro_escape_mod.json
+++ b/public/json/cidoo_v75_pro_escape_mod.json
@@ -1,0 +1,220 @@
+{
+    "title": "CIDOO V75 Pro — Escape & Tilde Swap Mod w/ Hyper Key",
+    "maintainers": [
+        "gsinti"
+    ],
+    "rules":
+    [
+        {
+            "description": "Left Shift + Esc: ~ (tilde)",
+            "manipulators":
+            [
+                {
+                    "from":
+                    {
+                        "key_code": "escape",
+                        "modifiers":
+                        {
+                            "mandatory":
+                            [
+                                "left_shift"
+                            ],
+                            "optional":
+                            [
+                                "caps_lock"
+                            ]
+                        }
+                    },
+                    "to":
+                    [
+                        {
+                            "key_code": "grave_accent_and_tilde",
+                            "modifiers":
+                            [
+                                "shift"
+                            ],
+                            "repeat": false
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "Right Shift + Esc: ` (grave)",
+            "manipulators":
+            [
+                {
+                    "from":
+                    {
+                        "key_code": "escape",
+                        "modifiers":
+                        {
+                            "mandatory":
+                            [
+                                "right_shift"
+                            ],
+                            "optional":
+                            [
+                                "caps_lock"
+                            ]
+                        }
+                    },
+                    "to":
+                    [
+                        {
+                            "key_code": "grave_accent_and_tilde",
+                            "repeat": false
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "Control + Esc: Control + `",
+            "manipulators":
+            [
+                {
+                    "from":
+                    {
+                        "key_code": "escape",
+                        "modifiers":
+                        {
+                            "mandatory":
+                            [
+                                "control"
+                            ],
+                            "optional":
+                            [
+                                "caps_lock"
+                            ]
+                        }
+                    },
+                    "to":
+                    [
+                        {
+                            "key_code": "grave_accent_and_tilde",
+                            "modifiers":
+                            [
+                                "control"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "Command + Esc: ⌘ + ` (app window cycle)",
+            "manipulators":
+            [
+                {
+                    "from":
+                    {
+                        "key_code": "escape",
+                        "modifiers":
+                        {
+                            "mandatory":
+                            [
+                                "command"
+                            ],
+                            "optional":
+                            [
+                                "caps_lock"
+                            ]
+                        }
+                    },
+                    "to":
+                    [
+                        {
+                            "key_code": "grave_accent_and_tilde",
+                            "modifiers":
+                            [
+                                "command"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "Caps Lock (held): ⌃⌥⇧⌘ (Hyper Key)",
+            "manipulators":
+            [
+                {
+                    "from":
+                    {
+                        "key_code": "caps_lock",
+                        "modifiers":
+                        {
+                            "optional":
+                            [
+                                "caps_lock"
+                            ]
+                        }
+                    },
+                    "to":
+                    [
+                        {
+                            "key_code": "left_shift",
+                            "modifiers":
+                            [
+                                "left_command",
+                                "left_control",
+                                "left_option"
+                            ],
+                            "lazy": true
+                        }
+                    ],
+                    "to_if_alone":
+                    [
+                        {
+                            "key_code": "caps_lock",
+                            "repeat": false
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "Hyper Key + Esc: Shift + Escape",
+            "manipulators":
+            [
+                {
+                    "from":
+                    {
+                        "key_code": "escape",
+                        "modifiers":
+                        {
+                            "mandatory":
+                            [
+                                "left_shift",
+                                "left_command",
+                                "left_control",
+                                "left_option"
+                            ],
+                            "optional":
+                            [
+                                "caps_lock"
+                            ]
+                        }
+                    },
+                    "to":
+                    [
+                        {
+                            "key_code": "escape",
+                            "modifiers":
+                            [
+                                "shift"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Adds mods to the CIDOO V75 Pro in order to mimic the Keychron K6 layout, effectively "combining" the Escape and Tilde keys.