### PR TITLE
add glove 80 lower level mouse emulation

### DIFF
--- a/public/extra_descriptions/glove_80_lower_level_mouse_bindings.html
+++ b/public/extra_descriptions/glove_80_lower_level_mouse_bindings.html
@@ -1,0 +1,71 @@
+<h3>Mouse Emulation for Glove 80 Lower Layer</h3>
+
+<p>
+  This rule provides full mouse control using the Glove 80 keyboard's lower layer, designed for Mac Mouse Keys style navigation. Movement controls are on the right hand (numpad), while modifiers and
+  click controls are on the left hand.
+</p>
+<p>
+  <b>Note:</b> All commands assume you are in the <a href="https://docs.moergo.com/glove80-user-guide/typing-with-glove80/#lower-layer" target="_blank">Glove 80's lower layer</a>. By default, access
+  the Glove 80's lower layer by holding the <b>Layer</b> key.
+</p>
+
+<h4>Movement (Right Hand - Numpad):</h4>
+<ul>
+  <li><b>Keypad 8:</b> Move mouse up</li>
+  <li><b>Keypad 2:</b> Move mouse down</li>
+  <li><b>Keypad 4:</b> Move mouse left</li>
+  <li><b>Keypad 6:</b> Move mouse right</li>
+  <li><b>Keypad 7:</b> Move mouse diagonally up-left</li>
+  <li><b>Keypad 9:</b> Move mouse diagonally up-right</li>
+  <li><b>Keypad 1:</b> Move mouse diagonally down-left</li>
+  <li><b>Keypad 3:</b> Move mouse diagonally down-right</li>
+</ul>
+
+<h4>Click Controls:</h4>
+<ul>
+  <li><b>Keypad 5:</b> Left click (right hand)</li>
+  <li><b>F11:</b> Left click (left hand)</li>
+  <li><b>F12:</b> Right click (left hand)</li>
+</ul>
+<p>
+  <i>Note: The left hand left click (F11) is particularly useful for click-and-hold operations, as it frees up your right hand to continue controlling mouse movement with the numpad.</i>
+</p>
+
+<h4>Modifiers (Left Hand):</h4>
+<ul>
+  <li><b>End (hold):</b> Scroll mode - hold End and use numpad keys to scroll instead of move</li>
+  <li><b>Page Up:</b> Fast mode (2.0x speed)</li>
+  <li><b>Page Down:</b> Slow mode (0.3x speed)</li>
+</ul>
+
+<h4>Scroll Mode:</h4>
+<p>Hold the <b>End</b> key and use the numpad keys to scroll:</p>
+<ul>
+  <li><b>End + Keypad 8:</b> Scroll up</li>
+  <li><b>End + Keypad 2:</b> Scroll down</li>
+  <li><b>End + Keypad 4:</b> Scroll left</li>
+  <li><b>End + Keypad 6:</b> Scroll right</li>
+  <li><b>End + Keypad 7:</b> Scroll diagonally up-left</li>
+  <li><b>End + Keypad 9:</b> Scroll diagonally up-right</li>
+  <li><b>End + Keypad 1:</b> Scroll diagonally down-left</li>
+  <li><b>End + Keypad 3:</b> Scroll diagonally down-right</li>
+</ul>
+
+<h4>Example Usage:</h4>
+<ol>
+  <li>Press <b>Page Up</b> to activate fast mode</li>
+  <li>Use <b>Keypad 8/2/4/6</b> to move the mouse quickly</li>
+  <li>Press <b>F11</b> to left click</li>
+  <li>Hold <b>End</b> and press <b>Keypad 2</b> to scroll down</li>
+  <li>Press <b>Page Down</b> to activate slow mode for precise control</li>
+</ol>
+
+<p style="margin-top: 20px">
+  <i>Designed specifically for the Glove 80 split ergonomic keyboard's lower layer layout without a need to update the firmware.</i>
+</p>
+<p style="margin-top: 20px">
+  <i
+    >Inspired by Mac Mouse Keys, <a href="https://ke-complex-modifications.pqrs.org/?q=mouse%20scroll#mouse_full_emulation_with_right_command_super_fast" target="_blank">this config</a> by
+    <a href="https://github.com/maxdzyubak" target="_blank">@maxdzyubak</a>, and by not wanting to flash my Glove 80 again 😆</i
+  >
+</p>

--- a/public/groups.json
+++ b/public/groups.json
@@ -1707,6 +1707,10 @@
         },
         {
           "path": "json/uk_apple_to_uk_corsair_makr.json"
+        },
+        {
+          "path": "json/glove_80_lower_level_mouse_bindings.json",
+          "extra_description_path": "extra_descriptions/glove_80_lower_level_mouse_bindings.html"
         }
       ]
     },

