### PR TITLE
added RK61 keyboard custom rule for slash and tilde, useful for mac users

### DIFF
--- a/public/json/rk61_for_mac.json
+++ b/public/json/rk61_for_mac.json
@@ -1,0 +1,59 @@
+{
+  "title": "RK61 Keyboard Mac Fix: Tilde and Slash Key Remapping",
+  "maintainers": [
+    "juan-28"
+  ],
+  "rules": [
+    {
+      "description": "right_shift + esc → ~",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "escape",
+            "modifiers": {
+              "mandatory": [
+                "right_shift"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "up_arrow turn to slash when press with left_command",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "up_arrow",
+            "modifiers": {
+              "mandatory": [
+                "left_command"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "slash"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/rk61_for_mac.json.js
+++ b/src/json/rk61_for_mac.json.js
@@ -1,0 +1,60 @@
+// JavaScript should be written in ECMAScript 5.1.
+
+function main() {
+  console.log(
+    JSON.stringify(
+      {
+        title: 'RK61 Keyboard Mac Fix: Tilde and Slash Key Remapping',
+        maintainers:['juan-28'],
+        rules: [
+          {
+            description: 'right_shift + esc → ~',
+            manipulators: [
+              {
+                type: 'basic',
+                from: {
+                  key_code: 'escape',
+                  modifiers: {
+                    mandatory: ['right_shift'],
+                    optional: ['any'],
+                  },
+                },
+                to: [
+                  {
+                    key_code: 'grave_accent_and_tilde',
+                    modifiers: ['left_shift'],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            description: 'up_arrow turn to slash when press with left_command',
+            manipulators: [
+              {
+                type: 'basic',
+                from: {
+                  key_code: 'up_arrow',
+                  modifiers: {
+                    mandatory: ['left_command'],
+                    optional: ['any'],
+                  },
+                },
+                to: [
+                  {
+                    key_code: 'slash',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      null,
+      '  '
+    )
+  );
+}
+
+main();
+


### PR DESCRIPTION
This PR adds custom key mappings for the RK61 keyboard on macOS using Karabiner-Elements. It includes the following remappings:

- `right_shift + esc` to `~`
- `left_command + up_arrow` to `/`

These changes aim to improve the usability of the RK61 keyboard on macOS.