### PR TITLE
Add right_control hold for Doubao voice input rule

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -1121,6 +1121,9 @@
           "path": "json/left_option_to_chinese.json"
         },
         {
+          "path": "json/right-ctrl-doubao-voice-input.json"
+        },
+        {
           "path": "json/japanese.json"
         },
         {

--- a/public/json/right-ctrl-doubao-voice-input.json
+++ b/public/json/right-ctrl-doubao-voice-input.json
@@ -1,0 +1,53 @@
+{
+    "title": "Hold right_control to activate Doubao voice input, switch back to WeChat input on release (rev 1)",
+    "maintainers": [
+        "Molunerfinn"
+    ],
+    "rules": [
+        {
+            "description": "Hold right_control: switch to Doubao input + activate fn; release: switch back to WeChat input",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "right_control",
+                        "modifiers": {
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "select_input_source": {
+                                "input_source_id": "^com\\.bytedance\\.inputmethod\\.doubaoime\\.pinyin$"
+                            },
+                            "hold_down_milliseconds": 50
+                        },
+                        {
+                            "key_code": "fn"
+                        }
+                    ],
+                    "to_after_key_up": [
+                        {
+                            "set_variable": {
+                                "name": "__delay__",
+                                "value": 1
+                            },
+                            "hold_down_milliseconds": 1000
+                        },
+                        {
+                            "select_input_source": {
+                                "input_source_id": "^com\\.tencent\\.inputmethod\\.wetype\\.pinyin$"
+                            },
+                            "hold_down_milliseconds": 50
+                        },
+                        {
+                            "key_code": "left_shift"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

- Add a new complex modification rule: hold `right_control` to switch to Doubao IME and activate `fn` key for voice input; on release, switch back to WeChat IME with Chinese input mode restored.
- Register the rule under the "International (Language Specific)" group in `groups.json`.

## Details

**On press:**
1. Switch input source to Doubao IME (`com.bytedance.inputmethod.doubaoime.pinyin`)
2. Wait 50ms for the input source to settle
3. Activate `fn` key (triggers Doubao's voice input)

**On release:**
1. Wait 1 second for pending voice input to commit
2. Switch input source back to WeChat IME (`com.tencent.inputmethod.wetype.pinyin`)
3. Wait 50ms, then press `Shift` to restore Chinese input mode

## Test plan

- [x] `make all` passes with no errors
- [ ] Rule imported and tested in Karabiner-Elements