### PR TITLE
Disable annoying shortcuts for Safari and Finder

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -1829,7 +1829,7 @@
           "path": "json/disable_print_finder.json"
         },
         {
-          "path": "json/disable_print_finder.json"
+          "path": "json/disable_mail_safari.json"
         },
         {
           "path": "json/block_one_handed_combos.json"

--- a/public/groups.json
+++ b/public/groups.json
@@ -1826,6 +1826,12 @@
       "id": "miscellaneous",
       "files": [
         {
+          "path": "json/disable_print_finder.json"
+        },
+        {
+          "path": "json/disable_print_finder.json"
+        },
+        {
           "path": "json/block_one_handed_combos.json"
         },
         {

--- a/public/json/disable_mail_safari.json
+++ b/public/json/disable_mail_safari.json
@@ -1,0 +1,37 @@
+{
+  "description": "Disable mail shortcut on Safari",
+  "manipulators": [
+    {
+      "conditions": [
+        {
+          "bundle_identifiers": ["^com.apple.Safari"],
+          "type": "frontmost_application_if"
+        }
+      ],
+      "from": {
+        "key_code": "i",
+        "modifiers": {
+          "mandatory": ["left_command"],
+          "optional": ["left_shift", "right_shift"]
+        }
+      },
+      "type": "basic"
+    },
+    {
+      "conditions": [
+        {
+          "bundle_identifiers": ["^com.apple.Safari"],
+          "type": "frontmost_application_if"
+        }
+      ],
+      "from": {
+        "key_code": "i",
+        "modifiers": {
+          "mandatory": ["right_command"],
+          "optional": ["left_shift", "right_shift"]
+        }
+      },
+      "type": "basic"
+    }
+  ]
+}

--- a/public/json/disable_mail_safari.json
+++ b/public/json/disable_mail_safari.json
@@ -1,37 +1,42 @@
 {
-  "description": "Disable mail shortcut on Safari",
-  "manipulators": [
+  "title": "Disable mail shortcut on Safari",
+  "rules": [
     {
-      "conditions": [
+      "description": "Disable mail shortcut on Safari",
+      "manipulators": [
         {
-          "bundle_identifiers": ["^com.apple.Safari"],
-          "type": "frontmost_application_if"
-        }
-      ],
-      "from": {
-        "key_code": "i",
-        "modifiers": {
-          "mandatory": ["left_command"],
-          "optional": ["left_shift", "right_shift"]
-        }
-      },
-      "type": "basic"
-    },
-    {
-      "conditions": [
+          "conditions": [
+            {
+              "bundle_identifiers": ["^com.apple.Safari"],
+              "type": "frontmost_application_if"
+            }
+          ],
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": ["left_command"],
+              "optional": ["left_shift", "right_shift"]
+            }
+          },
+          "type": "basic"
+        },
         {
-          "bundle_identifiers": ["^com.apple.Safari"],
-          "type": "frontmost_application_if"
+          "conditions": [
+            {
+              "bundle_identifiers": ["^com.apple.Safari"],
+              "type": "frontmost_application_if"
+            }
+          ],
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": ["right_command"],
+              "optional": ["left_shift", "right_shift"]
+            }
+          },
+          "type": "basic"
         }
-      ],
-      "from": {
-        "key_code": "i",
-        "modifiers": {
-          "mandatory": ["right_command"],
-          "optional": ["left_shift", "right_shift"]
-        }
-      },
-      "type": "basic"
+      ]
     }
   ]
 }

--- a/public/json/disable_print_finder.json
+++ b/public/json/disable_print_finder.json
@@ -1,0 +1,37 @@
+{
+  "description": "Disable print shortcut on Finder",
+  "manipulators": [
+    {
+      "conditions": [
+        {
+          "bundle_identifiers": ["^com.apple.finder"],
+          "type": "frontmost_application_if"
+        }
+      ],
+      "from": {
+        "key_code": "p",
+        "modifiers": {
+          "mandatory": ["left_command"],
+          "optional": []
+        }
+      },
+      "type": "basic"
+    },
+    {
+      "conditions": [
+        {
+          "bundle_identifiers": ["^com.apple.finder"],
+          "type": "frontmost_application_if"
+        }
+      ],
+      "from": {
+        "key_code": "p",
+        "modifiers": {
+          "mandatory": ["right_command"],
+          "optional": []
+        }
+      },
+      "type": "basic"
+    }
+  ]
+}

--- a/public/json/disable_print_finder.json
+++ b/public/json/disable_print_finder.json
@@ -1,37 +1,42 @@
 {
-  "description": "Disable print shortcut on Finder",
-  "manipulators": [
+  "title": "Disable print shortcut on Finder",
+  "rules": [
     {
-      "conditions": [
+      "description": "Disable print shortcut on Finder",
+      "manipulators": [
         {
-          "bundle_identifiers": ["^com.apple.finder"],
-          "type": "frontmost_application_if"
-        }
-      ],
-      "from": {
-        "key_code": "p",
-        "modifiers": {
-          "mandatory": ["left_command"],
-          "optional": []
-        }
-      },
-      "type": "basic"
-    },
-    {
-      "conditions": [
+          "conditions": [
+            {
+              "bundle_identifiers": ["^com.apple.finder"],
+              "type": "frontmost_application_if"
+            }
+          ],
+          "from": {
+            "key_code": "p",
+            "modifiers": {
+              "mandatory": ["left_command"],
+              "optional": []
+            }
+          },
+          "type": "basic"
+        },
         {
-          "bundle_identifiers": ["^com.apple.finder"],
-          "type": "frontmost_application_if"
+          "conditions": [
+            {
+              "bundle_identifiers": ["^com.apple.finder"],
+              "type": "frontmost_application_if"
+            }
+          ],
+          "from": {
+            "key_code": "p",
+            "modifiers": {
+              "mandatory": ["right_command"],
+              "optional": []
+            }
+          },
+          "type": "basic"
         }
-      ],
-      "from": {
-        "key_code": "p",
-        "modifiers": {
-          "mandatory": ["right_command"],
-          "optional": []
-        }
-      },
-      "type": "basic"
+      ]
     }
   ]
 }


### PR DESCRIPTION
- disable cmd+p for Finder
- disable cmd+shift+i mail shortcut for Safari