--- a/public/json/glove_80_lower_level_mouse_bindings.json
+++ b/public/json/glove_80_lower_level_mouse_bindings.json
@@ -1,0 +1,364 @@
+{
+  "title": "Mouse Emulation for Glove 80 Lower Layer",
+  "maintainers": ["yoyomeng2"],
+  "rules": [
+    {
+      "description": "Use the Glove 80's Layer key for mouse movement using the numpad (Mac Mouse Keys style) on right side and modifiers on left side.",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "name": "mouse_scroll_mode",
+              "type": "variable_if",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "keypad_1"
+          },
+          "to": [
+            {
+              "mouse_key": {
+                "horizontal_wheel": 32,
+                "vertical_wheel": 32
+              }
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "name": "mouse_scroll_mode",
+              "type": "variable_if",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "keypad_2"
+          },
+          "to": [
+            {
+              "mouse_key": {
+                "vertical_wheel": 32
+              }
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "name": "mouse_scroll_mode",
+              "type": "variable_if",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "keypad_3"
+          },
+          "to": [
+            {
+              "mouse_key": {
+                "horizontal_wheel": -32,
+                "vertical_wheel": 32
+              }
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "name": "mouse_scroll_mode",
+              "type": "variable_if",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "keypad_4"
+          },
+          "to": [
+            {
+              "mouse_key": {
+                "horizontal_wheel": 32
+              }
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "name": "mouse_scroll_mode",
+              "type": "variable_if",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "keypad_6"
+          },
+          "to": [
+            {
+              "mouse_key": {
+                "horizontal_wheel": -32
+              }
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "name": "mouse_scroll_mode",
+              "type": "variable_if",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "keypad_7"
+          },
+          "to": [
+            {
+              "mouse_key": {
+                "horizontal_wheel": 32,
+                "vertical_wheel": -32
+              }
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "name": "mouse_scroll_mode",
+              "type": "variable_if",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "keypad_8"
+          },
+          "to": [
+            {
+              "mouse_key": {
+                "vertical_wheel": -32
+              }
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "conditions": [
+            {
+              "name": "mouse_scroll_mode",
+              "type": "variable_if",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "keypad_9"
+          },
+          "to": [
+            {
+              "mouse_key": {
+                "horizontal_wheel": -32,
+                "vertical_wheel": -32
+              }
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "keypad_1"
+          },
+          "to": [
+            {
+              "mouse_key": {
+                "x": -1536,
+                "y": 1536
+              }
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "keypad_2"
+          },
+          "to": [
+            {
+              "mouse_key": {
+                "y": 1536
+              }
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "keypad_3"
+          },
+          "to": [
+            {
+              "mouse_key": {
+                "x": 1536,
+                "y": 1536
+              }
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "keypad_4"
+          },
+          "to": [
+            {
+              "mouse_key": {
+                "x": -1536
+              }
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "keypad_6"
+          },
+          "to": [
+            {
+              "mouse_key": {
+                "x": 1536
+              }
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "keypad_7"
+          },
+          "to": [
+            {
+              "mouse_key": {
+                "x": -1536,
+                "y": -1536
+              }
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "keypad_8"
+          },
+          "to": [
+            {
+              "mouse_key": {
+                "y": -1536
+              }
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "keypad_9"
+          },
+          "to": [
+            {
+              "mouse_key": {
+                "x": 1536,
+                "y": -1536
+              }
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "keypad_5"
+          },
+          "to": [
+            {
+              "pointing_button": "button1"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "f11"
+          },
+          "to": [
+            {
+              "pointing_button": "button1"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "f12"
+          },
+          "to": [
+            {
+              "pointing_button": "button2"
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "page_down"
+          },
+          "to": [
+            {
+              "mouse_key": {
+                "speed_multiplier": 0.3
+              }
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "page_up"
+          },
+          "to": [
+            {
+              "mouse_key": {
+                "speed_multiplier": 2.0
+              }
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "end"
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "mouse_scroll_mode",
+                "value": 1
+              }
+            }
+          ],
+          "to_after_key_up": [
+            {
+              "set_variable": {
+                "name": "mouse_scroll_mode",
+                "value": 0
+              }
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This rule provides full mouse control using the Glove 80 keyboard's lower layer, designed for Mac Mouse Keys style navigation. Movement controls are on the right hand (numpad), while modifiers and click controls are on the left hand.