### PR TITLE
Bind the key SLASH (/) on the US keyboard on any keyboard (configuration is for Swiss French keyboard)

### DIFF
--- a/public/json/bind_unexistant_key_slash_on_swiss_keyboard.json
+++ b/public/json/bind_unexistant_key_slash_on_swiss_keyboard.json
@@ -1,0 +1,22 @@
+{
+  "title": "Bind unexistant key Slash (/) on Swiss KeyBoards (by using US keyboard for just one key)",
+  "rules": [
+    {
+      "description": "§ to / for Swiss Keyboards",
+      "enabled": false,
+      "manipulators": [
+        {
+          "from": { "key_code": "non_us_backslash" },
+          "parameters": {
+            "basic.to_if_alone_timeout_milliseconds": 10,
+            "basic.to_if_held_down_threshold_milliseconds": 10
+          },
+          "to": { "select_input_source": { "input_source_id": "com.apple.keylayout.US" } },
+          "to_after_key_up": { "select_input_source": { "input_source_id": "com.apple.keylayout.SwissFrench" } },
+          "to_if_held_down": [{ "key_code": "slash" }],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This code provides a smart solution to bind the Slash key (/) on Swiss keyboards, which don’t have a dedicated key for it, by temporarily switching to the US keyboard layout when pressing the key mapped to §. Here’s why I think it’s awesome:

	1.	Smart Key Remapping: I’ve tackled the common frustration for Swiss keyboard users who need quick access to the Slash key. By using the § key, which is often underused, I’ve mapped it to / when held down, creating a fluid and efficient workaround.
	2.	Dynamic Layout Switching: The code dynamically switches between the Swiss and US keyboard layouts. When § is pressed, it temporarily switches to the US layout, grabs the Slash key, and then reverts back to the Swiss layout upon key release. This preserves the overall integrity of the Swiss layout while solving a specific problem.
	3.	Precise Time Thresholds: I’ve set tight timeouts (10 milliseconds), so the key press behaves naturally, preventing accidental key holds from causing layout changes. This ensures the user experience remains smooth without interruptions.
	4.	User-Friendly Toggle: I made this feature optional by allowing it to be toggled via the "enabled": false flag, so users can control when they want the key remap to be active.

After spending like 3 hours trying to find a way to use the Slash / shortcut in Zoho apps (Zoho Projects for example), which is the shortcut for search. I realized it wasn’t working with a basic Karabiner configuration or a JavaScript shortcut in Mac OS X. So, here it is—this solution works, and I hope it helps others facing the same issue.