### PR TITLE
Added a new rule: F3~5 to screenshots

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -1260,6 +1260,9 @@
         },
         {
           "path": "json/om_optionR_to_fn.json"
+        },
+        {
+          "path": "json/F3-5_to_screenshots.json"
         }
       ]
     },

--- a/public/json/F3-5_to_screenshots.json
+++ b/public/json/F3-5_to_screenshots.json
@@ -42,7 +42,7 @@
       ]
     },
     {
-      "description": "F5 to ⇧⌘5 (screen record)",
+      "description": "F5 to ⇧⌘5 (screen record menu)",
       "manipulators": [
         {
           "type": "basic",

--- a/public/json/F3-5_to_screenshots.json
+++ b/public/json/F3-5_to_screenshots.json
@@ -1,0 +1,65 @@
+{
+  "title": "F3~5 to screenshots",
+  "rules": [
+    {
+      "description": "F3 to ⇧⌘3 (screenshot)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "f3"
+          },
+          "to": [
+            {
+              "key_code": "3",
+              "modifiers": [
+                "left_command",
+                "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "F4 to ⇧⌘4 (selective screenshot)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "f4"
+          },
+          "to": [
+            {
+              "key_code": "4",
+              "modifiers": [
+                "left_command",
+                "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "F5 to ⇧⌘5 (screen record)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "f5"
+          },
+          "to": [
+            {
+              "key_code": "5",
+              "modifiers": [
+                "left_command",
+                "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This rule turns MacBook's least used keys (F3, F4,  F5) into most overcomplicated commands (screenshot, selective screenshot, screen record menu) with reasonable mapping (because default keybinds of each are ⌘⇧3, ⌘⇧4, ⌘⇧5).

I implemented this rule for my own and have used for years, until it convinced me that this could help everybody a lot.
Please add this rule in collection if there's no problem, and as always, thanks for developing & maintaining such a life-saving tool.