### PR TITLE
Fix incorect keybinds

### DIFF
--- a/public/json/windows-pc-colemak-jetbrains.json
+++ b/public/json/windows-pc-colemak-jetbrains.json
@@ -266,7 +266,7 @@
           },
           "to": [
             {
-              "key_code": "k",
+              "key_code": "e",
               "modifiers": [
                 "left_control"
               ]
@@ -1239,7 +1239,7 @@
             }
           ],
           "from": {
-            "key_code": "s",
+            "key_code": "r",
             "modifiers": {
               "mandatory": [
                 "control"
@@ -1251,7 +1251,7 @@
           },
           "to": [
             {
-              "key_code": "s",
+              "key_code": "r",
               "modifiers": [
                 "left_command"
               ]
@@ -1316,7 +1316,7 @@
           },
           "to": [
             {
-              "key_code": "s",
+              "key_code": "r",
               "modifiers": [
                 "left_command"
               ]


### PR DESCRIPTION
 The windows-pc-colemark-jetbrains.json file has multiple erroneous keybinds.
    
The first describes changing the End key to instead perform as Control+E, however its implementation erroneously mapped to "k" and not "e".
    
The second describes changing Reload behaviour of Command+R to Control+R and changing F5 to Command+R, however its implementation erroneously used "s" for both of these instead of "r".