### PR TITLE
add toggling Kotoeri punctual style with control period

### DIFF
--- a/public/json/toggle_kotoeri_punctualstyle.json
+++ b/public/json/toggle_kotoeri_punctualstyle.json
@@ -1,0 +1,29 @@
+{
+    "title": "Toggle Kotoeri punctuation style",
+    "rules": [
+        {
+            "description": "Toggle Kotoeri's punctuation style with control + period",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "period",
+                        "modifiers": {
+                            "mandatory": [
+                                "control"
+                            ],
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "shell_command": "osascript -e 'try' -e '  set current to do shell script \"defaults read com.apple.inputmethod.Kotoeri JIMPrefPunctuationTypeKey\"' -e 'on error' -e '  set current to \"0\"' -e 'end try' -e 'if current = \"3\" then' -e '  do shell script \"defaults write com.apple.inputmethod.Kotoeri JIMPrefPunctuationTypeKey -int 0\"' -e 'else' -e '  do shell script \"defaults write com.apple.inputmethod.Kotoeri JIMPrefPunctuationTypeKey -int 3\"' -e 'end if' -e 'do shell script \"killall -HUP JapaneseIM-RomajiTyping\"' -e 'tell application \"System Events\" to key code 56'"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This is a configuration file that allows you to easily switch the punctuation style ([，．] / [、。]) in Kotoeri using the Control + Period shortcut. Since Apple does not officially provide an API for this, it runs a somewhat tricky script. It has been tested on macOS Sequoia 15.1.1, but it may not work properly on older versions.