### PR TITLE
Update HyperJIS: dual-function Escape, add maintainer attribution

### DIFF
--- a/public/json/hyperjis-accents-french.json
+++ b/public/json/hyperjis-accents-french.json
@@ -1,83 +1,388 @@
 {
   "title": "HyperJIS Accents: French Extension (Circumflex + Cedilla + Ligatures)",
+  "maintainers": [
+    "smnrg"
+  ],
   "rules": [
     {
-      "description": "French circumflex vowels (Fn + Option + vowel)",
+      "description": "HyperJIS: French circumflex vowels (Fn + Option + vowel)",
       "manipulators": [
         {
           "type": "basic",
-          "from": { "key_code": "a", "modifiers": { "mandatory": ["fn", "left_option"], "optional": ["caps_lock"] } },
-          "to": [ { "key_code": "i", "modifiers": ["left_option"] }, { "key_code": "a" } ]
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_option"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "i",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "a"
+            }
+          ]
         },
         {
           "type": "basic",
-          "from": { "key_code": "a", "modifiers": { "mandatory": ["fn", "left_option", "left_shift"], "optional": ["caps_lock"] } },
-          "to": [ { "key_code": "i", "modifiers": ["left_option"] }, { "key_code": "a", "modifiers": ["left_shift"] } ]
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_option",
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "i",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "a",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
         },
         {
           "type": "basic",
-          "from": { "key_code": "e", "modifiers": { "mandatory": ["fn", "left_option"], "optional": ["caps_lock"] } },
-          "to": [ { "key_code": "i", "modifiers": ["left_option"] }, { "key_code": "e" } ]
+          "from": {
+            "key_code": "e",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_option"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "i",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "e"
+            }
+          ]
         },
         {
           "type": "basic",
-          "from": { "key_code": "e", "modifiers": { "mandatory": ["fn", "left_option", "left_shift"], "optional": ["caps_lock"] } },
-          "to": [ { "key_code": "i", "modifiers": ["left_option"] }, { "key_code": "e", "modifiers": ["left_shift"] } ]
+          "from": {
+            "key_code": "e",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_option",
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "i",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "e",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
         },
         {
           "type": "basic",
-          "from": { "key_code": "i", "modifiers": { "mandatory": ["fn", "left_option"], "optional": ["caps_lock"] } },
-          "to": [ { "key_code": "i", "modifiers": ["left_option"] }, { "key_code": "i" } ]
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_option"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "i",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "i"
+            }
+          ]
         },
         {
           "type": "basic",
-          "from": { "key_code": "i", "modifiers": { "mandatory": ["fn", "left_option", "left_shift"], "optional": ["caps_lock"] } },
-          "to": [ { "key_code": "i", "modifiers": ["left_option"] }, { "key_code": "i", "modifiers": ["left_shift"] } ]
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_option",
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "i",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "i",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
         },
         {
           "type": "basic",
-          "from": { "key_code": "o", "modifiers": { "mandatory": ["fn", "left_option"], "optional": ["caps_lock"] } },
-          "to": [ { "key_code": "i", "modifiers": ["left_option"] }, { "key_code": "o" } ]
+          "from": {
+            "key_code": "o",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_option"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "i",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "o"
+            }
+          ]
         },
         {
           "type": "basic",
-          "from": { "key_code": "o", "modifiers": { "mandatory": ["fn", "left_option", "left_shift"], "optional": ["caps_lock"] } },
-          "to": [ { "key_code": "i", "modifiers": ["left_option"] }, { "key_code": "o", "modifiers": ["left_shift"] } ]
+          "from": {
+            "key_code": "o",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_option",
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "i",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "o",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
         },
         {
           "type": "basic",
-          "from": { "key_code": "u", "modifiers": { "mandatory": ["fn", "left_option"], "optional": ["caps_lock"] } },
-          "to": [ { "key_code": "i", "modifiers": ["left_option"] }, { "key_code": "u" } ]
+          "from": {
+            "key_code": "u",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_option"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "i",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "u"
+            }
+          ]
         },
         {
           "type": "basic",
-          "from": { "key_code": "u", "modifiers": { "mandatory": ["fn", "left_option", "left_shift"], "optional": ["caps_lock"] } },
-          "to": [ { "key_code": "i", "modifiers": ["left_option"] }, { "key_code": "u", "modifiers": ["left_shift"] } ]
+          "from": {
+            "key_code": "u",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_option",
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "i",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "u",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
         }
       ]
     },
     {
-      "description": "French cedilla and ligatures (Fn + c/q)",
+      "description": "HyperJIS: French cedilla and ligatures (Fn + c/q)",
       "manipulators": [
         {
           "type": "basic",
-          "from": { "key_code": "c", "modifiers": { "mandatory": ["fn"], "optional": ["caps_lock"] } },
-          "to": [ { "key_code": "c", "modifiers": ["left_option"] } ]
+          "from": {
+            "key_code": "c",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "c",
+              "modifiers": [
+                "left_option"
+              ]
+            }
+          ]
         },
         {
           "type": "basic",
-          "from": { "key_code": "c", "modifiers": { "mandatory": ["fn", "left_shift"], "optional": ["caps_lock"] } },
-          "to": [ { "key_code": "c", "modifiers": ["left_option", "left_shift"] } ]
+          "from": {
+            "key_code": "c",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "c",
+              "modifiers": [
+                "left_option",
+                "left_shift"
+              ]
+            }
+          ]
         },
         {
           "type": "basic",
-          "from": { "key_code": "q", "modifiers": { "mandatory": ["fn"], "optional": ["caps_lock"] } },
-          "to": [ { "key_code": "q", "modifiers": ["left_option"] } ]
+          "from": {
+            "key_code": "q",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "q",
+              "modifiers": [
+                "left_option"
+              ]
+            }
+          ]
         },
         {
           "type": "basic",
-          "from": { "key_code": "q", "modifiers": { "mandatory": ["fn", "left_shift"], "optional": ["caps_lock"] } },
-          "to": [ { "key_code": "q", "modifiers": ["left_option", "left_shift"] } ]
+          "from": {
+            "key_code": "q",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "q",
+              "modifiers": [
+                "left_option",
+                "left_shift"
+              ]
+            }
+          ]
         }
       ]
     }

