### PR TITLE
feat: add wezterm to windows shortcuts's excluded bundles

### DIFF
--- a/public/json/windows_shortcuts_on_macos.json
+++ b/public/json/windows_shortcuts_on_macos.json
@@ -59,7 +59,8 @@
                 "^co\\.zeit\\.hyperterm$",
                 "^co\\.zeit\\.hyper$",
                 "^io\\.alacritty$",
-                "^net\\.kovidgoyal\\.kitty$"
+                "^net\\.kovidgoyal\\.kitty$",
+                "^com\\.github\\.wez\\.wezterm$"
               ]
             }
           ]
@@ -119,7 +120,8 @@
                 "^co\\.zeit\\.hyperterm$",
                 "^co\\.zeit\\.hyper$",
                 "^io\\.alacritty$",
-                "^net\\.kovidgoyal\\.kitty$"
+                "^net\\.kovidgoyal\\.kitty$",
+                "^com\\.github\\.wez\\.wezterm$"
               ]
             }
           ]
@@ -179,7 +181,8 @@
                 "^co\\.zeit\\.hyperterm$",
                 "^co\\.zeit\\.hyper$",
                 "^io\\.alacritty$",
-                "^net\\.kovidgoyal\\.kitty$"
+                "^net\\.kovidgoyal\\.kitty$",
+                "^com\\.github\\.wez\\.wezterm$"
               ]
             }
           ]
@@ -231,7 +234,8 @@
                 "^co\\.zeit\\.hyperterm$",
                 "^co\\.zeit\\.hyper$",
                 "^io\\.alacritty$",
-                "^net\\.kovidgoyal\\.kitty$"
+                "^net\\.kovidgoyal\\.kitty$",
+                "^com\\.github\\.wez\\.wezterm$"
               ],
               "type": "frontmost_application_unless"
             }
@@ -299,7 +303,8 @@
                 "^co\\.zeit\\.hyperterm$",
                 "^co\\.zeit\\.hyper$",
                 "^io\\.alacritty$",
-                "^net\\.kovidgoyal\\.kitty$"
+                "^net\\.kovidgoyal\\.kitty$",
+                "^com\\.github\\.wez\\.wezterm$"
               ],
               "type": "frontmost_application_unless"
             }
@@ -372,7 +377,8 @@
                 "^co\\.zeit\\.hyperterm$",
                 "^co\\.zeit\\.hyper$",
                 "^io\\.alacritty$",
-                "^net\\.kovidgoyal\\.kitty$"
+                "^net\\.kovidgoyal\\.kitty$",
+                "^com\\.github\\.wez\\.wezterm$"
               ],
               "type": "frontmost_application_unless"
             }
@@ -441,7 +447,8 @@
                 "^co\\.zeit\\.hyperterm$",
                 "^co\\.zeit\\.hyper$",
                 "^io\\.alacritty$",
-                "^net\\.kovidgoyal\\.kitty$"
+                "^net\\.kovidgoyal\\.kitty$",
+                "^com\\.github\\.wez\\.wezterm$"
               ],
               "type": "frontmost_application_unless"
             }
@@ -507,7 +514,8 @@
                 "^co\\.zeit\\.hyperterm$",
                 "^co\\.zeit\\.hyper$",
                 "^io\\.alacritty$",
-                "^net\\.kovidgoyal\\.kitty$"
+                "^net\\.kovidgoyal\\.kitty$",
+                "^com\\.github\\.wez\\.wezterm$"
               ],
               "type": "frontmost_application_unless"
             }
@@ -572,7 +580,8 @@
                 "^co\\.zeit\\.hyperterm$",
                 "^co\\.zeit\\.hyper$",
                 "^io\\.alacritty$",
-                "^net\\.kovidgoyal\\.kitty$"
+                "^net\\.kovidgoyal\\.kitty$",
+                "^com\\.github\\.wez\\.wezterm$"
               ],
               "type": "frontmost_application_unless"
             }
@@ -637,7 +646,8 @@
                 "^co\\.zeit\\.hyperterm$",
                 "^co\\.zeit\\.hyper$",
                 "^io\\.alacritty$",
-                "^net\\.kovidgoyal\\.kitty$"
+                "^net\\.kovidgoyal\\.kitty$",
+                "^com\\.github\\.wez\\.wezterm$"
               ],
               "type": "frontmost_application_unless"
             }
