### PR TITLE
New rule to swap right_command with right_option

### DIFF
--- a/public/json/swap_right_command_and_right_option.json  
+++ b/public/json/swap_right_command_and_right_option.json  
@@ -1,0 +1,35 @@
+{
+  "title": "Swap Right Command and Right Option globally",
+  "maintainers": [
+    "mircobabini"
+  ],
+  "rules": [
+    {
+      "description": "Swap Right Command and Right Option for all keyboards.",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_command"
+          },
+          "to": [
+            {
+              "key_code": "right_option"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_option"
+          },
+          "to": [
+            {
+              "key_code": "right_command"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This is particuraly useful if you use a windows-alike external keyboard on mac, or a win/mac keyboard like:

![image](https://github.com/user-attachments/assets/1039c369-8ecf-4d0e-8988-5fd6988c79f7)
This is the Logitech MX Keys S. 

So, the right OPTION key is too far from the command, which is not familier with mac default keyboard. So it's pretty hard for  a mac user to hit right_command+ò to insert the @ (at symbol).

This basically switched the right_command to the right_option, and reverse.