### PR TITLE
Add device specific modifications for keyboard NiZ KB75

### DIFF
--- a/public/extra_descriptions/niz_kb75_fix_quotes_colon.html
+++ b/public/extra_descriptions/niz_kb75_fix_quotes_colon.html
@@ -1,0 +1,60 @@
+<link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
+
+<h3>Plum Nano 75 Bluetooth NiZ KB75 75EC-XRGB (fix quotes and semicolon)</h3>
+
+<p>
+This keyboard was first available under the brand name <a href="https://drop.com/buy/plum-nano-75-bluetooth-electro-capacitive-mechanical-keyboard">Plum Nano 75</a> and later changed to <a href="hbuttonps://www.NiZkeyboard.com">NiZ</a> KB75 75EC-XRGB. It identifies its vendor as CATEX TECH.
+</p>
+
+<p>
+The firmware has a bug with switched keys. Pressing the <button>;</button>  results in a <tt>:</tt> on screen. The keyboard actually sends <button>⇧ Shift left</button>+<button>;</button> to the computer. Consequently you have to press <button>⇧ Shift</button>+<button>;</button> to get a <tt>;</tt>. The same applies for <button>'</button> and <button>"</button>.
+</p>
+
+<p>
+This modification fixes this to work like most normal keyboards.
+</p>
+
+<style>
+  table.NiZ_kb75_keymap_table {
+    border-collapse: collapse;
+    margin: 10px;
+  }
+
+  table.NiZ_kb75_keymap_table th,
+  table.NiZ_kb75_keymap_table td {
+    border: 1px solid gray;
+    padding: 5px;
+  }
+
+  table.NiZ_kb75_keymap_table th {
+    background-color: #ddd;
+  }
+
+  table.NiZ_kb75_keymap_table {
+    text-align: center;
+  }
+</style>
+
+<table class="NiZ_kb75_keymap_table">
+  <tr>
+    <th>Key Press</th>
+    <th>Character</th>
+  </tr>
+  <tr>
+    <td><button>;</button></td>
+    <td><tt>;</tt></td>
+  </tr>
+  <tr>
+    <td><button>⇧ Shift</button>+<button>;</button></td>
+    <td><tt>:</tt></td>
+  </tr>
+  <tr>
+    <td><button>'</button></td>
+    <td><tt>'</tt></td>
+  </tr>
+  <tr>
+    <td><button>⇧ Shift</button>+<button>'</button></td>
+    <td><tt>"</tt></td>
+  </tr>
+
+</table>

--- a/public/json/niz_kb75_fix_quotes_colon.json
+++ b/public/json/niz_kb75_fix_quotes_colon.json
@@ -1,0 +1,121 @@
+{
+  "title": "Plum Nano 75 Bluetooth NiZ KB75 75EC-XRGB (fix quotes and semicolon)",
+  "maintainers": [
+    "orkoden"
+  ],
+  "rules": [
+    {
+      "description": " KB75 75EC-XRGB CATEX TECH. (fix quotes and semicolon)",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "identifiers": [
+                {
+                  "product_id": 20518,
+                  "vendor_id": 1155
+                }
+              ],
+              "type": "device_if"
+            }
+          ],
+          "from": {
+            "key_code": "semicolon",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "semicolon",
+              "modifiers": []
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "identifiers": [
+                {
+                  "product_id": 20518,
+                  "vendor_id": 1155
+                }
+              ],
+              "type": "device_if"
+            }
+          ],
+          "from": {
+            "key_code": "semicolon",
+            "modifiers": {}
+          },
+          "to": [
+            {
+              "key_code": "semicolon",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "identifiers": [
+                {
+                  "product_id": 20518,
+                  "vendor_id": 1155
+                }
+              ],
+              "type": "device_if"
+            }
+          ],
+          "from": {
+            "key_code": "quote",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "quote",
+              "modifiers": []
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "identifiers": [
+                {
+                  "product_id": 20518,
+                  "vendor_id": 1155
+                }
+              ],
+              "type": "device_if"
+            }
+          ],
+          "from": {
+            "key_code": "quote",
+            "modifiers": {}
+          },
+          "to": [
+            {
+              "key_code": "quote",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/niz_kb75_fix_quotes_colon.json.js
+++ b/src/json/niz_kb75_fix_quotes_colon.json.js
@@ -1,0 +1,117 @@
+function main() {
+  console.log(
+    JSON.stringify(
+      {
+        title: 'Plum Nano 75 Bluetooth NiZ KB75 75EC-XRGB (fix quotes and semicolon)',
+        maintainers: ['orkoden'],  
+        rules: [
+          {
+            "description": " KB75 75EC-XRGB CATEX TECH. (fix quotes and semicolon)",
+            "manipulators": [
+              {
+                "conditions": [
+                  {
+                    "identifiers": [
+                      {
+                        "product_id": 20518,
+                        "vendor_id": 1155
+                      }
+                    ],
+                    "type": "device_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "semicolon",
+                  "modifiers": { "mandatory": ["left_shift"] }
+                },
+                "to": [
+                  {
+                    "key_code": "semicolon",
+                    "modifiers": []
+                  }
+                ],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "identifiers": [
+                      {
+                        "product_id": 20518,
+                        "vendor_id": 1155
+                      }
+                    ],
+                    "type": "device_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "semicolon",
+                  "modifiers": {}
+                },
+                "to": [
+                  {
+                    "key_code": "semicolon",
+                    "modifiers": ["left_shift"]
+                  }
+                ],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "identifiers": [
+                      {
+                        "product_id": 20518,
+                        "vendor_id": 1155
+                      }
+                    ],
+                    "type": "device_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "quote",
+                  "modifiers": { "mandatory": ["left_shift"] }
+                },
+                "to": [
+                  {
+                    "key_code": "quote",
+                    "modifiers": []
+                  }
+                ],
+                "type": "basic"
+              },
+              {
+                "conditions": [
+                  {
+                    "identifiers": [
+                      {
+                        "product_id": 20518,
+                        "vendor_id": 1155
+                      }
+                    ],
+                    "type": "device_if"
+                  }
+                ],
+                "from": {
+                  "key_code": "quote",
+                  "modifiers": {}
+                },
+                "to": [
+                  {
+                    "key_code": "quote",
+                    "modifiers": ["left_shift"]
+                  }
+                ],
+                "type": "basic"
+              }
+            ]
+          }
+        ]
+      },
+      null,
+      '  '
+    )
+  )
+}
+  
+main()


### PR DESCRIPTION
### Plum Nano 75 Bluetooth NiZ KB75 75EC-XRGB (fix quotes and semicolon)

This keyboard was first available under the brand name [Plum Nano 75](https://drop.com/buy/plum-nano-75-bluetooth-electro-capacitive-mechanical-keyboard) and later changed to [NiZ](hbuttonps://www.NiZkeyboard.com) KB75 75EC-XRGB. It identifies its vendor as CATEX TECH.

The firmware has a bug with switched keys. Pressing the ; results in a : on screen. The keyboard actually sends ⇧ Shift left+; to the computer. Consequently you have to press ⇧ Shift+; to get a ;. The same applies for ' and ".

This modification fixes this to work like most normal keyboards.


| Key Press | Character |
| --- | --- |
| ;   | ;   |
| ⇧ Shift+; | :   |
| '   | '   |
| ⇧ Shift+' | "   |