### PR TITLE
Add fn+open_bracket to page_up

### DIFF
--- a/public/json/exchange_vertical_bar_pipe_and_backslash.json
+++ b/public/json/exchange_vertical_bar_pipe_and_backslash.json
@@ -1,5 +1,8 @@
 {
     "title": "Exchange vertical bar pipe (|) and backslash (\\)",
+    "maintainers": [
+        "duleorlovic"
+    ],
     "rules": [
         {
             "description": "Exchange vertical bar pipe (|) and backslash (\\)",

--- a/public/json/fn_open_bracket_to_page_up.json
+++ b/public/json/fn_open_bracket_to_page_up.json
@@ -1,0 +1,35 @@
+{
+    "title": "Exchange vertical bar pipe (|) and backslash (\\)",
+    "maintainers": [
+        "duleorlovic"
+    ],
+    "rules": [
+        {
+            "description": "fn+open_bracket/close_bracket to page up/page down",
+            "manipulators": [
+                {
+                    "from": {
+                        "key_code": "open_bracket",
+                        "modifiers": {
+                            "mandatory": ["fn"],
+                            "optional": ["any"]
+                        }
+                    },
+                    "to": [{ "key_code": "page_down" }],
+                    "type": "basic"
+                },
+                {
+                    "from": {
+                        "key_code": "close_bracket",
+                        "modifiers": {
+                            "mandatory": ["fn"],
+                            "optional": ["any"]
+                        }
+                    },
+                    "to": [{ "key_code": "page_up" }],
+                    "type": "basic"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Not sure why mac keyboard does not have page up and page down.
This will enable page up (or down) with fn + [ (or ])