### PR TITLE
Update german_umlaut.json

### DIFF
--- a/public/json/german_umlaut.json
+++ b/public/json/german_umlaut.json
@@ -1,269 +1,314 @@
 {
-    "description": "Change option + a/o/u to ä/ö/ü incl. shift for DE and EN",
-    "manipulators": [
+  "title": "German Umlaut",
+  "rules": [
+    {
+      "description": "Change option + a/o/u to ä/ö/ü",
+      "manipulators": [
         {
-            "conditions": [
-                {
-                    "input_sources": [{ "language": "en" }],
-                    "type": "input_source_if"
-                }
-            ],
-            "from": {
-                "key_code": "a",
-                "modifiers": {
-                    "mandatory": ["option"],
-                    "optional": ["caps_lock"]
-                }
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "mandatory": ["option"],
+              "optional": ["caps_lock"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "u",
+              "modifiers": ["left_option"]
             },
-            "to": [
+            { "key_code": "a" },
+            { "key_code": "vk_none" }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
                 {
-                    "key_code": "u",
-                    "modifiers": ["left_option"]
-                },
-                { "key_code": "a" },
-                { "key_code": "vk_none" }
-            ],
-            "type": "basic"
+                  "language": "en"
+                }
+              ],
+              "type": "input_source_if"
+            }
+          ]
         },
         {
-            "conditions": [
-                {
-                    "input_sources": [{ "language": "en" }],
-                    "type": "input_source_if"
-                }
-            ],
-            "from": {
-                "key_code": "a",
-                "modifiers": { "mandatory": ["option", "shift"] }
+          "from": {
+            "key_code": "a",
+            "modifiers": { "mandatory": ["option", "shift"] }
+          },
+          "to": [
+            {
+              "key_code": "u",
+              "modifiers": ["left_option"]
             },
-            "to": [
+            {
+              "key_code": "a",
+              "modifiers": ["left_shift"]
+            },
+            { "key_code": "vk_none" }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
                 {
-                    "key_code": "u",
-                    "modifiers": ["left_option"]
-                },
-                {
-                    "key_code": "a",
-                    "modifiers": ["left_shift"]
-                },
-                { "key_code": "vk_none" }
-            ],
-            "type": "basic"
+                  "language": "en"
+                }
+              ],
+              "type": "input_source_if"
+            }
+          ]
         },
         {
-            "conditions": [
-                {
-                    "input_sources": [{ "language": "^en$" }],
-                    "type": "input_source_if"
-                }
-            ],
-            "from": {
-                "key_code": "o",
-                "modifiers": {
-                    "mandatory": ["option"],
-                    "optional": ["caps_lock"]
-                }
+          "from": {
+            "key_code": "o",
+            "modifiers": {
+              "mandatory": ["option"],
+              "optional": ["caps_lock"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "u",
+              "modifiers": ["left_option"]
             },
-            "to": [
+            { "key_code": "o" },
+            { "key_code": "vk_none" }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
                 {
-                    "key_code": "u",
-                    "modifiers": ["left_option"]
-                },
-                { "key_code": "o" },
-                { "key_code": "vk_none" }
-            ],
-            "type": "basic"
+                  "language": "^en$"
+                }
+              ],
+              "type": "input_source_if"
+            }
+          ]
         },
         {
-            "conditions": [
-                {
-                    "input_sources": [{ "language": "en" }],
-                    "type": "input_source_if"
-                }
-            ],
-            "from": {
-                "key_code": "o",
-                "modifiers": { "mandatory": ["option", "shift"] }
+          "from": {
+            "key_code": "o",
+            "modifiers": { "mandatory": ["option", "shift"] }
+          },
+          "to": [
+            {
+              "key_code": "u",
+              "modifiers": ["left_option"]
             },
-            "to": [
+            {
+              "key_code": "o",
+              "modifiers": ["left_shift"]
+            },
+            { "key_code": "vk_none" }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
                 {
-                    "key_code": "u",
-                    "modifiers": ["left_option"]
-                },
-                {
-                    "key_code": "o",
-                    "modifiers": ["left_shift"]
-                },
-                { "key_code": "vk_none" }
-            ],
-            "type": "basic"
+                  "language": "en"
+                }
+              ],
+              "type": "input_source_if"
+            }
+          ]
         },
         {
-            "conditions": [
-                {
-                    "input_sources": [{ "language": "en" }],
-                    "type": "input_source_if"
-                }
-            ],
-            "from": {
-                "key_code": "u",
-                "modifiers": {
-                    "mandatory": ["option"],
-                    "optional": ["caps_lock"]
-                }
+          "from": {
+            "key_code": "u",
+            "modifiers": {
+              "mandatory": ["option"],
+              "optional": ["caps_lock"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "u",
+              "modifiers": ["left_option"]
             },
-            "to": [
+            { "key_code": "u" },
+            { "key_code": "vk_none" }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
                 {
-                    "key_code": "u",
-                    "modifiers": ["left_option"]
-                },
-                { "key_code": "u" },
-                { "key_code": "vk_none" }
-            ],
-            "type": "basic"
+                  "language": "en"
+                }
+              ],
+              "type": "input_source_if"
+            }
+          ]
         },
         {
-            "conditions": [
-                {
-                    "input_sources": [{ "language": "en" }],
-                    "type": "input_source_if"
-                }
-            ],
-            "from": {
-                "key_code": "u",
-                "modifiers": { "mandatory": ["option", "shift"] }
+          "from": {
+            "key_code": "u",
+            "modifiers": { "mandatory": ["option", "shift"] }
+          },
+          "to": [
+            {
+              "key_code": "u",
+              "modifiers": ["left_option"]
             },
-            "to": [
+            {
+              "key_code": "u",
+              "modifiers": ["left_shift"]
+            },
+            { "key_code": "vk_none" }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
                 {
-                    "key_code": "u",
-                    "modifiers": ["left_option"]
-                },
+                  "language": "en"
+                }
+              ],
+              "type": "input_source_if"
+            }
+          ]
+        },
+
+        {
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "mandatory": ["option"],
+              "optional": ["caps_lock"]
+            }
+          },
+          "to": [{ "key_code": "close_bracket" }, { "key_code": "a" }],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
                 {
-                    "key_code": "u",
-                    "modifiers": ["left_shift"]
-                },
-                { "key_code": "vk_none" }
-            ],
-            "type": "basic"
+                  "language": "de"
+                }
+              ],
+              "type": "input_source_if"
+            }
+          ]
         },
         {
-            "conditions": [
+          "from": {
+            "key_code": "a",
+            "modifiers": { "mandatory": ["option", "shift"] }
+          },
+          "to": [
+            { "key_code": "close_bracket" },
+            {
+              "key_code": "a",
+              "modifiers": ["left_shift"]
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
                 {
-                    "input_sources": [{ "language": "de" }],
-                    "type": "input_source_if"
+                  "language": "de"
                 }
-            ],
-            "from": {
-                "key_code": "a",
-                "modifiers": {
-                    "mandatory": ["option"],
-                    "optional": ["caps_lock"]
-                }
-            },
-            "to": [
-                { "key_code": "close_bracket" },
-                { "key_code": "a" }
-            ],
-            "type": "basic"
+              ],
+              "type": "input_source_if"
+            }
+          ]
         },
         {
-            "conditions": [
+          "from": {
+            "key_code": "o",
+            "modifiers": {
+              "mandatory": ["option"],
+              "optional": ["caps_lock"]
+            }
+          },
+          "to": [{ "key_code": "close_bracket" }, { "key_code": "o" }],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
                 {
-                    "input_sources": [{ "language": "de" }],
-                    "type": "input_source_if"
+                  "language": "de"
                 }
-            ],
-            "from": {
-                "key_code": "a",
-                "modifiers": { "mandatory": ["option", "shift"] }
-            },
-            "to": [
-                { "key_code": "close_bracket" },
-                {
-                    "key_code": "a",
-                    "modifiers": ["left_shift"]
-                }
-            ],
-            "type": "basic"
+              ],
+              "type": "input_source_if"
+            }
+          ]
         },
         {
-            "conditions": [
+          "from": {
+            "key_code": "o",
+            "modifiers": { "mandatory": ["option", "shift"] }
+          },
+          "to": [
+            { "key_code": "close_bracket" },
+            {
+              "key_code": "o",
+              "modifiers": ["left_shift"]
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
                 {
-                    "input_sources": [{ "language": "de" }],
-                    "type": "input_source_if"
+                  "language": "de"
                 }
-            ],
-            "from": {
-                "key_code": "o",
-                "modifiers": {
-                    "mandatory": ["option"],
-                    "optional": ["caps_lock"]
-                }
-            },
-            "to": [
-                { "key_code": "close_bracket" },
-                { "key_code": "o" }
-            ],
-            "type": "basic"
+              ],
+              "type": "input_source_if"
+            }
+          ]
         },
         {
-            "conditions": [
+          "from": {
+            "key_code": "u",
+            "modifiers": {
+              "mandatory": ["option"],
+              "optional": ["caps_lock"]
+            }
+          },
+          "to": [{ "key_code": "close_bracket" }, { "key_code": "u" }],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
                 {
-                    "input_sources": [{ "language": "de" }],
-                    "type": "input_source_if"
+                  "language": "de"
                 }
-            ],
-            "from": {
-                "key_code": "o",
-                "modifiers": { "mandatory": ["option", "shift"] }
-            },
-            "to": [
-                { "key_code": "close_bracket" },
-                {
-                    "key_code": "o",
-                    "modifiers": ["left_shift"]
-                }
-            ],
-            "type": "basic"
+              ],
+              "type": "input_source_if"
+            }
+          ]
         },
         {
-            "conditions": [
+          "from": {
+            "key_code": "u",
+            "modifiers": { "mandatory": ["option", "shift"] }
+          },
+          "to": [
+            { "key_code": "close_bracket" },
+            {
+              "key_code": "u",
+              "modifiers": ["left_shift"]
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
                 {
-                    "input_sources": [{ "language": "de" }],
-                    "type": "input_source_if"
+                  "language": "de"
                 }
-            ],
-            "from": {
-                "key_code": "u",
-                "modifiers": {
-                    "mandatory": ["option"],
-                    "optional": ["caps_lock"]
-                }
-            },
-            "to": [
-                { "key_code": "close_bracket" },
-                { "key_code": "u" }
-            ],
-            "type": "basic"
-        },
-        {
-            "conditions": [
-                {
-                    "input_sources": [{ "language": "de" }],
-                    "type": "input_source_if"
-                }
-            ],
-            "from": {
-                "key_code": "u",
-                "modifiers": { "mandatory": ["option", "shift"] }
-            },
-            "to": [
-                { "key_code": "close_bracket" },
-                {
-                    "key_code": "u",
-                    "modifiers": ["left_shift"]
-                }
-            ],
-            "type": "basic"
+              ],
+              "type": "input_source_if"
+            }
+          ]
         }
