### PR TITLE
Ctrl for lesser-than and greater-than signs

### DIFF
--- a/public/json/ctrl-greater_lesser_signs.json
+++ b/public/json/ctrl-greater_lesser_signs.json
@@ -1,0 +1,99 @@
+{
+  "title": "Ctrl + comma/period to lesser/greater-than signs",
+  "rules": [{
+    "description": "Enables greater-than and lesser-than signs with Ctrl+",
+    "manipulators": [{
+        "from": {
+          "key_code": "comma",
+          "modifiers": {
+            "mandatory": [
+              "right_control"
+            ],
+            "optional": [
+              "any"
+            ]
+          }
+        },
+        "to": [{
+          "shell_command": "printf '<' | pbcopy"
+        }],
+        "to_after_key_up": {
+          "key_code": "v",
+          "modifiers": [
+            "left_command"
+          ]
+        },
+        "type": "basic"
+      },
+      {
+        "from": {
+          "key_code": "period",
+          "modifiers": {
+            "mandatory": [
+              "right_control"
+            ],
+            "optional": [
+              "any"
+            ]
+          }
+        },
+        "to": [{
+          "shell_command": "printf '>' | pbcopy"
+        }],
+        "to_after_key_up": {
+          "key_code": "v",
+          "modifiers": [
+            "left_command"
+          ]
+        },
+        "type": "basic"
+      },
+      {
+        "from": {
+          "key_code": "comma",
+          "modifiers": {
+            "mandatory": [
+              "left_control"
+            ],
+            "optional": [
+              "any"
+            ]
+          }
+        },
+        "to": [{
+          "shell_command": "printf '<' | pbcopy"
+        }],
+        "to_after_key_up": {
+          "key_code": "v",
+          "modifiers": [
+            "left_command"
+          ]
+        },
+        "type": "basic"
+      },
+      {
+        "from": {
+          "key_code": "period",
+          "modifiers": {
+            "mandatory": [
+              "left_control"
+            ],
+            "optional": [
+              "any"
+            ]
+          }
+        },
+        "to": [{
+          "shell_command": "printf '>' | pbcopy"
+        }],
+        "to_after_key_up": {
+          "key_code": "v",
+          "modifiers": [
+            "left_command"
+          ]
+        },
+        "type": "basic"
+      }
+    ]
+  }]
+}


### PR DESCRIPTION
As described in the title, this allows to use `<` & `>` with Ctrl. This is convenient for Latin American language in EN keyboard.