### PR TITLE
Make bind work no matter of press order

### DIFF
--- a/public/json/cmd-shift-to-switch-input.json
+++ b/public/json/cmd-shift-to-switch-input.json
@@ -2,7 +2,8 @@
 {
   "title": "cmd + Shift Switch Languages",
   "maintainers": [
-    "s4wet"
+    "s4wet",
+    "Dolfost"
   ],
   "rules": [
     {
@@ -15,6 +16,25 @@
             "modifiers": {
               "mandatory": [
                 "left_command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "spacebar",
+              "modifiers": [
+                "left_control"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_command",
+            "modifiers": {
+              "mandatory": [
+                "left_shift"
               ]
             }
           },


### PR DESCRIPTION
Make bind work no matter is shift is pressed earlier than command or command is pressed earlier than shift