### PR TITLE
Add custom rules for Keychron K6 Spanish layout

### DIFF
--- a/public/extra_descriptions/keychron-k6-spanish-accents.json.html
+++ b/public/extra_descriptions/keychron-k6-spanish-accents.json.html
@@ -1,0 +1,30 @@
+<link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
+
+<h2>Keychron K6 Spanish Accents and &ntilde;</h2>
+
+<p>This profile allows you to insert accented characters using <code>fn</code> + key combinations.</p>
+
+<h2>Key Combinations</h2>
+<table>
+  <thead>
+  <tr>
+    <th>Key</th>
+    <th><code>fn</code> + ...</th>
+    <th>Outputs</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>' (single quote)</td>
+    <td><code>fn + '</code></td>
+    <td><code>&acute;</code> (accent)</td>
+  </tr>
+  <tr>
+    <td>n</td>
+    <td><code>fn + n</code></td>
+    <td>&ntilde; (<code>&ntilde;</code>)</td>
+  </tr>
+  </tbody>
+</table>
+
+<p>Configuration maintained by <a href="https://github.com/bguzmanm" target="_blank">bguzmanm</a>.</p>

--- a/public/groups.json
+++ b/public/groups.json
@@ -1937,6 +1937,10 @@
         {
           "path": "json/keychron_k6_useful_escape_caps_lock.json",
           "extra_description_path": "extra_descriptions/keychron_k6_useful_escape_caps_lock.json.html"
+        },
+        {
+          "path": "json/keychron-k6-spanish-accents.json",
+          "extra_description_path": "extra_descriptions/keychron-k6-spanish-accents.json.html"
         }
       ]
     },

--- a/public/json/keychron-k6-spanish-accents.json
+++ b/public/json/keychron-k6-spanish-accents.json
@@ -1,0 +1,42 @@
+{
+  "title": "Keychron K6 Spanish",
+  "maintainers": ["bguzmanm"],
+  "rules": [
+    {
+      "description": "Add a, e, i, o or u with accent mark",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "quote",
+            "modifiers": { "mandatory": ["fn"] }
+          },
+          "to": [
+            {
+              "key_code": "e",
+              "modifiers": ["option"]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Add n with sign",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "n",
+            "modifiers": { "mandatory": ["fn"] }
+          },
+          "to": [
+            {
+              "key_code": "n",
+              "modifiers": ["option"]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds a new set of complex modifications for the Keychron K6 keyboard configured for Spanish (Latin American) layout.

The configuration includes:

- fn + ' → acute accent dead key (´)
- fn + n → ñ

These mappings help users type accented characters more easily on macOS when using a Spanish layout with the Keychron K6.