--- a/public/json/hyperjis-accents-german.json
+++ b/public/json/hyperjis-accents-german.json
@@ -1,48 +1,206 @@
 {
   "title": "HyperJIS Accents: German Extension (Umlauts + Eszett)",
+  "maintainers": [
+    "smnrg"
+  ],
   "rules": [
     {
-      "description": "German umlauts (Fn + Option + a/o/u)",
+      "description": "HyperJIS: German umlauts (Fn + Option + a/o/u)",
       "manipulators": [
         {
           "type": "basic",
-          "from": { "key_code": "a", "modifiers": { "mandatory": ["fn", "left_option"], "optional": ["caps_lock"] } },
-          "to": [ { "key_code": "u", "modifiers": ["left_option"] }, { "key_code": "a" } ]
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_option"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "u",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "a"
+            }
+          ]
         },
         {
           "type": "basic",
-          "from": { "key_code": "a", "modifiers": { "mandatory": ["fn", "left_option", "left_shift"], "optional": ["caps_lock"] } },
-          "to": [ { "key_code": "u", "modifiers": ["left_option"] }, { "key_code": "a", "modifiers": ["left_shift"] } ]
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_option",
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "u",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "a",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
         },
         {
           "type": "basic",
-          "from": { "key_code": "o", "modifiers": { "mandatory": ["fn", "left_option"], "optional": ["caps_lock"] } },
-          "to": [ { "key_code": "u", "modifiers": ["left_option"] }, { "key_code": "o" } ]
+          "from": {
+            "key_code": "o",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_option"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "u",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "o"
+            }
+          ]
         },
         {
           "type": "basic",
-          "from": { "key_code": "o", "modifiers": { "mandatory": ["fn", "left_option", "left_shift"], "optional": ["caps_lock"] } },
-          "to": [ { "key_code": "u", "modifiers": ["left_option"] }, { "key_code": "o", "modifiers": ["left_shift"] } ]
+          "from": {
+            "key_code": "o",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_option",
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "u",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "o",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
         },
         {
           "type": "basic",
-          "from": { "key_code": "u", "modifiers": { "mandatory": ["fn", "left_option"], "optional": ["caps_lock"] } },
-          "to": [ { "key_code": "u", "modifiers": ["left_option"] }, { "key_code": "u" } ]
+          "from": {
+            "key_code": "u",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_option"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "u",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "u"
+            }
+          ]
         },
         {
           "type": "basic",
-          "from": { "key_code": "u", "modifiers": { "mandatory": ["fn", "left_option", "left_shift"], "optional": ["caps_lock"] } },
-          "to": [ { "key_code": "u", "modifiers": ["left_option"] }, { "key_code": "u", "modifiers": ["left_shift"] } ]
+          "from": {
+            "key_code": "u",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_option",
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "u",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "u",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
         }
       ]
     },
     {
-      "description": "German Eszett (Fn + s)",
+      "description": "HyperJIS: German Eszett (Fn + s)",
       "manipulators": [
         {
           "type": "basic",
-          "from": { "key_code": "s", "modifiers": { "mandatory": ["fn"], "optional": ["caps_lock"] } },
-          "to": [ { "key_code": "s", "modifiers": ["left_option"] } ]
+          "from": {
+            "key_code": "s",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "s",
+              "modifiers": [
+                "left_option"
+              ]
+            }
+          ]
         }
       ]
     }

