### PR TITLE
Update toggle-delete-with-lock-key-for-magic-keyboard.json

### DIFF
--- a/public/json/toggle-delete-with-lock-key-for-magic-keyboard.json
+++ b/public/json/toggle-delete-with-lock-key-for-magic-keyboard.json
@@ -12,6 +12,9 @@
           "from": {
             "consumer_key_code": "al_terminal_lock_or_screensaver"
           },
+          "parameters": {
+            "basic.to_if_held_down_threshold_milliseconds": 1500
+          },
           "to_if_alone": [
             {
               "key_code": "delete_or_backspace"


### PR DESCRIPTION
add held down threshold milliseconds to 1500