### PR TITLE
Disable ⌘Q for selected apps

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -100,6 +100,9 @@
           "path": "json/disable_cmd_f1_screen_mirroring.json"
         },
         {
+          "path": "json/disable_cmd_q.json"
+        },
+        {
           "path": "json/rotate_left_modifiers.json"
         },
         {

--- a/public/json/disable_cmd_q.json
+++ b/public/json/disable_cmd_q.json
@@ -1,0 +1,32 @@
+{
+  "title": "Disable ⌘Q for selected apps",
+  "rules": [
+    {
+      "description": "Disable ⌘Q in Firefox, LM Studio, iTerm, and Foxit Reader. Find another app's identifier with: osascript -e 'id of app \"NameOfTheApp\"'",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "q",
+            "modifiers": {
+              "mandatory": ["command"],
+              "optional": ["any"]
+            }
+          },
+          "to": [],
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^org\\.mozilla\\.firefox$",
+                "^ai\\.elementlabs\\.lmstudio$",
+                "^com\\.googlecode\\.iterm2$",
+                "^com\\.foxit\\-software\\.Foxit\\.PDF\\.Reader$"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Disable ⌘Q for selected apps (Firefox, LM Studio, iTerm, Foxit Reader)

This pull request adds a new complex modification rule that prevents accidental quitting of important apps using the ⌘Q shortcut.

## Rule functionality
- Swallows the ⌘Q keypress (does nothing) when the frontmost application is one of the following:
  - Firefox (`org.mozilla.firefox`)
  - LM Studio (`ai.elementlabs.lmstudio`)
  - iTerm2 (`com.googlecode.iterm2`)
  - Foxit PDF Reader (`com.foxit-software.Foxit.PDF.Reader`)

## Usage instructions
1. Install this rule via Karabiner-Elements: copy the JSON file into  
   `~/.config/karabiner/assets/complex_modifications/`.
2. Open **Karabiner-Elements → Complex Modifications → Add Rule**, and enable  
   “Disable ⌘Q for selected apps.”
3. To add additional apps:
   - Find the bundle identifier using Terminal:
     ```bash
     osascript -e 'id of app "NameOfTheApp"'
     ```
   - Add it to the `bundle_identifiers` array in the JSON file.

## Notes
- This rule only disables accidental quits for the specified apps. ⌘Q works normally in all other applications.
- The rule is compatible with macOS and has been tested on recent versions of Karabiner-Elements.