--- a/public/json/hyperjis-accents-romance.json
+++ b/public/json/hyperjis-accents-romance.json
@@ -1,8 +1,11 @@
 {
   "title": "HyperJIS Accents: Romance Base (Grave/Acute + Typography)",
+  "maintainers": [
+    "smnrg"
+  ],
   "rules": [
     {
-      "description": "Grave and acute accents on all vowels (Fn + vowel, double-tap to swap)",
+      "description": "HyperJIS: Grave and acute accents on all vowels (Fn + vowel, double-tap to swap)",
       "manipulators": [
         {
           "type": "basic",
@@ -947,7 +950,7 @@
       ]
     },
     {
-      "description": "Typography: Euro, guillemets, smart quotes",
+      "description": "HyperJIS: Typography — Euro, guillemets, smart quotes",
       "manipulators": [
         {
           "type": "basic",

--- a/public/json/hyperjis-accents-spanish.json
+++ b/public/json/hyperjis-accents-spanish.json
@@ -1,28 +1,110 @@
 {
   "title": "HyperJIS Accents: Spanish Extension (Ñ + Inverted Punctuation)",
+  "maintainers": [
+    "smnrg"
+  ],
   "rules": [
     {
-      "description": "Spanish characters (Fn + n/1//)",
+      "description": "HyperJIS: Spanish characters (Fn + n/1//)",
       "manipulators": [
         {
           "type": "basic",
-          "from": { "key_code": "n", "modifiers": { "mandatory": ["fn"], "optional": ["caps_lock"] } },
-          "to": [ { "key_code": "n", "modifiers": ["left_option"] }, { "key_code": "n" } ]
+          "from": {
+            "key_code": "n",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "n",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "n"
+            }
+          ]
         },
         {
           "type": "basic",
-          "from": { "key_code": "n", "modifiers": { "mandatory": ["fn", "left_shift"], "optional": ["caps_lock"] } },
-          "to": [ { "key_code": "n", "modifiers": ["left_option"] }, { "key_code": "n", "modifiers": ["left_shift"] } ]
+          "from": {
+            "key_code": "n",
+            "modifiers": {
+              "mandatory": [
+                "fn",
+                "left_shift"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "n",
+              "modifiers": [
+                "left_option"
+              ]
+            },
+            {
+              "key_code": "n",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
         },
         {
           "type": "basic",
-          "from": { "key_code": "1", "modifiers": { "mandatory": ["fn"], "optional": ["caps_lock"] } },
-          "to": [ { "key_code": "1", "modifiers": ["left_option"] } ]
+          "from": {
+            "key_code": "1",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "1",
+              "modifiers": [
+                "left_option"
+              ]
+            }
+          ]
         },
         {
           "type": "basic",
-          "from": { "key_code": "slash", "modifiers": { "mandatory": ["fn"], "optional": ["caps_lock"] } },
-          "to": [ { "key_code": "slash", "modifiers": ["left_option", "left_shift"] } ]
+          "from": {
+            "key_code": "slash",
+            "modifiers": {
+              "mandatory": [
+                "fn"
+              ],
+              "optional": [
+                "caps_lock"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "slash",
+              "modifiers": [
+                "left_option",
+                "left_shift"
+              ]
+            }
+          ]
         }
       ]
     }

--- a/public/json/hyperjis-core.json
+++ b/public/json/hyperjis-core.json
@@ -1,153 +1,11 @@
 {
   "title": "HyperJIS — Core Layout (JIS → US + Vim + Hyper + Tiling)",
+  "maintainers": [
+    "smnrg"
+  ],
   "rules": [
     {
-      "description": "HyperJIS: Caps Lock — tap for Escape, hold for Control",
-      "manipulators": [
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "caps_lock",
-            "modifiers": {
-              "optional": [
-                "any"
-              ]
-            }
-          },
-          "to_if_alone": [
-            {
-              "key_code": "escape"
-            }
-          ],
-          "to_if_held_down": [
-            {
-              "key_code": "left_control"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "HyperJIS: Space — tap for Space, hold for Left Control",
-      "manipulators": [
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "spacebar",
-            "modifiers": {
-              "optional": [
-                "any"
-              ]
-            }
-          },
-          "to_if_alone": [
-            {
-              "key_code": "spacebar"
-            }
-          ],
-          "to_if_held_down": [
-            {
-              "key_code": "left_control"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "HyperJIS: Left Control — tap for Escape, hold for Control",
-      "manipulators": [
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "left_control",
-            "modifiers": {
-              "optional": [
-                "any"
-              ]
-            }
-          },
-          "to_if_alone": [
-            {
-              "key_code": "escape"
-            }
-          ],
-          "to_if_held_down": [
-            {
-              "key_code": "left_control"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "HyperJIS: Left Option → Hyper Key (⌃⌥⇧⌘)",
-      "manipulators": [
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "left_option",
-            "modifiers": {
-              "optional": [
-                "any"
-              ]
-            }
-          },
-          "to_if_alone": [
-            {
-              "key_code": "left_shift",
-              "modifiers": [
-                "left_command",
-                "left_control",
-                "left_option"
-              ]
-            }
-          ],
-          "to_if_held_down": [
-            {
-              "key_code": "left_shift",
-              "modifiers": [
-                "left_command",
-                "left_control",
-                "left_option"
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "HyperJIS: Fn — tap for Language Switch, hold for Hyper (⌃⌥⇧⌘)",
-      "manipulators": [
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "fn",
-            "modifiers": {
-              "optional": [
-                "any"
-              ]
-            }
-          },
-          "to_if_alone": [
-            {
-              "apple_vendor_top_case_key_code": "keyboard_fn"
-            }
-          ],
-          "to_if_held_down": [
-            {
-              "key_code": "left_shift",
-              "modifiers": [
-                "left_command",
-                "left_control",
-                "left_option"
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "HyperJIS: Vim Navigation — Left Ctrl + H/J/K/L → Arrow Keys",
+      "description": "HyperJIS: Vim navigation — Left Ctrl + H/J/K/L → Arrow keys",
       "manipulators": [
         {
           "type": "basic",
@@ -228,91 +86,7 @@
       ]
     },
     {
-      "description": "HyperJIS: JIS Bottom Row — Eisuu (英数) → Left Command",
-      "manipulators": [
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "japanese_eisuu",
-            "modifiers": {
-              "optional": [
-                "any"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "left_command"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "HyperJIS: JIS Bottom Row — Kana (かな) → Right Command",
-      "manipulators": [
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "japanese_kana",
-            "modifiers": {
-              "optional": [
-                "any"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "right_command"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "HyperJIS: Left Command → Left Option",
-      "manipulators": [
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "left_command",
-            "modifiers": {
-              "optional": [
-                "any"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "left_option"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "HyperJIS: Right Command → Right Option",
-      "manipulators": [
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "right_command",
-            "modifiers": {
-              "optional": [
-                "any"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "right_option"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "HyperJIS: International3 (¥) → Grave Accent / Tilde",
+      "description": "HyperJIS: International3 (¥) → Grave accent / Tilde",
       "manipulators": [
         {
           "type": "basic",
@@ -387,27 +161,7 @@
       ]
     },
     {
-      "description": "HyperJIS: International1 → Emoji Picker (⌃⌘Space)",
-      "manipulators": [
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "international1"
-          },
-          "to": [
-            {
-              "key_code": "spacebar",
-              "modifiers": [
-                "left_command",
-                "left_control"
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "HyperJIS: Escape — tap for Screenshot, hold for Hyper+W",
+      "description": "HyperJIS: Escape — tap for Screenshot (⇧⌘4), hold for ⌃⌥⇧⌘W",
       "manipulators": [
         {
           "type": "basic",
@@ -438,7 +192,230 @@
       ]
     },
     {
-      "description": "HyperJIS: Arrow Keys → Fn+HJKL (frees arrows for window tiling via Swish)",
+      "description": "HyperJIS: International1 (ろ) → Emoji picker (⌃⌘Space)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "international1"
+          },
+          "to": [
+            {
+              "key_code": "spacebar",
+              "modifiers": [
+                "left_command",
+                "left_control"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "HyperJIS: Space — tap for Space, hold for Left Control",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "spacebar",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to_if_alone": [
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "to_if_held_down": [
+            {
+              "key_code": "left_control"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "HyperJIS: Left Control — tap for Escape, hold for Control",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_control",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to_if_alone": [
+            {
+              "key_code": "escape"
+            }
+          ],
+          "to_if_held_down": [
+            {
+              "key_code": "left_control"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "HyperJIS: Left Option → Hyper key (⌃⌥⇧⌘)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_option",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to_if_alone": [
+            {
+              "key_code": "left_shift",
+              "modifiers": [
+                "left_command",
+                "left_control",
+                "left_option"
+              ]
+            }
+          ],
+          "to_if_held_down": [
+            {
+              "key_code": "left_shift",
+              "modifiers": [
+                "left_command",
+                "left_control",
+                "left_option"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "HyperJIS: Fn — tap for Language Switch, hold for Hyper (⌃⌥⇧⌘)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "fn",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to_if_alone": [
+            {
+              "apple_vendor_top_case_key_code": "keyboard_fn"
+            }
+          ],
+          "to_if_held_down": [
+            {
+              "key_code": "left_shift",
+              "modifiers": [
+                "left_command",
+                "left_control",
+                "left_option"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "HyperJIS: Left Command → Left Option",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_command",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_option"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "HyperJIS: Eisuu (英数) → Left Command",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "japanese_eisuu",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_command"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "HyperJIS: Kana (かな) → Right Command",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "japanese_kana",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_command"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "HyperJIS: Right Command → Right Option",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_command",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_option"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "HyperJIS: Arrow keys → Fn+HJKL (frees arrows for window tiling)",
       "manipulators": [
         {
           "type": "basic",
@@ -513,6 +490,27 @@
               "modifiers": [
                 "fn"
               ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "HyperJIS: Caps Lock → Fn",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "caps_lock",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "fn"
             }
           ]
         }


### PR DESCRIPTION
Updates to the HyperJIS rules merged in #1947:

- Dual-function Escape (tap → ⇧⌘4 screenshot, hold → ⌃⌥⇧⌘W) instead of simple screenshot
- Added "maintainers": ["smnrg"] field to all 5 files for site attribution
- Verified all rules match the upstream HyperJIS v1.0.2 release

No structural changes, no new files, no groups.json changes needed.