@@ -702,7 +712,8 @@
                 "^co\\.zeit\\.hyperterm$",
                 "^co\\.zeit\\.hyper$",
                 "^io\\.alacritty$",
-                "^net\\.kovidgoyal\\.kitty$"
+                "^net\\.kovidgoyal\\.kitty$",
+                "^com\\.github\\.wez\\.wezterm$"
               ],
               "type": "frontmost_application_unless"
             }
@@ -762,7 +773,8 @@
                 "^co\\.zeit\\.hyperterm$",
                 "^co\\.zeit\\.hyper$",
                 "^io\\.alacritty$",
-                "^net\\.kovidgoyal\\.kitty$"
+                "^net\\.kovidgoyal\\.kitty$",
+                "^com\\.github\\.wez\\.wezterm$"
               ],
               "type": "frontmost_application_unless"
             }
@@ -827,7 +839,8 @@
                 "^co\\.zeit\\.hyperterm$",
                 "^co\\.zeit\\.hyper$",
                 "^io\\.alacritty$",
-                "^net\\.kovidgoyal\\.kitty$"
+                "^net\\.kovidgoyal\\.kitty$",
+                "^com\\.github\\.wez\\.wezterm$"
               ],
               "type": "frontmost_application_unless"
             }
@@ -1378,7 +1391,8 @@
                 "^co\\.zeit\\.hyperterm$",
                 "^co\\.zeit\\.hyper$",
                 "^io\\.alacritty$",
-                "^net\\.kovidgoyal\\.kitty$"
+                "^net\\.kovidgoyal\\.kitty$",
+                "^com\\.github\\.wez\\.wezterm$"
               ],
               "type": "frontmost_application_unless"
             }
@@ -1519,7 +1533,8 @@
                 "^co\\.zeit\\.hyperterm$",
                 "^co\\.zeit\\.hyper$",
                 "^io\\.alacritty$",
-                "^net\\.kovidgoyal\\.kitty$"
+                "^net\\.kovidgoyal\\.kitty$",
+                "^com\\.github\\.wez\\.wezterm$"
               ],
               "type": "frontmost_application_unless"
             }
@@ -1579,7 +1594,8 @@
                 "^co\\.zeit\\.hyperterm$",
                 "^co\\.zeit\\.hyper$",
                 "^io\\.alacritty$",
-                "^net\\.kovidgoyal\\.kitty$"
+                "^net\\.kovidgoyal\\.kitty$",
+                "^com\\.github\\.wez\\.wezterm$"
               ],
               "type": "frontmost_application_unless"
             }
@@ -1662,7 +1678,8 @@
                 "^co\\.zeit\\.hyperterm$",
                 "^co\\.zeit\\.hyper$",
                 "^io\\.alacritty$",
-                "^net\\.kovidgoyal\\.kitty$"
+                "^net\\.kovidgoyal\\.kitty$",
+                "^com\\.github\\.wez\\.wezterm$"
               ]
             }
           ]
@@ -1720,7 +1737,8 @@
                 "^co\\.zeit\\.hyperterm$",
                 "^co\\.zeit\\.hyper$",
                 "^io\\.alacritty$",
-                "^net\\.kovidgoyal\\.kitty$"
+                "^net\\.kovidgoyal\\.kitty$",
+                "^com\\.github\\.wez\\.wezterm$"
               ]
             }
           ]

--- a/src/json/windows_shortcuts_on_macos.json.js
+++ b/src/json/windows_shortcuts_on_macos.json.js
@@ -36,6 +36,7 @@ function main() {
     '^co\\.zeit\\.hyper$',
     '^io\\.alacritty$',
     '^net\\.kovidgoyal\\.kitty$',
+    '^com\\.github\\.wez\\.wezterm$'
   ])
 
   console.log(


### PR DESCRIPTION
# Summary

This PR adds [WezTerm](https://wezfurlong.org/wezterm/) to the list of excluded bundles for Windows shortcuts on Macs. WezTerm is a cross-platform terminal, similar to `kitty` and  `alacritty`. Therefore, Windows shortcuts like `Ctrl+C` and `Ctrl+A` should be disabled to prevent sending incorrect commands to WezTerm.