### PR TITLE
Readme add key tag make all

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Follow the steps below to create a PR and add your settings!
     If you placed a generator file into `src/json`, json file will be generated in the `public/json` by this command.
 
     ```shell
-    make
+    make all
     ```
 
     If there is a problem, an error message is displayed. Fix your files until no errors are shown.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Follow the steps below to create a PR and add your settings!
     },
     ```
 
+    You can use the tag `<button>⇧Shift</button>` to make a nice <button>⇧Shift</button> in your html.
     </details>
 
 6.  Run `make` command in Terminal to validate your files.<br/>


### PR DESCRIPTION
Adds a hint to use the html tag `<button>` for nicer buttons in html. 

Changed `make` to `make all` because just `make` didn't work for me the first time I ran it.