### PR TITLE
Fix description in SIGKILL frontmost application

### DIFF
--- a/public/json/SIGKILL_frontmost_application.json
+++ b/public/json/SIGKILL_frontmost_application.json
@@ -3,7 +3,7 @@
 
     "rules": [
 	{
-	    "description": "Saves you from having to reset the computer if e.g. a program has captured the screen and hangs. It does so by sending the SIGKILL signal to the frontmost application. Note: Macos already has a similar keybinding: Press Shift+Ctrl+Cmd+Esc for three seconds. However the built-in keybinding only sends SIGTERM, which doesn't always work, for instance if the program has a signal handler or runs in a debugger.",
+	    "description": "Saves you from having to reset the computer if e.g. a program has captured the screen and hangs. It does so by sending the SIGKILL signal to the frontmost application. Note: Macos already has a similar keybinding: Press Shift+Option+Cmd+Esc for three seconds. However the built-in keybinding only sends SIGTERM, which doesn't always work, for instance if the program has a signal handler or runs in a debugger.",
 	    
 	    "manipulators": [
 		{


### PR DESCRIPTION
Learned a shortcut from this rule, but as can been seen in the following screenshot the native shortcut for force quitting apps is Shift+_Option_+Cmd+Esc, not Ctrl:

![CleanShot 2024-12-21 at 19 26 53@2x](https://github.com/user-attachments/assets/c7d4d4c9-1c9c-4425-84a9-e3a855fc1ccb)
