### PR TITLE
Enable shift for Layer 4 in neo_layouts_based_on_abc_extended

### DIFF
--- a/public/json/neo_layouts_based_on_abc_extended_layout.json
+++ b/public/json/neo_layouts_based_on_abc_extended_layout.json
@@ -265,7 +265,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -297,7 +298,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -329,7 +331,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -361,7 +364,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -401,7 +405,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -432,7 +437,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -467,7 +473,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -499,7 +506,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -530,7 +538,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -561,7 +570,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -592,7 +602,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -623,7 +634,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -654,7 +666,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -686,7 +699,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -717,7 +731,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -748,7 +763,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -779,7 +795,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -810,7 +827,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -841,7 +859,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -873,7 +892,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -904,7 +924,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -935,7 +956,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -966,7 +988,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -997,7 +1020,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -1028,7 +1052,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -1060,7 +1085,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -1091,7 +1117,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -1122,7 +1149,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -1153,7 +1181,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -1184,7 +1213,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -1215,7 +1245,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -1250,7 +1281,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -1281,7 +1313,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -1312,7 +1345,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -1343,7 +1377,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -1374,7 +1409,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -1405,7 +1441,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -1436,7 +1473,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -1467,7 +1505,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -1498,7 +1537,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -1530,7 +1570,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -1561,7 +1602,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -1592,7 +1634,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -1623,7 +1666,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -1654,7 +1698,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -4872,7 +4917,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -4904,7 +4950,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -4936,7 +4983,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -4968,7 +5016,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5008,7 +5057,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5039,7 +5089,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5074,7 +5125,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5106,7 +5158,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5137,7 +5190,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5168,7 +5222,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5199,7 +5254,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5230,7 +5286,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5261,7 +5318,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5293,7 +5351,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5324,7 +5383,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5355,7 +5415,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5386,7 +5447,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5417,7 +5479,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5448,7 +5511,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5480,7 +5544,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5511,7 +5576,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5542,7 +5608,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5573,7 +5640,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5604,7 +5672,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5635,7 +5704,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5667,7 +5737,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5698,7 +5769,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5729,7 +5801,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5760,7 +5833,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5791,7 +5865,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5822,7 +5897,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5857,7 +5933,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5888,7 +5965,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5919,7 +5997,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5950,7 +6029,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -5981,7 +6061,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -6012,7 +6093,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -6043,7 +6125,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -6074,7 +6157,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -6105,7 +6189,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -6137,7 +6222,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -6168,7 +6254,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -6199,7 +6286,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -6230,7 +6318,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -6261,7 +6350,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -9479,7 +9569,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -9511,7 +9602,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -9543,7 +9635,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -9575,7 +9668,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -9615,7 +9709,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -9646,7 +9741,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -9681,7 +9777,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -9713,7 +9810,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -9744,7 +9842,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -9775,7 +9874,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -9806,7 +9906,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -9837,7 +9938,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -9868,7 +9970,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -9900,7 +10003,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -9931,7 +10035,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -9962,7 +10067,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -9993,7 +10099,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10024,7 +10131,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10055,7 +10163,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10087,7 +10196,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10118,7 +10228,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10149,7 +10260,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10180,7 +10292,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10211,7 +10324,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10242,7 +10356,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10274,7 +10389,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10305,7 +10421,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10336,7 +10453,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10367,7 +10485,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10398,7 +10517,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10429,7 +10549,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10464,7 +10585,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10495,7 +10617,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10526,7 +10649,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10557,7 +10681,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10588,7 +10713,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10619,7 +10745,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10650,7 +10777,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10681,7 +10809,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10712,7 +10841,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10744,7 +10874,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10775,7 +10906,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10806,7 +10938,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10837,7 +10970,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -10868,7 +11002,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -23300,7 +23435,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -23332,7 +23468,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -23364,7 +23501,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -23396,7 +23534,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -23436,7 +23575,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -23467,7 +23607,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -23502,7 +23643,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -23534,7 +23676,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -23565,7 +23708,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -23596,7 +23740,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -23627,7 +23772,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -23658,7 +23804,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -23689,7 +23836,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -23721,7 +23869,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -23752,7 +23901,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -23783,7 +23933,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -23814,7 +23965,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -23845,7 +23997,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -23876,7 +24029,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -23908,7 +24062,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -23939,7 +24094,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -23970,7 +24126,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -24001,7 +24158,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -24032,7 +24190,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -24063,7 +24222,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -24095,7 +24255,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -24126,7 +24287,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -24157,7 +24319,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -24188,7 +24351,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -24219,7 +24383,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -24250,7 +24415,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -24285,7 +24451,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -24316,7 +24483,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -24347,7 +24515,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -24378,7 +24547,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -24409,7 +24579,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -24440,7 +24611,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -24471,7 +24643,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -24502,7 +24675,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -24533,7 +24707,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -24565,7 +24740,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -24596,7 +24772,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -24627,7 +24804,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -24658,7 +24836,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -24689,7 +24868,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -27907,7 +28087,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -27939,7 +28120,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -27971,7 +28153,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28003,7 +28186,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28043,7 +28227,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28074,7 +28259,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28109,7 +28295,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28141,7 +28328,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28172,7 +28360,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28203,7 +28392,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28234,7 +28424,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28265,7 +28456,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28296,7 +28488,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28328,7 +28521,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28359,7 +28553,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28390,7 +28585,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28421,7 +28617,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28452,7 +28649,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28483,7 +28681,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28515,7 +28714,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28546,7 +28746,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28577,7 +28778,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28608,7 +28810,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28639,7 +28842,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28670,7 +28874,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28702,7 +28907,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28733,7 +28939,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28764,7 +28971,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28795,7 +29003,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28826,7 +29035,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28857,7 +29067,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28892,7 +29103,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28923,7 +29135,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28954,7 +29167,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -28985,7 +29199,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -29016,7 +29231,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -29047,7 +29263,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -29078,7 +29295,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -29109,7 +29327,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -29140,7 +29359,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -29172,7 +29392,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -29203,7 +29424,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -29234,7 +29456,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -29265,7 +29488,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },
@@ -29296,7 +29520,8 @@
               "optional": [
                 "control",
                 "option",
-                "command"
+                "command",
+                "shift"
               ]
             }
           },

