### PR TITLE
Add macOS scripts for AltTab and closing applications

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -444,9 +444,6 @@
         {
           "path": "json/caps_lock_debug_various_ides.json",
           "extra_description_path": "extra_descriptions/caps_lock_debug_various_ides.html"
-        },
-        {
-          "path": "json/swap_command_tab_and_option_tab.json"
         }
       ]
     },

--- a/public/groups.json
+++ b/public/groups.json
@@ -181,6 +181,12 @@
         {
           "path": "json/command_hjkl_to_activate_windows.json",
           "extra_description_path": "extra_descriptions/command_hjkl_to_activate_windows.json.html"
+        },
+        {
+          "path": "json/option+x_to_close_on_macos.json"
+        },
+        {
+          "path": "json/swap_command_tab_and_option_tab.json"
         }
       ]
     },
@@ -438,6 +444,9 @@
         {
           "path": "json/caps_lock_debug_various_ides.json",
           "extra_description_path": "extra_descriptions/caps_lock_debug_various_ides.html"
+        },
+        {
+          "path": "json/swap_command_tab_and_option_tab.json"
         }
       ]
     },

--- a/public/json/option+x_to_close_on_macos.json
+++ b/public/json/option+x_to_close_on_macos.json
@@ -1,0 +1,32 @@
+{
+    "title": "Easy close apps (option+x) on macOS",
+    "maintainers": [
+        "SergioInToronto"
+    ],
+    "rules": [
+        {
+            "description": "Remap option+x to command+q, to close applications on macOS.",
+            "manipulators": [
+                {
+                    "from": {
+                        "key_code": "x",
+                        "modifiers": {
+                            "mandatory": [
+                                "left_option"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "q",
+                            "modifiers": [
+                                "command"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        }
+    ]
+}

--- a/public/json/swap_command_tab_and_option_tab.json
+++ b/public/json/swap_command_tab_and_option_tab.json
@@ -1,0 +1,52 @@
+{
+    "title": "Swap \"command + tab\" with \"option + tab\" (Compatibility for AltTab app)",
+    "maintainers": [
+        "SergioInToronto"
+    ],
+    "rules": [
+        {
+            "description": "Swap \"command + tab\" with \"option + tab\"",
+            "_todo": "Would be nice to swap command+shift with option+shift as well, but didn't seem to work since shift is a modifier",
+            "manipulators": [
+                {
+                    "from": {
+                        "key_code": "tab",
+                        "modifiers": {
+                            "mandatory": [
+                                "command"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "tab",
+                            "modifiers": [
+                                "option"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "from": {
+                        "key_code": "tab",
+                        "modifiers": {
+                            "mandatory": [
+                                "option"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "tab",
+                            "modifiers": [
+                                "command"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        }
+    ]
+}

--- a/public/json/swap_command_tab_and_option_tab.json
+++ b/public/json/swap_command_tab_and_option_tab.json
@@ -5,8 +5,7 @@
     ],
     "rules": [
         {
-            "description": "Swap \"command + tab\" with \"option + tab\"",
-            "_todo": "Would be nice to swap command+shift with option+shift as well, but didn't seem to work since shift is a modifier",
+            "description": "Swap \"command + tab\" with \"option + tab\" (Compatibility for AltTab app)",
             "manipulators": [
                 {
                     "from": {
@@ -41,6 +40,46 @@
                             "key_code": "tab",
                             "modifiers": [
                                 "command"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "from": {
+                        "key_code": "left_shift",
+                        "modifiers": {
+                            "mandatory": [
+                                "left_command"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "left_shift",
+                            "modifiers": [
+                                "left_option"
+                            ]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "from": {
+                        "key_code": "tab",
+                        "modifiers": {
+                            "mandatory": [
+                                "left_option",
+                                "left_shift"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "tab",
+                            "modifiers": [
+                                "left_command",
+                                "left_shift"
                             ]
                         }
                     ],


### PR DESCRIPTION
1. A popular macOS app, [AltTab](https://alt-tab-macos.netlify.app/), replaces macOS's default application switcher. It's much better, but macOS prevents using command+tab as the hotkey. This modification solves that.

2. On other OSes I use super+x to close windows. It's way more convenient than alt+f4. Bring that to macOS too.