### PR TITLE
Add a rule to prevent accidental close window(⌘⇧W) in Google Chrome for ei-kana-cmd

### DIFF
--- a/public/json/ei-kana-cmd.json
+++ b/public/json/ei-kana-cmd.json
@@ -66,6 +66,29 @@
       "to": [ { "set_variable": { "name": "⌘Q TAPPED", "value": 1 } } ]
     }
 
+  ] },
+
+  { "description": "Google Chromeで⌘⇧Wを2連打したときのみウィンドウを閉じるようにする", "manipulators": [      
+
+    { "description": " ⌘⇧W ×2 ",
+      "from": { "key_code": "w", "modifiers": { "mandatory": ["command", "shift"], "optional": ["caps_lock"] } }, "type": "basic",
+        "conditions": [
+          { "type": "variable_if", "name": "CMD_SHIFT_W_TAPPED", "value": 1 },
+          { "type": "frontmost_application_if", "bundle_identifiers": [ "^com\\.google\\.Chrome$" ] }
+        ],
+      "to": [ { "key_code": "w", "modifiers": ["command", "shift"] } ]
+    },
+
+    { "description": " ⌘⇧W ×1 ",
+      "from": { "key_code": "w", "modifiers": { "mandatory": ["command", "shift"], "optional": ["caps_lock"] } }, "type": "basic",
+        "conditions": [ { "type": "frontmost_application_if", "bundle_identifiers": [ "^com\\.google\\.Chrome$" ] } ],
+        "to_delayed_action": {
+          "to_if_invoked": [ { "set_variable": { "name": "CMD_SHIFT_W_TAPPED", "value": 0 } } ],
+          "to_if_canceled": [ { "set_variable": { "name": "CMD_SHIFT_W_TAPPED", "value": 0 } } ]
+        },
+      "to": [ { "set_variable": { "name": "CMD_SHIFT_W_TAPPED", "value": 1 } } ]      
+    }
+    
   ] }
 
 ] }


### PR DESCRIPTION
When the left and right Command keys are configured as language switch keys, it’s possible to accidentally close a Google Chrome window with ⌘+Shift+W.
To prevent this, I added a rule to disable the shortcut unless it’s pressed twice in a row.