### PR TITLE
Google Chrome URL copy with command + shift + C

### DIFF
--- a/public/json/chrome-url-copy.json
+++ b/public/json/chrome-url-copy.json
@@ -1,0 +1,53 @@
+{
+  "title": "Google Chrome URL Copy",
+  "maintainers": [
+    "doxxx93"
+  ],
+  "rules": [
+    {
+      "description": "Google Chrome: Command + Shift + C → Copy URL and unfocus address bar",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.google\\.Chrome$"
+              ]
+            }
+          ],
+          "type": "basic",
+          "from": {
+            "key_code": "c",
+            "modifiers": {
+              "mandatory": [
+                "command",
+                "shift"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "l",
+              "modifiers": [
+                "command"
+              ]
+            },
+            {
+              "key_code": "c",
+              "modifiers": [
+                "command"
+              ]
+            },
+            {
+              "key_code": "escape"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This pull request introduces a new JSON configuration file for a Google Chrome URL copy shortcut. The file defines a custom keyboard shortcut for copying the URL and unfocusing the address bar in Google Chrome.

Key changes include:

* [`public/json/chrome-url-copy.json`](diffhunk://#diff-7fe7051a154794aeaccb7fe1cbbb559e99c746315b6a5e627edea143550ebeaaR1-R53): Added a new configuration file that specifies a keyboard shortcut (Command + Shift + C) to copy the URL and unfocus the address bar in Google Chrome. This includes the title, maintainers, and detailed rules for the shortcut.

Adds a convenient shortcut to copy the current URL in Chromium-based browsers:
- Press Command+Shift+C to copy the current URL
- Automatically returns focus to the page content
- Works in Chrome, Chrome Canary, Edge, Brave, and Chromium