### PR TITLE
Fix PC-Style Lock Screen

### DIFF
--- a/public/json/Pc_Style_Shortcuts_HarunMod.json
+++ b/public/json/Pc_Style_Shortcuts_HarunMod.json
@@ -2228,10 +2228,10 @@
           },
           "to": [
             {
-              "key_code": "power",
+              "key_code": "q",
               "modifiers": [
                 "left_control",
-                "left_shift"
+                "left_command"
               ]
             }
           ],


### PR DESCRIPTION
The Control+Shift+Power does not work properly on my macOS Sonoma 14.5 with only PC-Style Shortcuts enabled in Karabiner 14.13.0. Using Control+Command+q fixes the issue for me and locks the screen properly.