### PR TITLE
Disable Option-click minimizing windows

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -168,6 +168,9 @@
         },
         {
           "path": "json/fix-ghost-select-in-context-menu.json"
+        },
+        {
+          "path": "json/disable_option_click.json"
         }
       ]
     },

--- a/public/json/disable_option_click.json
+++ b/public/json/disable_option_click.json
@@ -1,0 +1,27 @@
+{
+    "title": "Disable Option-click minimizing windows",
+    "rules": [
+        {
+            "description": "Disable Option-click minimizing windows",
+            "manipulators": [
+                {
+                    "from": {
+                        "modifiers": {
+                            "mandatory": [
+                                "left_option"
+                            ]
+                        },
+                        "pointing_button": "button1"
+                    },
+                    "to": [
+                        {
+                            "modifiers": [],
+                            "pointing_button": "button1"
+                        }
+                    ],
+                    "type": "basic"
+                }
+           ]
+        }
+    ]
+}


### PR DESCRIPTION
When pressing option and clicking between windows the active window is disabled. I use option to control widow management shortcuts, so often end up accidentally minimizing windows. Here is someone else running into this: https://discussions.apple.com/thread/252719638?sortBy=best

This will of course break any apps that have behavior attached to option-click, but I haven't hit any yet!