### PR TITLE
Add HyperJIS - JIS keyboard remapper + multilingual accent system

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -1292,6 +1292,21 @@
         },
         {
           "path": "json/Option+numbers_to_lithuanian_symbols.json"
+        },
+        {
+          "path": "json/hyperjis-core.json"
+        },
+        {
+          "path": "json/hyperjis-accents-romance.json"
+        },
+        {
+          "path": "json/hyperjis-accents-french.json"
+        },
+        {
+          "path": "json/hyperjis-accents-spanish.json"
+        },
+        {
+          "path": "json/hyperjis-accents-german.json"
         }
       ]
     },

--- a/public/json/hyperjis-accents-french.json
+++ b/public/json/hyperjis-accents-french.json
@@ -1,0 +1,85 @@
+{
+  "title": "HyperJIS Accents: French Extension (Circumflex + Cedilla + Ligatures)",
+  "rules": [
+    {
+      "description": "French circumflex vowels (Fn + Option + vowel)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": { "key_code": "a", "modifiers": { "mandatory": ["fn", "left_option"], "optional": ["caps_lock"] } },
+          "to": [ { "key_code": "i", "modifiers": ["left_option"] }, { "key_code": "a" } ]
+        },
+        {
+          "type": "basic",
+          "from": { "key_code": "a", "modifiers": { "mandatory": ["fn", "left_option", "left_shift"], "optional": ["caps_lock"] } },
+          "to": [ { "key_code": "i", "modifiers": ["left_option"] }, { "key_code": "a", "modifiers": ["left_shift"] } ]
+        },
+        {
+          "type": "basic",
+          "from": { "key_code": "e", "modifiers": { "mandatory": ["fn", "left_option"], "optional": ["caps_lock"] } },
+          "to": [ { "key_code": "i", "modifiers": ["left_option"] }, { "key_code": "e" } ]
+        },
+        {
+          "type": "basic",
+          "from": { "key_code": "e", "modifiers": { "mandatory": ["fn", "left_option", "left_shift"], "optional": ["caps_lock"] } },
+          "to": [ { "key_code": "i", "modifiers": ["left_option"] }, { "key_code": "e", "modifiers": ["left_shift"] } ]
+        },
+        {
+          "type": "basic",
+          "from": { "key_code": "i", "modifiers": { "mandatory": ["fn", "left_option"], "optional": ["caps_lock"] } },
+          "to": [ { "key_code": "i", "modifiers": ["left_option"] }, { "key_code": "i" } ]
+        },
+        {
+          "type": "basic",
+          "from": { "key_code": "i", "modifiers": { "mandatory": ["fn", "left_option", "left_shift"], "optional": ["caps_lock"] } },
+          "to": [ { "key_code": "i", "modifiers": ["left_option"] }, { "key_code": "i", "modifiers": ["left_shift"] } ]
+        },
+        {
+          "type": "basic",
+          "from": { "key_code": "o", "modifiers": { "mandatory": ["fn", "left_option"], "optional": ["caps_lock"] } },
+          "to": [ { "key_code": "i", "modifiers": ["left_option"] }, { "key_code": "o" } ]
+        },
+        {
+          "type": "basic",
+          "from": { "key_code": "o", "modifiers": { "mandatory": ["fn", "left_option", "left_shift"], "optional": ["caps_lock"] } },
+          "to": [ { "key_code": "i", "modifiers": ["left_option"] }, { "key_code": "o", "modifiers": ["left_shift"] } ]
+        },
+        {
+          "type": "basic",
+          "from": { "key_code": "u", "modifiers": { "mandatory": ["fn", "left_option"], "optional": ["caps_lock"] } },
+          "to": [ { "key_code": "i", "modifiers": ["left_option"] }, { "key_code": "u" } ]
+        },
+        {
+          "type": "basic",
+          "from": { "key_code": "u", "modifiers": { "mandatory": ["fn", "left_option", "left_shift"], "optional": ["caps_lock"] } },
+          "to": [ { "key_code": "i", "modifiers": ["left_option"] }, { "key_code": "u", "modifiers": ["left_shift"] } ]
+        }
+      ]
+    },
+    {
+      "description": "French cedilla and ligatures (Fn + c/q)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": { "key_code": "c", "modifiers": { "mandatory": ["fn"], "optional": ["caps_lock"] } },
+          "to": [ { "key_code": "c", "modifiers": ["left_option"] } ]
+        },
+        {
+          "type": "basic",
+          "from": { "key_code": "c", "modifiers": { "mandatory": ["fn", "left_shift"], "optional": ["caps_lock"] } },
+          "to": [ { "key_code": "c", "modifiers": ["left_option", "left_shift"] } ]
+        },
+        {
+          "type": "basic",
+          "from": { "key_code": "q", "modifiers": { "mandatory": ["fn"], "optional": ["caps_lock"] } },
+          "to": [ { "key_code": "q", "modifiers": ["left_option"] } ]
+        },
+        {
+          "type": "basic",
+          "from": { "key_code": "q", "modifiers": { "mandatory": ["fn", "left_shift"], "optional": ["caps_lock"] } },
+          "to": [ { "key_code": "q", "modifiers": ["left_option", "left_shift"] } ]
+        }
+      ]
+    }
+  ]
+}

