### PR TITLE
Capslock for Chinese v1

### DIFF
--- a/public/json/CapslockChinese.json
+++ b/public/json/CapslockChinese.json
@@ -1,0 +1,37 @@
+{
+    "title": "Capslock for Chinese",
+    "maintainers": [
+        "RickWang000"
+    ],
+    "rules": [
+        {
+            "description": "CapsLock Fix with Chinese Input Source",
+            "manipulators": [
+                {
+                    "from": {
+                        "key_code": "caps_lock"
+                    },
+                    "parameters": {
+                        "basic.to_if_alone_timeout_milliseconds": 200,
+                        "basic.to_if_held_down_threshold_milliseconds": 200
+                    },
+                    "to_if_alone": [
+                        {
+                            "key_code": "spacebar",
+                            "modifiers": [
+                                "left_control",
+                                "left_option"
+                            ]
+                        }
+                    ],
+                    "to_if_held_down": [
+                        {
+                            "key_code": "caps_lock"
+                        }
+                    ],
+                    "type": "basic"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
### CapsLock Fix with Chinese Input Source

- Compatible with macOS

- Fixes CapsLock functionality disruption caused by using Sogou Input Method

- Restores original CapsLock functionality in Sogou Input Method environment (short press to switch input method, long press to toggle caps lock)

- Recommended to disable the original Chinese Pinyin input method for convenience
-----

### 中文输入法大写锁定修复
- MacOS适用

- 解决使用搜狗输入法之后导致的Capslock功能紊乱

- 实现在搜狗输入法环境下的Capslock原始功能（短按切换输入法，长按切换大写锁定）

- 建议将原本的中文拼音输入法禁用更方便