### PR TITLE
Map Keychron Dictation Key on Mac

### DIFF
--- a/public/json/keychron_k1_dictation_mac.json
+++ b/public/json/keychron_k1_dictation_mac.json
@@ -1,0 +1,23 @@
+{
+  "title": "Map Keychron Dictation Key on Mac",
+  "maintainers": [
+    "paritoshshah"
+  ],
+  "rules": [
+    {
+      "description": "Map Keychron Dictation Key on Mac",
+      "manipulators": [
+        {
+          "from": {
+            "simultaneous": [
+              { "key_code": "spacebar" },
+              { "key_code": "fn" }
+            ]
+          },
+          "to": [{ "consumer_key_code": "dictation" }],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
#### Problem
The dedicated dictation key on many Keychron keyboards sends `Fn + Spacebar`. On recent versions of macOS, this key combination no longer activates Dictation, leaving the key non-functional for its intended purpose.

#### Solution
This PR adds a new mapping that correctly wires the `Fn + Spacebar` key combination to trigger the system's Dictation service. This ensures the dedicated hardware key works out-of-the-box as users would expect.

#### Testing
- [x] Verified on macOS Sequoia 15.6.1 with Keychron K1 SE keyboard
- [x] Confirmed the `Fn + Spacebar` combination now toggles Dictation on and off.