### PR TITLE
Add 'Double-tap play/pause to skip track' complex mod

### DIFF
--- a/public/extra_descriptions/double_tap_play_to_skip.json.html
+++ b/public/extra_descriptions/double_tap_play_to_skip.json.html
@@ -1,0 +1,5 @@
+<link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
+
+<h3>Double-tap play/pause to skip track</h3>
+
+<p>This complex modification assigns the play/pause media button twice, so that it works as before with a single press of the button. If it is tapped twice, it will instead skip to the next track.</p>

--- a/public/groups.json
+++ b/public/groups.json
@@ -985,6 +985,10 @@
       "id": "key-specific",
       "files": [
         {
+          "path": "json/double_tap_play_to_skip.json",
+          "extra_description_path": "extra_descriptions/double_tap_play_to_skip.json.html"
+        },
+        {
           "path": "json/accute_accent_deadkey_azerty.json",
           "extra_description_path": "extra_descriptions/accute_accent_deadkey_azerty.json.html"
         },

--- a/public/json/double_tap_play_to_skip.json
+++ b/public/json/double_tap_play_to_skip.json
@@ -1,0 +1,66 @@
+{
+  "title": "Double-tap play/pause to skip track",
+  "maintainers": [
+    "yarinkaul"
+  ],
+  "rules": [
+    {
+      "description": "Double-tap play/pause to skip track",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "name": "play-pause-count",
+              "type": "variable_if",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "vk_consumer_play"
+          },
+          "to": [
+            {
+              "key_code": "vk_consumer_next"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "vk_consumer_play"
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "play-pause-count",
+                "value": 1
+              }
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_canceled": [
+              {
+                "set_variable": {
+                  "name": "play-pause-count",
+                  "value": 0
+                }
+              },
+              {
+                "key_code": "vk_consumer_next"
+              }
+            ],
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "play-pause-count",
+                  "value": 0
+                }
+              }
+            ]
+          },
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/double_tap_play_to_skip.json.js
+++ b/src/json/double_tap_play_to_skip.json.js
@@ -1,0 +1,78 @@
+// JavaScript should be written in ECMAScript 5.1.
+
+function main() {
+  console.log(
+    JSON.stringify(
+      {
+        title: 'Double-tap play/pause to skip track',
+        "maintainers": [
+          "yarinkaul"
+        ],
+        rules: [
+          {
+            "description": "Double-tap play/pause to skip track",
+            "manipulators": [
+              {
+                "conditions": [
+                  {
+                    "name": "play-pause-count",
+                    "type": "variable_if",
+                    "value": 1
+                  }
+                ],
+                "from": {
+                  "key_code": "vk_consumer_play"
+                },
+                "to": [
+                  {
+                    "key_code": "vk_consumer_next"
+                  }
+                ],
+                "type": "basic"
+              },
+              {
+                "from": {
+                  "key_code": "vk_consumer_play"
+                },
+                "to": [
+                  {
+                    "set_variable": {
+                      "name": "play-pause-count",
+                      "value": 1
+                    }
+                  }
+                ],
+                "to_delayed_action": {
+                  "to_if_canceled": [
+                    {
+                      "set_variable": {
+                        "name": "play-pause-count",
+                        "value": 0
+                      }
+                    },
+                    {
+                      "key_code": "vk_consumer_next"
+                    }
+                  ],
+                  "to_if_invoked": [
+                    {
+                      "set_variable": {
+                        "name": "play-pause-count",
+                        "value": 0
+                      }
+                    }
+                  ]
+                },
+                "type": "basic"
+              }
+            ]
+          }
+        ],
+      },
+      null,
+      '  '
+    )
+  )
+}
+
+main()


### PR DESCRIPTION
This complex modification assigns the play/pause media button twice, so that it works as before with a single press of the button. If it is tapped twice, it will instead skip to the next track.

Tested on a Logitech MX Keys Mini connected to a 2021 MacBook Pro running Mac OS X 14.2.1.