### PR TITLE
Add shift modifier for Home/end and FN+arrows presets

### DIFF
--- a/public/json/HomeEnd.json
+++ b/public/json/HomeEnd.json
@@ -44,8 +44,13 @@
           ],
           "type": "basic",
           "from": {
-              "key_code": "home"
-            },
+            "key_code": "home",
+            "modifiers": {
+              "optional": [
+                "shift"
+              ]
+            }
+          },
           "to": [
             {
             "key_code": "left_arrow",
@@ -98,8 +103,13 @@
           ],
           "type": "basic",
           "from": {
-              "key_code": "end"
-            },
+            "key_code": "end",
+            "modifiers": {
+              "optional": [
+                "shift"
+              ]
+            }
+          },
           "to": [
             {
             "key_code": "right_arrow",

--- a/public/json/fn_arrows.json
+++ b/public/json/fn_arrows.json
@@ -14,7 +14,8 @@
               ],
               "optional": [
                 "caps_lock",
-                "option"
+                "option",
+                "shift"
               ]
             }
           },
@@ -39,7 +40,8 @@
               ],
               "optional": [
                 "caps_lock",
-                "option"
+                "option",
+                "shift"
               ]
             }
           },
@@ -64,7 +66,8 @@
               ],
               "optional": [
                 "caps_lock",
-                "option"
+                "option",
+                "shift"
               ]
             }
           },
@@ -89,13 +92,68 @@
               ],
               "optional": [
                 "caps_lock",
-                "option"
+                "option",
+                "shift"
               ]
             }
           },
           "to": [
             {
               "key_code": "end"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "FN + Left to Cmd + Left",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_arrow",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock",
+                "option",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+                "key_code": "left_arrow",
+                "modifiers": "command"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "FN + Right to Cmd + Right",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_arrow",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock",
+                "option",
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+                "key_code": "right_arrow",
+                "modifiers": "command"
             }
           ]
         }


### PR DESCRIPTION
This PR modifies already existing presets.

This is designed to have a Linux like behaviour when pressing either home/end or FN + right or left

The presets already exist elsewhere, but now the shift modifier is added, because it can be used when you want e.g. to select all the text until the end of the line.