### PR TITLE
[Update] Second tap on SandS etc. will not input modifier key

### DIFF
--- a/public/json/om_fn_to_esc.json
+++ b/public/json/om_fn_to_esc.json
@@ -6,10 +6,47 @@
       "manipulators": [
         {
           "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "fn-esc",
+              "value": 1
+            }
+          ],
           "from": {
             "key_code": "fn",
             "modifiers": {
               "optional": [
+                "shift",
+                "option",
+                "control",
+                "command",
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "fn",
+              "lazy": true
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "escape"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "fn",
+            "modifiers": {
+              "optional": [
+                "shift",
+                "option",
+                "control",
+                "command",
                 "caps_lock"
               ]
             }
@@ -22,8 +59,32 @@
           "to_if_alone": [
             {
               "key_code": "escape"
+            },
+            {
+              "set_variable": {
+                "name": "fn-esc",
+                "value": 1
+              }
             }
-          ]
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "fn-esc",
+                  "value": 0
+                }
+              }
+            ],
+            "to_if_canceled": [
+              {
+                "set_variable": {
+                  "name": "fn-esc",
+                  "value": 0
+                }
+              }
+            ]
+          }
         }
       ]
     }

--- a/public/json/om_personal_rules.json
+++ b/public/json/om_personal_rules.json
@@ -93,6 +93,39 @@
       "manipulators": [
         {
           "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "shift-space",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "spacebar",
+            "modifiers": {
+              "optional": [
+                "shift",
+                "option",
+                "control",
+                "command",
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_shift",
+              "lazy": true
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "spacebar"
+            }
+          ]
+        },
+        {
+          "type": "basic",
           "from": {
             "key_code": "spacebar",
             "modifiers": {
@@ -113,8 +146,32 @@
           "to_if_alone": [
             {
               "key_code": "spacebar"
+            },
+            {
+              "set_variable": {
+                "name": "shift-space",
+                "value": 1
+              }
             }
-          ]
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "shift-space",
+                  "value": 0
+                }
+              }
+            ],
+            "to_if_canceled": [
+              {
+                "set_variable": {
+                  "name": "shift-space",
+                  "value": 0
+                }
+              }
+            ]
+          }
         },
         {
           "type": "basic",
@@ -138,6 +195,39 @@
       "manipulators": [
         {
           "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "control-return",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "return_or_enter",
+            "modifiers": {
+              "optional": [
+                "shift",
+                "option",
+                "control",
+                "command",
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_control",
+              "lazy": true
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "return_or_enter"
+            }
+          ]
+        },
+        {
+          "type": "basic",
           "from": {
             "key_code": "return_or_enter",
             "modifiers": {
@@ -158,8 +248,32 @@
           "to_if_alone": [
             {
               "key_code": "return_or_enter"
+            },
+            {
+              "set_variable": {
+                "name": "control-return",
+                "value": 1
+              }
             }
-          ]
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "control-return",
+                  "value": 0
+                }
+              }
+            ],
+            "to_if_canceled": [
+              {
+                "set_variable": {
+                  "name": "control-return",
+                  "value": 0
+                }
+              }
+            ]
+          }
         },
         {
           "type": "basic",
@@ -641,6 +755,38 @@
       "manipulators": [
         {
           "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "command-eisuu",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "left_command",
+            "modifiers": {
+              "optional": [
+                "shift",
+                "option",
+                "control",
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_command",
+              "lazy": true
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "japanese_eisuu"
+            }
+          ]
+        },
+        {
+          "type": "basic",
           "from": {
             "key_code": "left_command",
             "modifiers": {
@@ -660,6 +806,62 @@
           "to_if_alone": [
             {
               "key_code": "japanese_eisuu"
+            },
+            {
+              "set_variable": {
+                "name": "command-eisuu",
+                "value": 1
+              }
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "command-eisuu",
+                  "value": 0
+                }
+              }
+            ],
+            "to_if_canceled": [
+              {
+                "set_variable": {
+                  "name": "command-eisuu",
+                  "value": 0
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "command-kana",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "right_command",
+            "modifiers": {
+              "optional": [
+                "shift",
+                "option",
+                "control",
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_command",
+              "lazy": true
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "japanese_kana"
             }
           ]
         },
@@ -684,8 +886,32 @@
           "to_if_alone": [
             {
               "key_code": "japanese_kana"
+            },
+            {
+              "set_variable": {
+                "name": "command-kana",
+                "value": 1
+              }
             }
-          ]
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "command-kana",
+                  "value": 0
+                }
+              }
+            ],
+            "to_if_canceled": [
+              {
+                "set_variable": {
+                  "name": "command-kana",
+                  "value": 0
+                }
+              }
+            ]
+          }
         }
       ]
     },


### PR DESCRIPTION
Updated my settings.
Please review.

- Changed so that the second tap on SandS etc. will not input modifier key.