--- a/public/json/hyperjis-accents-german.json
+++ b/public/json/hyperjis-accents-german.json
@@ -1,0 +1,50 @@
+{
+  "title": "HyperJIS Accents: German Extension (Umlauts + Eszett)",
+  "rules": [
+    {
+      "description": "German umlauts (Fn + Option + a/o/u)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": { "key_code": "a", "modifiers": { "mandatory": ["fn", "left_option"], "optional": ["caps_lock"] } },
+          "to": [ { "key_code": "u", "modifiers": ["left_option"] }, { "key_code": "a" } ]
+        },
+        {
+          "type": "basic",
+          "from": { "key_code": "a", "modifiers": { "mandatory": ["fn", "left_option", "left_shift"], "optional": ["caps_lock"] } },
+          "to": [ { "key_code": "u", "modifiers": ["left_option"] }, { "key_code": "a", "modifiers": ["left_shift"] } ]
+        },
+        {
+          "type": "basic",
+          "from": { "key_code": "o", "modifiers": { "mandatory": ["fn", "left_option"], "optional": ["caps_lock"] } },
+          "to": [ { "key_code": "u", "modifiers": ["left_option"] }, { "key_code": "o" } ]
+        },
+        {
+          "type": "basic",
+          "from": { "key_code": "o", "modifiers": { "mandatory": ["fn", "left_option", "left_shift"], "optional": ["caps_lock"] } },
+          "to": [ { "key_code": "u", "modifiers": ["left_option"] }, { "key_code": "o", "modifiers": ["left_shift"] } ]
+        },
+        {
+          "type": "basic",
+          "from": { "key_code": "u", "modifiers": { "mandatory": ["fn", "left_option"], "optional": ["caps_lock"] } },
+          "to": [ { "key_code": "u", "modifiers": ["left_option"] }, { "key_code": "u" } ]
+        },
+        {
+          "type": "basic",
+          "from": { "key_code": "u", "modifiers": { "mandatory": ["fn", "left_option", "left_shift"], "optional": ["caps_lock"] } },
+          "to": [ { "key_code": "u", "modifiers": ["left_option"] }, { "key_code": "u", "modifiers": ["left_shift"] } ]
+        }
+      ]
+    },
+    {
+      "description": "German Eszett (Fn + s)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": { "key_code": "s", "modifiers": { "mandatory": ["fn"], "optional": ["caps_lock"] } },
+          "to": [ { "key_code": "s", "modifiers": ["left_option"] } ]
+        }
+      ]
+    }
+  ]
+}

