### PR TITLE
add new rule to toggle Dark Reader On/Off in Chrome/Brave

### DIFF
--- a/public/json/dark_reader_toggle.json
+++ b/public/json/dark_reader_toggle.json
@@ -1,0 +1,34 @@
+{
+  "title": "Dark Reader Toggle",
+  "rules": [
+    {
+      "description": "Change F7 to Toggle Dark Mode Reader in Browsers",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "bundle_identifiers": [
+                "^com\\.brave\\.Browser$",
+                "^com\\.google\\.Chrome$"
+              ],
+              "type": "frontmost_application_if"
+            }
+          ],
+          "from": {
+            "key_code": "f7"
+          },
+          "to": [
+            {
+              "key_code": "d",
+              "modifiers": [
+                "left_shift",
+                "left_option"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
https://darkreader.org/ is a browser extension to enable dark mode on any websites

Shift+Option+D is the command to toggle it on and off

this is a companion rule with https://github.com/pqrs-org/KE-complex_modifications/pull/1685

lmk if you think it's better to merge those two and maybe rename the rule to dark_mode.json or similar