### PR TITLE
Add Caps Lock to debug in various IDEs

### DIFF
--- a/public/extra_descriptions/caps_lock_debug_various_ides.html
+++ b/public/extra_descriptions/caps_lock_debug_various_ides.html
@@ -1,0 +1,53 @@
+<link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
+
+<h2>Caps Lock to Debug in Various IDE</h2>
+
+<p>Use the same keyboard shortcuts to debug across various IDEs. Hold the Caps Lock key and press the other key to perform the action.</p>
+
+<h3>Mapping</h3>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">Key</th>
+      <th scope="col">Maps To</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><kbd>⇪ Caps Lock</kbd> + <kbd>↓ Down Arrow</kbd></td>
+      <td>Step Over</td>
+    </tr>
+    <tr>
+      <td><kbd>⇪ Caps Lock</kbd> + <kbd>← Left Arrow</kbd></td>
+      <td>Step Out</td>
+    </tr>
+    <tr>
+      <td><kbd>⇪ Caps Lock</kbd> + <kbd>→ Right Arrow</kbd></td>
+      <td>Step In</td>
+    </tr>
+    <tr>
+      <td><kbd>⇪ Caps Lock</kbd> + <kbd>↵ Enter</kbd></td>
+      <td>Continue</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3>Supported IDEs</h3>
+<ul>
+  <li>Xcode</li>
+  <li>Intellij</li>
+  <li>Visual Studio Code (VSCode)</li>
+</ul>
+
+<h3>Change Log</h3>
+
+<dl>
+  <dt>Revision 1</dt>
+  <dd>Add support for Xcode, Intellij, and VSCode</dd>
+</dl>
+
+<h3>Modifications</h3>
+
+<p>Feel free to add other IDEs that they want.</p>
+

--- a/public/groups.json
+++ b/public/groups.json
@@ -434,6 +434,10 @@
         {
           "path": "json/powerpoint.json",
           "extra_description_path": "extra_descriptions/powerpoint.json.html"
+        },
+        {
+          "path": "json/caps_lock_debug_various_ides.json",
+          "extra_description_path": "extra_descriptions/caps_lock_debug_various_ides.html"
         }
       ]
     },

--- a/public/json/caps_lock_debug_various_ides.json
+++ b/public/json/caps_lock_debug_various_ides.json
@@ -1,0 +1,281 @@
+{
+    "title": "Caps Lock to Debug in Various IDEs",
+    "description": "Map Caps Lock to Debugger Commands for IDEs such as Xcode, Intellij, and Visual Studio Code (VSCode). Current support: Step Over, Step In, Step Out, Continue",
+    "author": "Aung David Moe",
+    "maintainers": ["logicxd"],
+    "rules": [
+        {
+            "description": "Caps Lock + Down Arrow -> Step Over",
+            "manipulators": [
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.apple\\.dt\\.Xcode$"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "down_arrow",
+                        "modifiers": { "mandatory": ["caps_lock"] }
+                    },
+                    "to": [
+                        {
+                            "key_code": "f6",
+                            "modifiers": ["fn"]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.jetbrains\\.intellij$"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "down_arrow",
+                        "modifiers": { "mandatory": ["caps_lock"] }
+                    },
+                    "to": [
+                        {
+                            "key_code": "f8",
+                            "modifiers": ["fn"]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.microsoft\\.VSCode$"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "down_arrow",
+                        "modifiers": { "mandatory": ["caps_lock"] }
+                    },
+                    "to": [
+                        {
+                            "key_code": "f10",
+                            "modifiers": ["fn"]
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "Caps Lock + Right Arrow -> Step In",
+            "manipulators": [
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.apple\\.dt\\.Xcode$"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "right_arrow",
+                        "modifiers": { "mandatory": ["caps_lock"] }
+                    },
+                    "to": [
+                        {
+                            "key_code": "f7",
+                            "modifiers": ["fn"]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.jetbrains\\.intellij$"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "right_arrow",
+                        "modifiers": { "mandatory": ["caps_lock"] }
+                    },
+                    "to": [
+                        {
+                            "key_code": "f7",
+                            "modifiers": ["fn"]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.microsoft\\.VSCode$"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "right_arrow",
+                        "modifiers": { "mandatory": ["caps_lock"] }
+                    },
+                    "to": [
+                        {
+                            "key_code": "f11",
+                            "modifiers": ["fn"]
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "Caps Lock + Left Arrow -> Step Out",
+            "manipulators": [
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.apple\\.dt\\.Xcode$"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "left_arrow",
+                        "modifiers": { "mandatory": ["caps_lock"] }
+                    },
+                    "to": [
+                        {
+                            "key_code": "f8",
+                            "modifiers": ["fn"]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.jetbrains\\.intellij$"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "left_arrow",
+                        "modifiers": { "mandatory": ["caps_lock"] }
+                    },
+                    "to": [
+                        {
+                            "key_code": "f8",
+                            "modifiers": ["fn", "shift"]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.microsoft\\.VSCode$"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "left_arrow",
+                        "modifiers": { "mandatory": ["caps_lock"] }
+                    },
+                    "to": [
+                        {
+                            "key_code": "f11",
+                            "modifiers": ["fn", "shift"]
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        },
+        {
+            "description": "Caps Lock + Enter -> Continue",
+            "manipulators": [
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.apple\\.dt\\.Xcode$"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "return_or_enter",
+                        "modifiers": { "mandatory": ["caps_lock"] }
+                    },
+                    "to": [
+                        {
+                            "key_code": "y",
+                            "modifiers": ["left_command", "left_control"]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.jetbrains\\.intellij$"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "return_or_enter",
+                        "modifiers": { "mandatory": ["caps_lock"] }
+                    },
+                    "to": [
+                        {
+                            "key_code": "f9",
+                            "modifiers": ["fn"]
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "bundle_identifiers": [
+                                "^com\\.microsoft\\.VSCode$"
+                            ],
+                            "type": "frontmost_application_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "return_or_enter",
+                        "modifiers": { "mandatory": ["caps_lock"] }
+                    },
+                    "to": [
+                        {
+                            "key_code": "f5",
+                            "modifiers": ["fn"]
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        }
+    ]
+    
+}


### PR DESCRIPTION
## Description

Map Caps Lock to Debugger Commands for IDEs such as Xcode, Intellij, and Visual Studio Code (VSCode). Current support: Step Over, Step In, Step Out, Continue

## Screenshots

<img width=450 src='https://github.com/user-attachments/assets/638ca5dc-d01b-4a01-83ca-5e4ba4c0a29b'>

<img width=450 src='https://github.com/user-attachments/assets/3751776a-9362-48e3-90c6-07d9850c645d'>

<img width=450 src='https://github.com/user-attachments/assets/fdf54eca-8c3d-4dda-9d69-4ce2c0843701'>

## Tested

1. On all 3 IDEs that the commands work
2. Checked out changes with `make preview-server` and applied to Karabiner 
