### PR TITLE
Update swap_cmd_option_unless_apple.json

### DIFF
--- a/public/json/swap_cmd_option_unless_apple.json
+++ b/public/json/swap_cmd_option_unless_apple.json
@@ -12,7 +12,7 @@
                         {
                             "identifiers": [
                                 {
-                                    "vendor_id": 1452
+                                    "is_built_in_keyboard": true
                                 },
                                 {
                                     "vendor_id": 76
@@ -41,7 +41,7 @@
                         {
                             "identifiers": [
                                 {
-                                    "vendor_id": 1452
+                                    "is_built_in_keyboard": true
                                 },
                                 {
                                     "vendor_id": 76
@@ -70,7 +70,7 @@
                         {
                             "identifiers": [
                                 {
-                                    "vendor_id": 1452
+                                    "is_built_in_keyboard": true
                                 },
                                 {
                                     "vendor_id": 76


### PR DESCRIPTION
Update swap_cmd_option_unless_apple.json to use is_built_in_keyboard identifier for device conditions