### PR TITLE
Add rule "Swap Command and Option for all non-Apple keyboards"

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -704,6 +704,9 @@
         },
         {
           "path": "json/swap_cmd_option_unless_builtin.json"
+        },
+        {
+          "path": "json/swap_cmd_option_unless_apple.json"
         }
       ]
     },

--- a/public/json/swap_cmd_option_unless_apple.json
+++ b/public/json/swap_cmd_option_unless_apple.json
@@ -1,0 +1,100 @@
+{
+    "title": "Swap Command and Option Keys",
+    "maintainers": [
+        "FelixDuo"
+    ],
+    "rules": [
+        {
+            "description": "Swap Command and Option for all non-Apple keyboards",
+            "manipulators": [
+                {
+                    "conditions": [
+                        {
+                            "identifiers": [
+                                {
+                                    "vendor_id": 1452
+                                },
+                                {
+                                    "vendor_id": 76
+                                }
+                            ],
+                            "type": "device_unless"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "left_command",
+                        "modifiers": {
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "left_option"
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "identifiers": [
+                                {
+                                    "vendor_id": 1452
+                                },
+                                {
+                                    "vendor_id": 76
+                                }
+                            ],
+                            "type": "device_unless"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "left_option",
+                        "modifiers": {
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "left_command"
+                        }
+                    ],
+                    "type": "basic"
+                },
+                {
+                    "conditions": [
+                        {
+                            "identifiers": [
+                                {
+                                    "vendor_id": 1452
+                                },
+                                {
+                                    "vendor_id": 76
+                                }
+                            ],
+                            "type": "device_unless"
+                        }
+                    ],
+                    "from": {
+                        "key_code": "right_option",
+                        "modifiers": {
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "right_command"
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Provide a config for those who has apple magic keyboard and other keyboards, periodically switch among those keyboards. Swap command and option keys on the left, and change the right option key to comand key as usually there is no right windows/command key for windows keyboard.