--- a/src/json/neo_layouts_based_on_abc_extended_layout.json.js
+++ b/src/json/neo_layouts_based_on_abc_extended_layout.json.js
@@ -80,7 +80,7 @@ function neo2() {
           fromKeys: remapFromKeys.concat(['spacebar']),
           toKeys: remapToLayer4Keys.concat(['keypad_0']),
           fromModifiers: {
-            optional: ['control', 'option', 'command']
+            optional: ['control', 'option', 'command', 'shift']
           },
           conditions: [ifMod4On, isLayoutActive]
         }
@@ -146,7 +146,7 @@ function neoQwertz() {
           fromKeys: remapFromKeys.concat(['spacebar']),
           toKeys: remapToLayer4Keys.concat(['keypad_0']),
           fromModifiers: {
-            optional: ['control', 'option', 'command']
+            optional: ['control', 'option', 'command', 'shift']
           },
           conditions: [ifMod4On, isLayoutActive]
         }
@@ -212,7 +212,7 @@ function bone() {
           fromKeys: remapFromKeys.concat(['spacebar']),
           toKeys: remapToLayer4Keys.concat(['keypad_0']),
           fromModifiers: {
-            optional: ['control', 'option', 'command']
+            optional: ['control', 'option', 'command', 'shift']
           },
           conditions: [ifMod4On, isLayoutActive]
         }
@@ -438,7 +438,7 @@ function adnw() {
           fromKeys: remapFromKeys.concat(['spacebar']),
           toKeys: remapToLayer4Keys.concat(['keypad_0']),
           fromModifiers: {
-            optional: ['control', 'option', 'command']
+            optional: ['control', 'option', 'command', 'shift']
           },
           conditions: [ifMod4On, isLayoutActive]
         }
@@ -504,7 +504,7 @@ function koy() {
           fromKeys: remapFromKeys.concat(['spacebar']),
           toKeys: remapToLayer4Keys.concat(['keypad_0']),
           fromModifiers: {
-            optional: ['control', 'option', 'command']
+            optional: ['control', 'option', 'command', 'shift']
           },
           conditions: [ifMod4On, isLayoutActive]
         }


### PR DESCRIPTION
Using shift with the layer 4 movement keys does not select text. This change addresses this shortcoming.