### PR TITLE
feat: add korean won to backtick with shortcut preserved

### DIFF
--- a/public/extra_descriptions/korean_won_to_backtick_with_shortcut_preserved.html
+++ b/public/extra_descriptions/korean_won_to_backtick_with_shortcut_preserved.html
@@ -1,0 +1,16 @@
+<link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
+<base target="_top">
+
+<h3>Korean Won (₩) to Backtick (`) with shortcut preserved</h3>
+
+<p>
+	MacOS의 <b>단축키 사용의 영향 없이</b>, ₩ 키를 ` 키로 변경합니다.<br>
+    오직 단일로 ₩ 키를 눌렀을 때만, ` ( + ⌥ left_option ) 키로 변경됩니다.<br>
+    다른 키와 조합하여 ₩ 키를 눌렀을 때는, ₩ 키로 남아 단축키에 영향을 주지 않습니다.<br>
+</p>
+
+<ul>
+	<li><code>₩</code> -> <code>` ( + ⌥ left_option )</code></li>
+	<li><code>⌘ command + ₩</code>  -> <code>⌘ command + ` <del>( + ⌥ left_option )</del></code></li>
+    <li><code>Other keys + ₩</code> -> <code>Other keys + `</code></li>
+</ul>

--- a/public/groups.json
+++ b/public/groups.json
@@ -1150,6 +1150,10 @@
           "path": "json/caps_lock_toggle_korean_english_include_parallels.json"
         },
         {
+          "path": "json/korean_won_to_backtick_with_shortcut_preserved.json",
+          "extra_description_path": "extra_descriptions/korean_won_to_backtick_with_shortcut_preserved.html"
+        },
+        {
           "path": "json/korean_won_to_backtick.json"
         },
         {

--- a/public/json/korean_won_to_backtick_with_shortcut_preserved.json
+++ b/public/json/korean_won_to_backtick_with_shortcut_preserved.json
@@ -1,0 +1,40 @@
+{
+  "title": "Korean Won (₩) to Backtick (`) with shortcut preserved",
+  "maintainers": [
+    "sts07142"
+  ],
+  "rules": [
+    {
+      "description": "(₩) -> (`) 으로 변환하며, (`) 을 포함한 단축키 사용에 영향을 주지 않습니다.",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "ko"
+                }
+              ],
+              "type": "input_source_if"
+            }
+          ],
+          "from": {
+            "key_code": "grave_accent_and_tilde",
+            "modifiers": {
+              "optional": []
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/korean_won_to_backtick_with_shortcut_preserved.json.js
+++ b/src/json/korean_won_to_backtick_with_shortcut_preserved.json.js
@@ -1,0 +1,44 @@
+// JavaScript should be written in ECMAScript 5.1.
+
+function main() {
+  console.log(
+    JSON.stringify(
+      {
+        title: 'Korean Won (₩) to Backtick (`) with shortcut preserved',
+        maintainers: [
+          "sts07142"
+        ],
+        rules: [
+          {
+            "description": "(₩) -> (`) 으로 변환하며, (`) 을 포함한 단축키 사용에 영향을 주지 않습니다.",
+            "manipulators": [
+                {
+                    "conditions": [
+                        {
+                            "input_sources": [{ "language": "ko" }],
+                            "type": "input_source_if"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "grave_accent_and_tilde",
+                        "modifiers": { "optional": [] }
+                    },
+                    "to": [
+                        {
+                            "key_code": "grave_accent_and_tilde",
+                            "modifiers": ["option"]
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        },
+        ],
+      },
+      null,
+      '  '
+    )
+  )
+}
+
+main()


### PR DESCRIPTION
Similar rules exist in #375  #1491 .
However, these existing rules have implications for shorcut using backticks.

Therefore, this rule converts only a standalone press of the won (₩) key to a backtick (`).
If the won (₩)  key is pressed together with any other modifier key, it behaves normally and does not interfere with existing shortcuts.