### PR TITLE
Update README (<button> to <kbd>)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Follow the steps below to create a PR and add your settings!
     },
     ```
 
-    You can use the tag `<button>⇧Shift</button>` to make a nice <button>⇧Shift</button> in your html.
+    You can use the tag `<kbd>⇧Shift</kbd>` to make a nice <kbd>⇧Shift</kbd> in your html.
     </details>
 
 6.  Run `make` command in Terminal to validate your files.<br/>


### PR DESCRIPTION
The `<kbd>` tag is more appropriate, so while it's not mandatory, I think it would be better to use this one if possible.
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd

Example:
https://ke-complex-modifications.pqrs.org/#personal_tekezo