--- a/public/json/hyperjis-accents-romance.json
+++ b/public/json/hyperjis-accents-romance.json
@@ -1,0 +1,1071 @@
+{
+  "title": "HyperJIS Accents: Romance Base (Grave/Acute + Typography)",
+  "rules": [
+    {
+      "description": "Grave and acute accents on all vowels (Fn + vowel, double-tap to swap)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "it_e_lower",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "e",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_or_backspace"
+            },
+            {
+              "key_code": "e",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "e"
+            },
+            {
+              "set_variable": {
+                "name": "it_e_lower",
+                "value": 0
+              }
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "e",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "e"
+            },
+            {
+              "set_variable": {
+                "name": "it_e_lower",
+                "value": 1
+              }
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "it_e_lower",
+                  "value": 0
+                }
+              }
+            ],
+            "to_if_canceled": [
+              {
+                "set_variable": {
+                  "name": "it_e_lower",
+                  "value": 0
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "it_e_upper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "e",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_or_backspace"
+            },
+            {
+              "key_code": "e",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "e",
+              "modifiers": [
+                "left_shift"
+              ]
+            },
+            {
+              "set_variable": {
+                "name": "it_e_upper",
+                "value": 0
+              }
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "e",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "e",
+              "modifiers": [
+                "left_shift"
+              ]
+            },
+            {
+              "set_variable": {
+                "name": "it_e_upper",
+                "value": 1
+              }
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "it_e_upper",
+                  "value": 0
+                }
+              }
+            ],
+            "to_if_canceled": [
+              {
+                "set_variable": {
+                  "name": "it_e_upper",
+                  "value": 0
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "it_a_lower",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_or_backspace"
+            },
+            {
+              "key_code": "e",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "a"
+            },
+            {
+              "set_variable": {
+                "name": "it_a_lower",
+                "value": 0
+              }
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "a"
+            },
+            {
+              "set_variable": {
+                "name": "it_a_lower",
+                "value": 1
+              }
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "it_a_lower",
+                  "value": 0
+                }
+              }
+            ],
+            "to_if_canceled": [
+              {
+                "set_variable": {
+                  "name": "it_a_lower",
+                  "value": 0
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "it_a_upper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_or_backspace"
+            },
+            {
+              "key_code": "e",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "a",
+              "modifiers": [
+                "left_shift"
+              ]
+            },
+            {
+              "set_variable": {
+                "name": "it_a_upper",
+                "value": 0
+              }
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "a",
+              "modifiers": [
+                "left_shift"
+              ]
+            },
+            {
+              "set_variable": {
+                "name": "it_a_upper",
+                "value": 1
+              }
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "it_a_upper",
+                  "value": 0
+                }
+              }
+            ],
+            "to_if_canceled": [
+              {
+                "set_variable": {
+                  "name": "it_a_upper",
+                  "value": 0
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "it_i_lower",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_or_backspace"
+            },
+            {
+              "key_code": "e",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "i"
+            },
+            {
+              "set_variable": {
+                "name": "it_i_lower",
+                "value": 0
+              }
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "i"
+            },
+            {
+              "set_variable": {
+                "name": "it_i_lower",
+                "value": 1
+              }
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "it_i_lower",
+                  "value": 0
+                }
+              }
+            ],
+            "to_if_canceled": [
+              {
+                "set_variable": {
+                  "name": "it_i_lower",
+                  "value": 0
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "it_i_upper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_or_backspace"
+            },
+            {
+              "key_code": "e",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "i",
+              "modifiers": [
+                "left_shift"
+              ]
+            },
+            {
+              "set_variable": {
+                "name": "it_i_upper",
+                "value": 0
+              }
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "i",
+              "modifiers": [
+                "left_shift"
+              ]
+            },
+            {
+              "set_variable": {
+                "name": "it_i_upper",
+                "value": 1
+              }
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "it_i_upper",
+                  "value": 0
+                }
+              }
+            ],
+            "to_if_canceled": [
+              {
+                "set_variable": {
+                  "name": "it_i_upper",
+                  "value": 0
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "it_o_lower",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "o",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_or_backspace"
+            },
+            {
+              "key_code": "e",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "o"
+            },
+            {
+              "set_variable": {
+                "name": "it_o_lower",
+                "value": 0
+              }
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "o",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "o"
+            },
+            {
+              "set_variable": {
+                "name": "it_o_lower",
+                "value": 1
+              }
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "it_o_lower",
+                  "value": 0
+                }
+              }
+            ],
+            "to_if_canceled": [
+              {
+                "set_variable": {
+                  "name": "it_o_lower",
+                  "value": 0
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "it_o_upper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "o",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_or_backspace"
+            },
+            {
+              "key_code": "e",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "o",
+              "modifiers": [
+                "left_shift"
+              ]
+            },
+            {
+              "set_variable": {
+                "name": "it_o_upper",
+                "value": 0
+              }
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "o",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "o",
+              "modifiers": [
+                "left_shift"
+              ]
+            },
+            {
+              "set_variable": {
+                "name": "it_o_upper",
+                "value": 1
+              }
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "it_o_upper",
+                  "value": 0
+                }
+              }
+            ],
+            "to_if_canceled": [
+              {
+                "set_variable": {
+                  "name": "it_o_upper",
+                  "value": 0
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "it_u_lower",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "u",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_or_backspace"
+            },
+            {
+              "key_code": "e",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "u"
+            },
+            {
+              "set_variable": {
+                "name": "it_u_lower",
+                "value": 0
+              }
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "u",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "u"
+            },
+            {
+              "set_variable": {
+                "name": "it_u_lower",
+                "value": 1
+              }
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "it_u_lower",
+                  "value": 0
+                }
+              }
+            ],
+            "to_if_canceled": [
+              {
+                "set_variable": {
+                  "name": "it_u_lower",
+                  "value": 0
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "it_u_upper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "u",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_or_backspace"
+            },
+            {
+              "key_code": "e",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "u",
+              "modifiers": [
+                "left_shift"
+              ]
+            },
+            {
+              "set_variable": {
+                "name": "it_u_upper",
+                "value": 0
+              }
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "u",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "u",
+              "modifiers": [
+                "left_shift"
+              ]
+            },
+            {
+              "set_variable": {
+                "name": "it_u_upper",
+                "value": 1
+              }
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "it_u_upper",
+                  "value": 0
+                }
+              }
+            ],
+            "to_if_canceled": [
+              {
+                "set_variable": {
+                  "name": "it_u_upper",
+                  "value": 0
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "description": "Typography: Euro, guillemets, smart quotes",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "4",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "2",
+              "modifiers": [
+                "left_option",
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "comma",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "backslash",
+              "modifiers": [
+                "left_option"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "period",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock",
+                "left_shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "backslash",
+              "modifiers": [
+                "left_option",
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "open_bracket",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "open_bracket",
+              "modifiers": [
+                "left_option"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "close_bracket",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "open_bracket",
+              "modifiers": [
+                "left_option",
+                "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/public/json/hyperjis-accents-spanish.json
+++ b/public/json/hyperjis-accents-spanish.json
@@ -1,0 +1,30 @@
+{
+  "title": "HyperJIS Accents: Spanish Extension (Ñ + Inverted Punctuation)",
+  "rules": [
+    {
+      "description": "Spanish characters (Fn + n/1//)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": { "key_code": "n", "modifiers": { "mandatory": ["fn"], "optional": ["caps_lock"] } },
+          "to": [ { "key_code": "n", "modifiers": ["left_option"] }, { "key_code": "n" } ]
+        },
+        {
+          "type": "basic",
+          "from": { "key_code": "n", "modifiers": { "mandatory": ["fn", "left_shift"], "optional": ["caps_lock"] } },
+          "to": [ { "key_code": "n", "modifiers": ["left_option"] }, { "key_code": "n", "modifiers": ["left_shift"] } ]
+        },
+        {
+          "type": "basic",
+          "from": { "key_code": "1", "modifiers": { "mandatory": ["fn"], "optional": ["caps_lock"] } },
+          "to": [ { "key_code": "1", "modifiers": ["left_option"] } ]
+        },
+        {
+          "type": "basic",
+          "from": { "key_code": "slash", "modifiers": { "mandatory": ["fn"], "optional": ["caps_lock"] } },
+          "to": [ { "key_code": "slash", "modifiers": ["left_option", "left_shift"] } ]
+        }
+      ]
+    }
+  ]
+}

--- a/public/json/hyperjis-core.json
+++ b/public/json/hyperjis-core.json
@@ -1,0 +1,522 @@
+{
+  "title": "HyperJIS — Core Layout (JIS → US + Vim + Hyper + Tiling)",
+  "rules": [
+    {
+      "description": "HyperJIS: Caps Lock — tap for Escape, hold for Control",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "caps_lock",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to_if_alone": [
+            {
+              "key_code": "escape"
+            }
+          ],
+          "to_if_held_down": [
+            {
+              "key_code": "left_control"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "HyperJIS: Space — tap for Space, hold for Left Control",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "spacebar",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to_if_alone": [
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "to_if_held_down": [
+            {
+              "key_code": "left_control"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "HyperJIS: Left Control — tap for Escape, hold for Control",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_control",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to_if_alone": [
+            {
+              "key_code": "escape"
+            }
+          ],
+          "to_if_held_down": [
+            {
+              "key_code": "left_control"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "HyperJIS: Left Option → Hyper Key (⌃⌥⇧⌘)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_option",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to_if_alone": [
+            {
+              "key_code": "left_shift",
+              "modifiers": [
+                "left_command",
+                "left_control",
+                "left_option"
+              ]
+            }
+          ],
+          "to_if_held_down": [
+            {
+              "key_code": "left_shift",
+              "modifiers": [
+                "left_command",
+                "left_control",
+                "left_option"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "HyperJIS: Fn — tap for Language Switch, hold for Hyper (⌃⌥⇧⌘)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "fn",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to_if_alone": [
+            {
+              "apple_vendor_top_case_key_code": "keyboard_fn"
+            }
+          ],
+          "to_if_held_down": [
+            {
+              "key_code": "left_shift",
+              "modifiers": [
+                "left_command",
+                "left_control",
+                "left_option"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "HyperJIS: Vim Navigation — Left Ctrl + H/J/K/L → Arrow Keys",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "h",
+            "modifiers": {
+              "mandatory": [
+                "left_control"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "mandatory": [
+                "left_control"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "down_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "k",
+            "modifiers": {
+              "mandatory": [
+                "left_control"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "mandatory": [
+                "left_control"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "HyperJIS: JIS Bottom Row — Eisuu (英数) → Left Command",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "japanese_eisuu",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_command"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "HyperJIS: JIS Bottom Row — Kana (かな) → Right Command",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "japanese_kana",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_command"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "HyperJIS: Left Command → Left Option",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_command",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_option"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "HyperJIS: Right Command → Right Option",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_command",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_option"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "HyperJIS: International3 (¥) → Grave Accent / Tilde",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "international3"
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "international3",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "international3",
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "international3",
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "grave_accent_and_tilde",
+              "modifiers": [
+                "shift",
+                "option"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "HyperJIS: International1 → Emoji Picker (⌃⌘Space)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "international1"
+          },
+          "to": [
+            {
+              "key_code": "spacebar",
+              "modifiers": [
+                "left_command",
+                "left_control"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "HyperJIS: Escape — tap for Screenshot, hold for Hyper+W",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "escape"
+          },
+          "to_if_alone": [
+            {
+              "key_code": "4",
+              "modifiers": [
+                "left_shift",
+                "left_command"
+              ]
+            }
+          ],
+          "to_if_held_down": [
+            {
+              "key_code": "w",
+              "modifiers": [
+                "left_control",
+                "left_option",
+                "left_shift",
+                "left_command"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "HyperJIS: Arrow Keys → Fn+HJKL (frees arrows for window tiling via Swish)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_arrow",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "h",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_arrow",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "l",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "up_arrow",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "down_arrow",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j",
+              "modifiers": [
+                "fn"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## HyperJIS Core: JIS Apple Keyboard → US Layout + Vim + Hyper

Remaps an Apple JIS keyboard into a US-like power-user layout:

- Caps Lock: tap → Escape, hold → Control
- Space (hold) → Control
- Left Option → Hyper key (⌃⌥⇧⌘)
- Vim navigation via Ctrl+HJKL
- Eisuu → Command, Kana → Command, ¥ → `/~
- Arrow keys freed for window tiling (optional)

Each rule is independent and can be enabled/disabled individually.

## Multilingual accent system (4 files, modular)

**Romance base** (Italian, Spanish, Portuguese, French):
- Fn + vowel → grave (è, à, ì, ò, ù)
- Double-tap → acute (é, á, í, ó, ú)
- Fn + Shift + vowel → uppercase
- Fn + 4 → €, Fn + comma/period → «/», Fn + brackets → "/"

**French extension:** Fn + Option + vowel → circumflex (â, ê, î, ô, û), Fn + c → ç, Fn + q → œ

**Spanish extension:** Fn + n → ñ, Fn + 1 → ¡, Fn + / → ¿

**German extension:** Fn + Option + a/o/u → umlauts (ä, ö, ü), Fn + s → ß

No input source switching needed. Users install the base + whichever extension matches their language.

More info: https://github.com/smnrg/HyperJIS