### PR TITLE
Danish Dk keyboard add / and |

### DIFF
--- a/public/json/DK_Programmer.json
+++ b/public/json/DK_Programmer.json
@@ -75,6 +75,56 @@
           "type": "basic"
         }
       ]
+    },
+    {
+    "description": "Danish Dk keyboard, altgr key_left_of_z =>          \\",
+    "manipulators": [
+        {
+            "from": {
+                "key_code": "non_us_backslash",
+                "modifiers": {
+                    "mandatory": [
+                        "right_option",
+                        "left_shift"
+                    ]
+                }
+            },
+            "to": [
+                {
+                    "key_code": "7",
+                    "modifiers": [
+                        "left_option",
+                        "left_shift"
+                    ]
+                }
+            ],
+            "type": "basic"
+        }
+      ]
+    },
+    {
+    "description": "Danish Dk keyboard, altgr key_left_of_z =>         |",
+    "manipulators": [
+        {
+            "from": {
+                "key_code": "non_us_backslash",
+                "modifiers": {
+                    "mandatory": [
+                        "right_option"
+                    ]
+                }
+            },
+            "to": [
+                {
+                    "key_code": "i",
+                    "modifiers": [
+                        "left_option"
+                    ]
+                }
+            ],
+            "type": "basic"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
[Changelog]

- Add | on left of z + altgr
- Add \ on left of z + altgr + shift