### PR TITLE
feat: Add intuitive Spanish accent mapping for Keychron K6

### DIFF
--- a/public/extra_descriptions/keychron-k6-es-latam.json.html
+++ b/public/extra_descriptions/keychron-k6-es-latam.json.html
@@ -1,0 +1,40 @@
+<link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
+
+<h2>Keychron K6 for es-LATAM users</h2>
+
+<p>This profile allows you to insert accented characters using <code>[</code> + key combinations. This configuration facilitates accenting for users accustomed to ISO Latam distributions.</p>
+
+<h2>Key Combinations</h2>
+<table>
+  <thead>
+  <tr>
+    <th>Key</th>
+    <th>Combination</th>
+    <th>Outputs</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>a, e, i, o, u</td>
+    <td><code>[</code> + vowel</td>
+    <td>&aacute;, &eacute;, &iacute;, &oacute;, &uacute;</td>
+  </tr>
+  <tr>
+    <td>A, E, I, O, U</td>
+    <td><code>[</code> + <code>shift</code> + vowel</td>
+    <td>&Aacute;, &Eacute;, &Iacute;, &Oacute;, &Uacute;</td>
+  </tr>
+  <tr>
+    <td>n</td>
+    <td><code>[</code> + n</td>
+    <td>&ntilde;</td>
+  </tr>
+  <tr>
+    <td>N</td>
+    <td><code>[</code> + <code>shift</code> + n</td>
+    <td>&Ntilde;</td>
+  </tr>
+  </tbody>
+</table>
+
+<p>Configuration maintained by <a href="https://github.com/bguzmanm" target="_blank">bguzmanm</a>.</p>

--- a/public/extra_descriptions/keychron-k6-es-latam.json.html
+++ b/public/extra_descriptions/keychron-k6-es-latam.json.html
@@ -1,37 +1,37 @@
 <link rel="stylesheet" href="../../vendor/css/bootstrap.min.css" />
 
-<h2>Keychron K6 for es-LATAM users</h2>
+<h2>Intuitive Spanish Accent Mapping for Keychron K6</h2>
 
-<p>This profile allows you to insert accented characters using <code>[</code> + key combinations. This configuration facilitates accenting for users accustomed to ISO Latam distributions.</p>
+<p>
+    This complex modification significantly improves the Spanish typing experience on the Keychron K6 keyboard. It provides a more ergonomic and intuitive way to type accented characters and the letter <code>&ntilde;</code>, which is especially helpful for users accustomed to Latin American (ISO) keyboard layouts.
+</p>
+<p>
+    Instead of using the default macOS key combinations, this feature maps the <code>[</code> key as a dedicated accent trigger. This allows for a faster and more natural workflow by mimicking the muscle memory of standard Spanish keyboards.
+</p>
 
-<h2>Key Combinations</h2>
+<h3>Key Combinations</h3>
 <table>
   <thead>
   <tr>
-    <th>Key</th>
     <th>Combination</th>
-    <th>Outputs</th>
+    <th>Output</th>
   </tr>
   </thead>
   <tbody>
   <tr>
-    <td>a, e, i, o, u</td>
-    <td><code>[</code> + vowel</td>
-    <td>&aacute;, &eacute;, &iacute;, &oacute;, &uacute;</td>
+    <td><code>[</code> + vowel (a, e, i, o, u)</td>
+    <td>Vowel with &acute; (&aacute;, &eacute;, &iacute;, &oacute;, &uacute;)</td>
   </tr>
   <tr>
-    <td>A, E, I, O, U</td>
     <td><code>[</code> + <code>shift</code> + vowel</td>
-    <td>&Aacute;, &Eacute;, &Iacute;, &Oacute;, &Uacute;</td>
+    <td>Uppercase vowel with &acute; (&Aacute;, &Eacute;, &Iacute;, &Oacute;, &Uacute;)</td>
   </tr>
   <tr>
-    <td>n</td>
-    <td><code>[</code> + n</td>
+    <td><code>[</code> + <code>n</code></td>
     <td>&ntilde;</td>
   </tr>
   <tr>
-    <td>N</td>
-    <td><code>[</code> + <code>shift</code> + n</td>
+    <td><code>[</code> + <code>shift</code> + <code>n</code></td>
     <td>&Ntilde;</td>
   </tr>
   </tbody>

--- a/public/groups.json
+++ b/public/groups.json
@@ -1941,6 +1941,10 @@
         {
           "path": "json/keychron-k6-spanish-accents.json",
           "extra_description_path": "extra_descriptions/keychron-k6-spanish-accents.json.html"
+        },
+        {
+          "path": "json/keychron-k6-es-latam.json",
+          "extra_description_path": "extra_descriptions/keychron-k6-spanish-accents.json.html"
         }
       ]
     },

--- a/public/json/keychron-k6-es-latam.json
+++ b/public/json/keychron-k6-es-latam.json
@@ -1,0 +1,271 @@
+{
+  "title": "Keychron K6 es-Latam",
+  "maintainers": [
+    "bguzmanm"
+  ],
+  "rules": [
+    {
+      "description": "Press '[' and a vowel to get an accent (e.g., [ + a = á, [ + shift + a = Á)",
+      "manipulators": [
+        {
+          "from": {
+            "modifiers": { "mandatory": ["shift"] },
+            "simultaneous": [
+              { "key_code": "open_bracket" },
+              { "key_code": "a" }
+            ],
+            "simultaneous_options": { "key_down_order": "strict" }
+          },
+          "to": [
+            {
+              "key_code": "e",
+              "modifiers": ["option"]
+            },
+            {
+              "key_code": "a",
+              "modifiers": ["shift"]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "modifiers": { "optional": ["any"] },
+            "simultaneous": [
+              { "key_code": "open_bracket" },
+              { "key_code": "a" }
+            ],
+            "simultaneous_options": { "key_down_order": "strict" }
+          },
+          "to": [
+            {
+              "key_code": "e",
+              "modifiers": ["option"]
+            },
+            { "key_code": "a" }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Press '[' and e vowel to get an accent (e.g., [ + e = é, [ + shift + e = É)",
+      "manipulators": [
+        {
+          "from": {
+            "modifiers": { "mandatory": ["shift"] },
+            "simultaneous": [
+              { "key_code": "open_bracket" },
+              { "key_code": "e" }
+            ],
+            "simultaneous_options": { "key_down_order": "strict" }
+          },
+          "to": [
+            {
+              "key_code": "e",
+              "modifiers": ["option"]
+            },
+            {
+              "key_code": "e",
+              "modifiers": ["shift"]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "modifiers": { "optional": ["any"] },
+            "simultaneous": [
+              { "key_code": "open_bracket" },
+              { "key_code": "e" }
+            ],
+            "simultaneous_options": { "key_down_order": "strict" }
+          },
+          "to": [
+            {
+              "key_code": "e",
+              "modifiers": ["option"]
+            },
+            { "key_code": "e" }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Press '[' and i vowel to get an accent (e.g., [ + i = í, [ + shift + i = Í)",
+      "manipulators": [
+        {
+          "from": {
+            "modifiers": { "mandatory": ["shift"] },
+            "simultaneous": [
+              { "key_code": "open_bracket" },
+              { "key_code": "i" }
+            ],
+            "simultaneous_options": { "key_down_order": "strict" }
+          },
+          "to": [
+            {
+              "key_code": "e",
+              "modifiers": ["option"]
+            },
+            {
+              "key_code": "i",
+              "modifiers": ["shift"]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "modifiers": { "optional": ["any"] },
+            "simultaneous": [
+              { "key_code": "open_bracket" },
+              { "key_code": "i" }
+            ],
+            "simultaneous_options": { "key_down_order": "strict" }
+          },
+          "to": [
+            {
+              "key_code": "e",
+              "modifiers": ["option"]
+            },
+            { "key_code": "i" }
+          ],
+          "type": "basic"
+        }
+      ]
+    }, {
+      "description": "Press '[' and o vowel to get an accent (e.g., [ + o = ó, [ + shift + o = Ó)",
+      "manipulators": [
+        {
+          "from": {
+            "modifiers": { "mandatory": ["shift"] },
+            "simultaneous": [
+              { "key_code": "open_bracket" },
+              { "key_code": "o" }
+            ],
+            "simultaneous_options": { "key_down_order": "strict" }
+          },
+          "to": [
+            {
+              "key_code": "e",
+              "modifiers": ["option"]
+            },
+            {
+              "key_code": "o",
+              "modifiers": ["shift"]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "modifiers": { "optional": ["any"] },
+            "simultaneous": [
+              { "key_code": "open_bracket" },
+              { "key_code": "o" }
+            ],
+            "simultaneous_options": { "key_down_order": "strict" }
+          },
+          "to": [
+            {
+              "key_code": "e",
+              "modifiers": ["option"]
+            },
+            { "key_code": "o" }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Press '[' and u vowel to get an accent (e.g., [ + u = ú, [ + shift + u = Ú)",
+      "manipulators": [
+        {
+          "from": {
+            "modifiers": { "mandatory": ["shift"] },
+            "simultaneous": [
+              { "key_code": "open_bracket" },
+              { "key_code": "u" }
+            ],
+            "simultaneous_options": { "key_down_order": "strict" }
+          },
+          "to": [
+            {
+              "key_code": "e",
+              "modifiers": ["option"]
+            },
+            {
+              "key_code": "u",
+              "modifiers": ["shift"]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "modifiers": { "optional": ["any"] },
+            "simultaneous": [
+              { "key_code": "open_bracket" },
+              { "key_code": "u" }
+            ],
+            "simultaneous_options": { "key_down_order": "strict" }
+          },
+          "to": [
+            {
+              "key_code": "e",
+              "modifiers": ["option"]
+            },
+            { "key_code": "u" }
+          ],
+          "type": "basic"
+        }
+      ]
+    },
+    {
+      "description": "Press '[' and 'n' to get ñ, or '[' and 'N' to get Ñ.",
+      "manipulators": [
+        {
+          "from": {
+            "modifiers": { "mandatory": ["shift"] },
+            "simultaneous": [
+              { "key_code": "open_bracket" },
+              { "key_code": "n" }
+            ],
+            "simultaneous_options": { "key_down_order": "strict" }
+          },
+          "to": [
+            {
+              "key_code": "n",
+              "modifiers": ["option"]
+            },
+            {
+              "key_code": "n",
+              "modifiers": ["shift"]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "modifiers": { "optional": ["any"] },
+            "simultaneous": [
+              { "key_code": "open_bracket" },
+              { "key_code": "n" }
+            ],
+            "simultaneous_options": { "key_down_order": "strict" }
+          },
+          "to": [
+            {
+              "key_code": "n",
+              "modifiers": ["option"]
+            },
+            { "key_code": "n" }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR introduces a new complex modification designed to significantly improve the Spanish typing experience on the Keychron K6 keyboard. It provides a more ergonomic and intuitive way to type accented characters and the letter ñ, which is especially helpful for users accustomed to Latin American (ISO) keyboard layouts.

Instead of using the default macOS key combinations, this feature maps the [ key as a dedicated accent trigger. This allows for a faster and more natural workflow by mimicking the muscle memory of standard Spanish keyboards.

Key Functionality:

- Intuitive Accents: Press [ followed by a vowel to instantly get the accented character (e.g., [ + a = á).
- Easy `ñ`: Simply press [ followed by n to type ñ.
- Seamless Capitalization: The mapping works with the Shift key to produce uppercase accented letters (Á) and Ñ.
- This enhancement aims to make the Keychron K6 a more viable and comfortable option for Spanish-speaking users, reducing friction and improving typing speed.