-    ]
+      ]
+    }
+  ]
 }

--- a/public/json/german_umlaut.json
+++ b/public/json/german_umlaut.json
@@ -1,181 +1,269 @@
 {
-  "title": "German Umlaut",
-  "rules": [
-    {
-      "description": "Change option + a/o/u to ä/ö/ü",
-      "manipulators": [
+    "description": "Change option + a/o/u to ä/ö/ü incl. shift for DE and EN",
+    "manipulators": [
         {
-          "type": "basic",
-          "from": {
-            "key_code": "a",
-            "modifiers": {
-              "mandatory": [
-                "option"
-              ],
-              "optional": [
-                "caps_lock"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "u",
-              "modifiers": [
-                "left_option"
-              ]
+            "conditions": [
+                {
+                    "input_sources": [{ "language": "en" }],
+                    "type": "input_source_if"
+                }
+            ],
+            "from": {
+                "key_code": "a",
+                "modifiers": {
+                    "mandatory": ["option"],
+                    "optional": ["caps_lock"]
+                }
             },
-            {
-              "key_code": "a"
-            },
-            {
-              "key_code": "vk_none"
-            }
-          ]
+            "to": [
+                {
+                    "key_code": "u",
+                    "modifiers": ["left_option"]
+                },
+                { "key_code": "a" },
+                { "key_code": "vk_none" }
+            ],
+            "type": "basic"
         },
         {
-          "type": "basic",
-          "from": {
-            "key_code": "a",
-            "modifiers": {
-              "mandatory": [
-                "option",
-                "shift"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "u",
-              "modifiers": [
-                "left_option"
-              ]
+            "conditions": [
+                {
+                    "input_sources": [{ "language": "en" }],
+                    "type": "input_source_if"
+                }
+            ],
+            "from": {
+                "key_code": "a",
+                "modifiers": { "mandatory": ["option", "shift"] }
             },
-            {
-              "key_code": "a",
-              "modifiers": [
-                "left_shift"
-              ]
-            },
-            {
-              "key_code": "vk_none"
-            }
-          ]
+            "to": [
+                {
+                    "key_code": "u",
+                    "modifiers": ["left_option"]
+                },
+                {
+                    "key_code": "a",
+                    "modifiers": ["left_shift"]
+                },
+                { "key_code": "vk_none" }
+            ],
+            "type": "basic"
         },
         {
-          "type": "basic",
-          "from": {
-            "key_code": "o",
-            "modifiers": {
-              "mandatory": [
-                "option"
-              ],
-              "optional": [
-                "caps_lock"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "u",
-              "modifiers": [
-                "left_option"
-              ]
+            "conditions": [
+                {
+                    "input_sources": [{ "language": "^en$" }],
+                    "type": "input_source_if"
+                }
+            ],
+            "from": {
+                "key_code": "o",
+                "modifiers": {
+                    "mandatory": ["option"],
+                    "optional": ["caps_lock"]
+                }
             },
-            {
-              "key_code": "o"
-            },
-            {
-              "key_code": "vk_none"
-            }
-          ]
+            "to": [
+                {
+                    "key_code": "u",
+                    "modifiers": ["left_option"]
+                },
+                { "key_code": "o" },
+                { "key_code": "vk_none" }
+            ],
+            "type": "basic"
         },
         {
-          "type": "basic",
-          "from": {
-            "key_code": "o",
-            "modifiers": {
-              "mandatory": [
-                "option",
-                "shift"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "u",
-              "modifiers": [
-                "left_option"
-              ]
+            "conditions": [
+                {
+                    "input_sources": [{ "language": "en" }],
+                    "type": "input_source_if"
+                }
+            ],
+            "from": {
+                "key_code": "o",
+                "modifiers": { "mandatory": ["option", "shift"] }
             },
-            {
-              "key_code": "o",
-              "modifiers": [
-                "left_shift"
-              ]
-            },
-            {
-              "key_code": "vk_none"
-            }
-          ]
+            "to": [
+                {
+                    "key_code": "u",
+                    "modifiers": ["left_option"]
+                },
+                {
+                    "key_code": "o",
+                    "modifiers": ["left_shift"]
+                },
+                { "key_code": "vk_none" }
+            ],
+            "type": "basic"
         },
         {
-          "type": "basic",
-          "from": {
-            "key_code": "u",
-            "modifiers": {
-              "mandatory": [
-                "option"
-              ],
-              "optional": [
-                "caps_lock"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "u",
-              "modifiers": [
-                "left_option"
-              ]
+            "conditions": [
+                {
+                    "input_sources": [{ "language": "en" }],
+                    "type": "input_source_if"
+                }
+            ],
+            "from": {
+                "key_code": "u",
+                "modifiers": {
+                    "mandatory": ["option"],
+                    "optional": ["caps_lock"]
+                }
             },
-            {
-              "key_code": "u"
-            },
-            {
-              "key_code": "vk_none"
-            }
-          ]
+            "to": [
+                {
+                    "key_code": "u",
+                    "modifiers": ["left_option"]
+                },
+                { "key_code": "u" },
+                { "key_code": "vk_none" }
+            ],
+            "type": "basic"
         },
         {
-          "type": "basic",
-          "from": {
-            "key_code": "u",
-            "modifiers": {
-              "mandatory": [
-                "option",
-                "shift"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "u",
-              "modifiers": [
-                "left_option"
-              ]
+            "conditions": [
+                {
+                    "input_sources": [{ "language": "en" }],
+                    "type": "input_source_if"
+                }
+            ],
+            "from": {
+                "key_code": "u",
+                "modifiers": { "mandatory": ["option", "shift"] }
             },
-            {
-              "key_code": "u",
-              "modifiers": [
-                "left_shift"
-              ]
+            "to": [
+                {
+                    "key_code": "u",
+                    "modifiers": ["left_option"]
+                },
+                {
+                    "key_code": "u",
+                    "modifiers": ["left_shift"]
+                },
+                { "key_code": "vk_none" }
+            ],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "input_sources": [{ "language": "de" }],
+                    "type": "input_source_if"
+                }
+            ],
+            "from": {
+                "key_code": "a",
+                "modifiers": {
+                    "mandatory": ["option"],
+                    "optional": ["caps_lock"]
+                }
             },
-            {
-              "key_code": "vk_none"
-            }
-          ]
+            "to": [
+                { "key_code": "close_bracket" },
+                { "key_code": "a" }
+            ],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "input_sources": [{ "language": "de" }],
+                    "type": "input_source_if"
+                }
+            ],
+            "from": {
+                "key_code": "a",
+                "modifiers": { "mandatory": ["option", "shift"] }
+            },
+            "to": [
+                { "key_code": "close_bracket" },
+                {
+                    "key_code": "a",
+                    "modifiers": ["left_shift"]
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "input_sources": [{ "language": "de" }],
+                    "type": "input_source_if"
+                }
+            ],
+            "from": {
+                "key_code": "o",
+                "modifiers": {
+                    "mandatory": ["option"],
+                    "optional": ["caps_lock"]
+                }
+            },
+            "to": [
+                { "key_code": "close_bracket" },
+                { "key_code": "o" }
+            ],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "input_sources": [{ "language": "de" }],
+                    "type": "input_source_if"
+                }
+            ],
+            "from": {
+                "key_code": "o",
+                "modifiers": { "mandatory": ["option", "shift"] }
+            },
+            "to": [
+                { "key_code": "close_bracket" },
+                {
+                    "key_code": "o",
+                    "modifiers": ["left_shift"]
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "input_sources": [{ "language": "de" }],
+                    "type": "input_source_if"
+                }
+            ],
+            "from": {
+                "key_code": "u",
+                "modifiers": {
+                    "mandatory": ["option"],
+                    "optional": ["caps_lock"]
+                }
+            },
+            "to": [
+                { "key_code": "close_bracket" },
+                { "key_code": "u" }
+            ],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "input_sources": [{ "language": "de" }],
+                    "type": "input_source_if"
+                }
+            ],
+            "from": {
+                "key_code": "u",
+                "modifiers": { "mandatory": ["option", "shift"] }
+            },
+            "to": [
+                { "key_code": "close_bracket" },
+                {
+                    "key_code": "u",
+                    "modifiers": ["left_shift"]
+                }
+            ],
+            "type": "basic"
         }
-      ]
-    }
-  ]
+    ]
 }

--- a/src/json/german_umlaut.json.js
+++ b/src/json/german_umlaut.json.js
@@ -2,64 +2,307 @@
 
 function main() {
   console.log(
-    JSON.stringify(
-      {
-        title: 'German Umlaut',
-        rules: [
-          {
-            description: 'Change option + a/o/u to ä/ö/ü',
-            manipulators: [
-              {
-                type: 'basic',
-                from: {
-                  key_code: 'a',
-                  modifiers: { mandatory: ['option'], optional: ['caps_lock'] },
-                },
-                to: [{ key_code: 'u', modifiers: ['left_option'] }, { key_code: 'a' }, { key_code: 'vk_none' }],
+    JSON.stringify({
+        "title": "German Umlaut",
+        "rules": [{
+          "description": "Change option + a/o/u to ä/ö/ü",
+          "manipulators": [{
+              "from": {
+                "key_code": "a",
+                "modifiers": {
+                  "mandatory": ["option"],
+                  "optional": ["caps_lock"]
+                }
               },
-              {
-                type: 'basic',
-                from: {
-                  key_code: 'a',
-                  modifiers: { mandatory: ['option', 'shift'] },
+              "to": [{
+                  "key_code": "u",
+                  "modifiers": ["left_option"]
                 },
-                to: [{ key_code: 'u', modifiers: ['left_option'] }, { key_code: 'a', modifiers: ['left_shift'] }, { key_code: 'vk_none' }],
-              },
-              {
-                type: 'basic',
-                from: {
-                  key_code: 'o',
-                  modifiers: { mandatory: ['option'], optional: ['caps_lock'] },
+                {
+                  "key_code": "a"
                 },
-                to: [{ key_code: 'u', modifiers: ['left_option'] }, { key_code: 'o' }, { key_code: 'vk_none' }],
+                {
+                  "key_code": "vk_none"
+                }
+              ],
+              "type": "basic",
+              "conditions": [{
+                "input_sources": [{
+                  "language": "en"
+                }],
+                "type": "input_source_if"
+              }]
+            },
+            {
+              "from": {
+                "key_code": "a",
+                "modifiers": {
+                  "mandatory": ["option", "shift"]
+                }
               },
-              {
-                type: 'basic',
-                from: {
-                  key_code: 'o',
-                  modifiers: { mandatory: ['option', 'shift'] },
+              "to": [{
+                  "key_code": "u",
+                  "modifiers": ["left_option"]
                 },
-                to: [{ key_code: 'u', modifiers: ['left_option'] }, { key_code: 'o', modifiers: ['left_shift'] }, { key_code: 'vk_none' }],
-              },
-              {
-                type: 'basic',
-                from: {
-                  key_code: 'u',
-                  modifiers: { mandatory: ['option'], optional: ['caps_lock'] },
+                {
+                  "key_code": "a",
+                  "modifiers": ["left_shift"]
                 },
-                to: [{ key_code: 'u', modifiers: ['left_option'] }, { key_code: 'u' }, { key_code: 'vk_none' }],
+                {
+                  "key_code": "vk_none"
+                }
+              ],
+              "type": "basic",
+              "conditions": [{
+                "input_sources": [{
+                  "language": "en"
+                }],
+                "type": "input_source_if"
+              }]
+            },
+            {
+              "from": {
+                "key_code": "o",
+                "modifiers": {
+                  "mandatory": ["option"],
+                  "optional": ["caps_lock"]
+                }
               },
-              {
-                type: 'basic',
-                from: {
-                  key_code: 'u',
-                  modifiers: { mandatory: ['option', 'shift'] },
+              "to": [{
+                  "key_code": "u",
+                  "modifiers": ["left_option"]
                 },
-                to: [{ key_code: 'u', modifiers: ['left_option'] }, { key_code: 'u', modifiers: ['left_shift'] }, { key_code: 'vk_none' }],
+                {
+                  "key_code": "o"
+                },
+                {
+                  "key_code": "vk_none"
+                }
+              ],
+              "type": "basic",
+              "conditions": [{
+                "input_sources": [{
+                  "language": "^en$"
+                }],
+                "type": "input_source_if"
+              }]
+            },
+            {
+              "from": {
+                "key_code": "o",
+                "modifiers": {
+                  "mandatory": ["option", "shift"]
+                }
               },
-            ],
-          },
-        ],
+              "to": [{
+                  "key_code": "u",
+                  "modifiers": ["left_option"]
+                },
+                {
+                  "key_code": "o",
+                  "modifiers": ["left_shift"]
+                },
+                {
+                  "key_code": "vk_none"
+                }
+              ],
+              "type": "basic",
+              "conditions": [{
+                "input_sources": [{
+                  "language": "en"
+                }],
+                "type": "input_source_if"
+              }]
+            },
+            {
+              "from": {
+                "key_code": "u",
+                "modifiers": {
+                  "mandatory": ["option"],
+                  "optional": ["caps_lock"]
+                }
+              },
+              "to": [{
+                  "key_code": "u",
+                  "modifiers": ["left_option"]
+                },
+                {
+                  "key_code": "u"
+                },
+                {
+                  "key_code": "vk_none"
+                }
+              ],
+              "type": "basic",
+              "conditions": [{
+                "input_sources": [{
+                  "language": "en"
+                }],
+                "type": "input_source_if"
+              }]
+            },
+            {
+              "from": {
+                "key_code": "u",
+                "modifiers": {
+                  "mandatory": ["option", "shift"]
+                }
+              },
+              "to": [{
+                  "key_code": "u",
+                  "modifiers": ["left_option"]
+                },
+                {
+                  "key_code": "u",
+                  "modifiers": ["left_shift"]
+                },
+                {
+                  "key_code": "vk_none"
+                }
+              ],
+              "type": "basic",
+              "conditions": [{
+                "input_sources": [{
+                  "language": "en"
+                }],
+                "type": "input_source_if"
+              }]
+            },
+
+            {
+              "from": {
+                "key_code": "a",
+                "modifiers": {
+                  "mandatory": ["option"],
+                  "optional": ["caps_lock"]
+                }
+              },
+              "to": [{
+                "key_code": "close_bracket"
+              }, {
+                "key_code": "a"
+              }],
+              "type": "basic",
+              "conditions": [{
+                "input_sources": [{
+                  "language": "de"
+                }],
+                "type": "input_source_if"
+              }]
+            },
+            {
+              "from": {
+                "key_code": "a",
+                "modifiers": {
+                  "mandatory": ["option", "shift"]
+                }
+              },
+              "to": [{
+                  "key_code": "close_bracket"
+                },
+                {
+                  "key_code": "a",
+                  "modifiers": ["left_shift"]
+                }
+              ],
+              "type": "basic",
+              "conditions": [{
+                "input_sources": [{
+                  "language": "de"
+                }],
+                "type": "input_source_if"
+              }]
+            },
+            {
+              "from": {
+                "key_code": "o",
+                "modifiers": {
+                  "mandatory": ["option"],
+                  "optional": ["caps_lock"]
+                }
+              },
+              "to": [{
+                "key_code": "close_bracket"
+              }, {
+                "key_code": "o"
+              }],
+              "type": "basic",
+              "conditions": [{
+                "input_sources": [{
+                  "language": "de"
+                }],
+                "type": "input_source_if"
+              }]
+            },
+            {
+              "from": {
+                "key_code": "o",
+                "modifiers": {
+                  "mandatory": ["option", "shift"]
+                }
+              },
+              "to": [{
+                  "key_code": "close_bracket"
+                },
+                {
+                  "key_code": "o",
+                  "modifiers": ["left_shift"]
+                }
+              ],
+              "type": "basic",
+              "conditions": [{
+                "input_sources": [{
+                  "language": "de"
+                }],
+                "type": "input_source_if"
+              }]
+            },
+            {
+              "from": {
+                "key_code": "u",
+                "modifiers": {
+                  "mandatory": ["option"],
+                  "optional": ["caps_lock"]
+                }
+              },
+              "to": [{
+                "key_code": "close_bracket"
+              }, {
+                "key_code": "u"
+              }],
+              "type": "basic",
+              "conditions": [{
+                "input_sources": [{
+                  "language": "de"
+                }],
+                "type": "input_source_if"
+              }]
+            },
+            {
+              "from": {
+                "key_code": "u",
+                "modifiers": {
+                  "mandatory": ["option", "shift"]
+                }
+              },
+              "to": [{
+                  "key_code": "close_bracket"
+                },
+                {
+                  "key_code": "u",
+                  "modifiers": ["left_shift"]
+                }
+              ],
+              "type": "basic",
+              "conditions": [{
+                "input_sources": [{
+                  "language": "de"
+                }],
+                "type": "input_source_if"
+              }]
+            }
+          ]
+        }]
       },
       null,
       '  '


### PR DESCRIPTION
added the conditions for en and de input sources, so the öäü shortcuts are working the same in the english and the german layout