### PR TITLE
Add complex rules to allow 'ä' and 'Ä' via long-pressing 'a'

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -950,6 +950,9 @@
         },
         {
           "path": "json/caps_lock_to_en_shift_caps_lock_to_ru.json"
+        },
+        {
+          "path": "json/us_intl_delayed_aumlaut.json"
         }
       ]
     },

--- a/public/json/us_intl_delayed_aumlaut.json
+++ b/public/json/us_intl_delayed_aumlaut.json
@@ -1,0 +1,76 @@
+{
+  "title": "Press and hold 'a' or 'A' for 500ms to type a German 'ä'",
+  "rules": [
+    {
+      "description": "'ä' on holding down 'a' for 500ms",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "a"
+          },
+          "parameters": {
+            "basic.to_if_held_down_threshold_milliseconds": 500
+          },
+          "to_if_alone": [
+            {
+              "key_code": "a"
+            }
+          ],
+          "to_if_held_down": [
+            {
+              "key_code": "u",
+              "modifiers": [
+                "left_command"
+              ]
+            },
+            {
+              "key_code": "a"
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "'Ä' on holding down 'shift + a' for 500ms",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "parameters": {
+            "basic.to_if_held_down_threshold_milliseconds": 500
+          },
+          "to_if_alone": [
+            {
+              "key_code": "a",
+              "modifiers": [
+                "shift"
+              ]
+            }
+          ],
+          "to_if_held_down": [
+            {
+              "key_code": "u",
+              "modifiers": [
+                "left_command"
+              ]
+            },
+            {
+              "key_code": "a",
+              "modifiers": [
+                "shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/us_intl_delayed_aumlaut.json.js
+++ b/src/json/us_intl_delayed_aumlaut.json.js
@@ -1,0 +1,88 @@
+// JavaScript should be written in ECMAScript 5.1.
+
+function main() {
+  console.log(
+    JSON.stringify(
+      {
+        title: 'Press and hold \'a\' or \'A\' for 500ms to type a German \'ä\'',
+        rules: [
+          {
+              description: '\'ä\' on holding down \'a\' for 500ms',
+              manipulators: [
+                  {
+                      from: {
+                          key_code: 'a'
+                      },
+                      parameters: {
+                          'basic.to_if_held_down_threshold_milliseconds': 500
+                      },
+                      to_if_alone: [
+                          {
+                              key_code: 'a'
+                          }
+                      ],
+                      to_if_held_down: [
+                          {
+                              key_code: 'u',
+                              modifiers: [
+                                  'left_command'
+                              ]
+                          },
+                          {
+                              key_code: 'a'
+                          }
+                      ],
+                      type: 'basic'
+                  }
+              ]
+          },
+          {
+              description: '\'Ä\' on holding down \'shift + a\' for 500ms',
+              manipulators: [
+                  {
+                      from: {
+                          key_code: 'a',
+                          modifiers: {
+                              mandatory: [
+                                  "shift"
+                              ]
+                          }
+                      },
+                      parameters: {
+                          'basic.to_if_held_down_threshold_milliseconds': 500
+                      },
+                      to_if_alone: [
+                          {
+                              key_code: 'a',
+                              modifiers: [
+                                  'shift'
+                              ]
+                          }
+                      ],
+                      'to_if_held_down': [
+                          {
+                              key_code: 'u',
+                              modifiers: [
+                                  'left_command'
+                              ]
+                          },
+                          {
+                              key_code: 'a',
+                              modifiers: [
+                                  'shift'
+                              ]
+                          }
+                      ],
+                      type: 'basic'
+                  }
+              ]
+          }
+        ],
+      },
+      null,
+      '  '
+    )
+  )
+}
+
+main()


### PR DESCRIPTION
This PR adds a ruleset to solve https://github.com/pqrs-org/Karabiner-Elements/issues/3608
