### PR TITLE
feat(*): add swap ctrl shift with ctrl space func

### DIFF
--- a/public/json/swap_ctrl_shift_with_ctrl_space.json
+++ b/public/json/swap_ctrl_shift_with_ctrl_space.json
@@ -1,0 +1,29 @@
+{
+  "title": "Swap Ctrl+Shift with Ctrl+Space for Input Source Switching",
+  "rules": [
+    {
+      "description": "Remaps the keyboard shortcut for input source switching, swapping Ctrl+Shift with Ctrl+Space for easier language switching.",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "left_shift",
+            "modifiers": {
+              "mandatory": [
+                "left_control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "spacebar",
+              "modifiers": [
+                "control"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/swap_ctrl_shift_with_ctrl_space.json.js
+++ b/src/json/swap_ctrl_shift_with_ctrl_space.json.js
@@ -1,0 +1,36 @@
+// JavaScript should be written in ECMAScript 5.1.
+
+function main() {
+    console.log(
+      JSON.stringify(
+        {
+          title: 'Swap Ctrl+Shift with Ctrl+Space for Input Source Switching',
+          rules: [
+            {
+                "description": "Remaps the keyboard shortcut for input source switching, swapping Ctrl+Shift with Ctrl+Space for easier language switching.",
+                "manipulators": [
+                    {
+                        "from": {
+                            "key_code": "left_shift",
+                            "modifiers": { "mandatory": ["left_control"] }
+                        },
+                        "to": [
+                            {
+                                "key_code": "spacebar",
+                                "modifiers": ["control"]
+                            }
+                        ],
+                        "type": "basic"
+                    }
+                ]
+            }
+          ],
+        },
+        null,
+        '  '
+      )
+    )
+  }
+  
+  main()
+  


### PR DESCRIPTION
This function remaps the default keyboard shortcut for switching input sources on macOS, making it more convenient for Vietnamese users familiar with input methods like VietKey. It swaps the Ctrl+Shift combination with Ctrl+Space to streamline language switching and enhance typing efficiency.