### PR TITLE
Fix Neo2's layer 3 in Wezterm in its default configuration

### DIFF
--- a/public/json/neo2.json
+++ b/public/json/neo2.json
@@ -6807,7 +6807,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -6861,7 +6862,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -6915,7 +6917,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -6969,7 +6972,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -7023,7 +7027,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -7082,7 +7087,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -7136,7 +7142,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -7190,7 +7197,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -7244,7 +7252,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -7298,7 +7307,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -7352,7 +7362,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -7406,7 +7417,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -7460,7 +7472,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -7514,7 +7527,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -7568,7 +7582,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -7622,7 +7637,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -7676,7 +7692,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -7730,7 +7747,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -7784,7 +7802,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -7838,7 +7857,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -7892,7 +7912,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -7946,7 +7967,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -8000,7 +8022,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -8054,7 +8077,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -8108,7 +8132,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -8162,7 +8187,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -8216,7 +8242,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -8270,7 +8297,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -8324,7 +8352,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -8378,7 +8407,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -8432,7 +8462,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -8486,7 +8517,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -8540,7 +8572,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -8594,7 +8627,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -8648,7 +8682,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -8702,7 +8737,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]
@@ -8756,7 +8792,8 @@
                 "com.apple.Terminal",
                 "org.gnu.Emacs",
                 "com.googlecode.iterm2",
-                "dev.warp.Warp-Stable"
+                "dev.warp.Warp-Stable",
+                "com.github.wez.wezterm"
               ]
             }
           ]

--- a/src/json/neo2.json.js
+++ b/src/json/neo2.json.js
@@ -33,12 +33,12 @@ function rules() {
       { input_source_id: '^org\\.unknown\\.keylayout\\.DeutschNeo2$' },
       { input_source_id: '^org\\.unknown\\.keylayout\\.DeutschBone$' },
       { input_source_id: '^org\\.unknown\\.keylayout\\.DeutschNeoQwertz$' },
-      { input_source_id: '^org\\.unknown\\.keylayout\\.DeutschADNW$' }
-    ]
+      { input_source_id: '^org\\.unknown\\.keylayout\\.DeutschADNW$' },
+    ],
   }
   const isNotExcludedApp = {
     type: 'frontmost_application_unless',
-    bundle_identifiers: ['com.apple.Terminal', 'org.gnu.Emacs', 'com.googlecode.iterm2', 'dev.warp.Warp-Stable']
+    bundle_identifiers: ['com.apple.Terminal', 'org.gnu.Emacs', 'com.googlecode.iterm2', 'dev.warp.Warp-Stable', 'com.github.wez.wezterm']
   }
 
   const neo2Layer4 = function(condition) {


### PR DESCRIPTION
The rules for Neo 2 include optional rules that should prevent applications from treating the produced keys as shortcuts with Option held. However, these rules break in some terminal applications because they treat Option differently from normal applications (e.g. as ESC+key). Therefore, the rules are inactive on some terminal apps by default. I have simply added another terminal to the list that breaks with those rules active.

This will have merge conflicts with #1538, but they are trivially resolveable in whichever order they're merged in.