### PR TITLE
Create rule to send Fn + Fx instead of Fx unless builtin keyboard

### DIFF
--- a/public/extra_descriptions/f_keys_to_fn_f_keys_unless_builtin.json.html
+++ b/public/extra_descriptions/f_keys_to_fn_f_keys_unless_builtin.json.html
@@ -1,0 +1,10 @@
+<link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
+
+<h4>Description</h4>
+<h5>Send Fn + Function keys for external keyboards.</h5>
+
+<h4>Notes</h4>
+<p>From v15.2.0 of Karabiner Element the F1-F12 key events sent by Karabiner-Elements, macOS will convert them once again into media keys (e.g., sending F10 will trigger mute).
+    <br/> If you want to send F1-F12 as-is using Complex Modifications, you will need to send fn+F1-F12 through Karabiner-Elements.
+    <br/> This rule will send the F1-F12 keys as if you were pressing the fn key on an external keyboard.
+</p>

--- a/public/groups.json
+++ b/public/groups.json
@@ -674,6 +674,10 @@
         },
         {
           "path": "json/caps_lock_bepo_tsrn.json"
+        },
+        {
+          "path": "json/f_keys_to_fn_f_keys_unless_builtin.json",
+          "extra_description_path": "extra_descriptions/f_keys_to_fn_f_keys_unless_builtin.json.html"
         }
       ]
     },

--- a/public/json/f_keys_to_fn_f_keys_unless_builtin.json
+++ b/public/json/f_keys_to_fn_f_keys_unless_builtin.json
@@ -1,0 +1,202 @@
+{
+    "title": "Send Fn + Function key instead of Function key unless builtin",
+    "rules": [
+        {
+            "description": "Rule: Fn + Fx instead of Fx unless builtin",
+            "manipulators": [
+                {
+                    "conditions": [
+                        {
+                            "identifiers": [{ "is_built_in_keyboard": true }],
+                            "type": "device_unless"
+                        }
+                    ],
+                    "from": { "key_code": "f1" },
+                    "to": [
+                        {
+                            "key_code": "f1",
+                            "modifiers": ["fn"]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "identifiers": [{ "is_built_in_keyboard": true }],
+                            "type": "device_unless"
+                        }
+                    ],
+                    "from": { "key_code": "f2" },
+                    "to": [
+                        {
+                            "key_code": "f2",
+                            "modifiers": ["fn"]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "identifiers": [{ "is_built_in_keyboard": true }],
+                            "type": "device_unless"
+                        }
+                    ],
+                    "from": { "key_code": "f3" },
+                    "to": [
+                        {
+                            "key_code": "f3",
+                            "modifiers": ["fn"]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "identifiers": [{ "is_built_in_keyboard": true }],
+                            "type": "device_unless"
+                        }
+                    ],
+                    "from": { "key_code": "f4" },
+                    "to": [
+                        {
+                            "key_code": "f4",
+                            "modifiers": ["fn"]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "identifiers": [{ "is_built_in_keyboard": true }],
+                            "type": "device_unless"
+                        }
+                    ],
+                    "from": { "key_code": "f5" },
+                    "to": [
+                        {
+                            "key_code": "f5",
+                            "modifiers": ["fn"]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "identifiers": [{ "is_built_in_keyboard": true }],
+                            "type": "device_unless"
+                        }
+                    ],
+                    "from": { "key_code": "f6" },
+                    "to": [
+                        {
+                            "key_code": "f6",
+                            "modifiers": ["fn"]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "identifiers": [{ "is_built_in_keyboard": true }],
+                            "type": "device_unless"
+                        }
+                    ],
+                    "from": { "key_code": "f7" },
+                    "to": [
+                        {
+                            "key_code": "f7",
+                            "modifiers": ["fn"]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "identifiers": [{ "is_built_in_keyboard": true }],
+                            "type": "device_unless"
+                        }
+                    ],
+                    "from": { "key_code": "f8" },
+                    "to": [
+                        {
+                            "key_code": "f8",
+                            "modifiers": ["fn"]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "identifiers": [{ "is_built_in_keyboard": true }],
+                            "type": "device_unless"
+                        }
+                    ],
+                    "from": { "key_code": "f9" },
+                    "to": [
+                        {
+                            "key_code": "f9",
+                            "modifiers": ["fn"]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "identifiers": [{ "is_built_in_keyboard": true }],
+                            "type": "device_unless"
+                        }
+                    ],
+                    "from": { "key_code": "f10" },
+                    "to": [
+                        {
+                            "key_code": "f10",
+                            "modifiers": ["fn"]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "identifiers": [{ "is_built_in_keyboard": true }],
+                            "type": "device_unless"
+                        }
+                    ],
+                    "from": { "key_code": "f11" },
+                    "to": [
+                        {
+                            "key_code": "f11",
+                            "modifiers": ["fn"]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "identifiers": [{ "is_built_in_keyboard": true }],
+                            "type": "device_unless"
+                        }
+                    ],
+                    "from": { "key_code": "f12" },
+                    "to": [
+                        {
+                            "key_code": "f12",
+                            "modifiers": ["fn"]
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
From v15.2.0 of Karabiner Element the F1-F12 key events sent by Karabiner-Elements, macOS will convert them once again into media keys (e.g., sending F10 will trigger mute).
This rule will send the F1-F12 keys as if you were pressing the fn key on an external keyboard.