### PR TITLE
change del button to left_com + delete_backslash

### DIFF
--- a/src/json/delete_file_or_dir_by_delete.js
+++ b/src/json/delete_file_or_dir_by_delete.js
@@ -1,0 +1,30 @@
+{
+    "manipulators": [
+        {
+            "description": "Change delete_forward to cmd+backslash in finder",
+            "from": {
+                "key_code": "delete_forward",
+                "modifiers": {
+                    "optional": [
+                        "any"
+                    ]
+                }
+            },
+            "to": [
+                {
+                    "key_code": "delete_backspace",
+                    "modifiers": [
+                        "left_command"
+                    ]
+                }
+            ],
+            "type": "basic",
+            "conditions": [
+                {
+                    "type": "frontmost_application_if",
+                    "bundle_identifiers": ["^com\\.apple\\.finder$"]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
I want to use delete button on my external keyboard (keychorn K3E1) for delete files or folders. 
Change delete_forward button to delete_or_backspace + left_command in finder.
