### PR TITLE
R_CMD to switch input languages, especially Korean

### DIFF
--- a/public/json/r_cmd_switch_languages_korean.json
+++ b/public/json/r_cmd_switch_languages_korean.json
@@ -1,0 +1,28 @@
+{
+  "title": "R_CMD to switch input languages, especially Korean",
+  "maintainers": ["predict-woo"],
+  "rules": [
+    {
+      "description": "R_CMD to switch input languages, Fixes the issue where R_CMD does not switch input languages when caps lock is on",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_gui",
+            "modifiers": {
+              "optional": ["any"]
+            }
+          },
+          "to": [
+            {
+              "repeat": false,
+              "key_code": "spacebar",
+              "modifiers": ["left_control", "left_alt"],
+              "lazy": true
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This fixes the issue where R_CMD does not switch input languages when caps lock is on.
The original author was @pydemia