### PR TITLE
SIGKILL_frontmost_application.json

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -5,6 +5,9 @@
       "id": "os-functionality",
       "files": [
         {
+          "path": "json/SIGKILL_frontmost_application.json"
+        },
+        {
           "path": "json/vim_like_switch_apps.json"
         },
         {

--- a/public/json/SIGKILL_frontmost_application.json
+++ b/public/json/SIGKILL_frontmost_application.json
@@ -1,0 +1,21 @@
+{
+    "title": "SIGKILL frontmost application",
+
+    "rules": [
+	{
+	    "description": "Saves you from having to reset the computer if e.g. a program has captured the screen and hangs. It does so by sending the SIGKILL signal to the frontmost application. Note: Macos already has a similar keybinding: Press Shift+Ctrl+Cmd+Esc for three seconds. However the built-in keybinding only sends SIGTERM, which doesn't always work, for instance if the program has a signal handler or runs in a debugger.",
+	    
+	    "manipulators": [
+		{
+		    "from": {
+			"key_code": "f12",
+			"modifiers": { "mandatory": ["left_shift", "left_option", "left_command"] }
+		    },
+		    "to": [{ "shell_command": "curr_app=$(osascript -e 'tell application \"System Events\" to (name of (first process whose frontmost is true))' | awk '{print \"\\x22\" $0 \"\\x22\" }') ; echo \"killall -9 $curr_app\" > /tmp/execute.sh ; sh /tmp/execute.sh ; rm /tmp/execute.sh" }],
+		    "type": "basic"
+		}
+	    ]
+	}
+    ]
+}
+

--- a/public/json/SIGKILL_frontmost_application.json
+++ b/public/json/SIGKILL_frontmost_application.json
@@ -11,7 +11,7 @@
 			"key_code": "f12",
 			"modifiers": { "mandatory": ["left_shift", "left_option", "left_command"] }
 		    },
-		    "to": [{ "shell_command": "curr_app=$(osascript -e 'tell application \"System Events\" to (name of (first process whose frontmost is true))' | awk '{print \"\\x22\" $0 \"\\x22\" }') ; echo \"killall -9 $curr_app\" > /tmp/execute.sh ; sh /tmp/execute.sh ; rm /tmp/execute.sh" }],
+		    "to": [{ "shell_command": "killall -9 \"$(osascript -e 'tell application \"System Events\" to (name of (first process whose frontmost is true))')\"" }],
 		    "type": "basic"
 		}
 	    ]


### PR DESCRIPTION
I didn't manage to create a nice-looking shell script command, but it works, at least for me. :-)

I use this keybinding to stop a full-screen application I'm working on from hanging my computer when there is a bug. When a program runs in a debugger, sending SIGTERM won't kill a program, so Macos' built-in keybinding for doing the same thing isn't good enough. This keybinding sends SIGKILL instead, and then the process dies.


	    "description": "Press LeftShift + LeftOption + LeftCommand + F12 to kill the frontmost application. This saves you from having to reset the computer e.g. if a program has captured the screen and hangs. It does so by sending SIGKILL to the frontmost application. Note: Macos already has a similar keybinding: Shift+Ctrl+Cmd+Esc (press keys for three seconds). However the built-in keybinding only sends SIGTERM, which doesn't always work, for instance if the program runs in a debugger or has a signal handler."	    
