### PR TITLE
shift switch input method for Mac default

### DIFF
--- a/public/json/shift_switch_inputmethod_next.json
+++ b/public/json/shift_switch_inputmethod_next.json
@@ -1,0 +1,52 @@
+{
+  "title": "shift switch input method",
+  "rules": [
+    {
+      "description": "shift switch input method for Mac default next",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "left_shift"
+          },
+          "to": [
+            {
+              "key_code": "right_shift",
+              "lazy": true
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "spacebar",
+              "modifiers": [
+                "control",
+                "option"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_shift"
+          },
+          "to": [
+            {
+              "key_code": "right_shift",
+              "lazy": true
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "spacebar",
+              "modifiers": [
+                "control",
+                "option"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/public/json/shift_switch_inputmethod_up.json
+++ b/public/json/shift_switch_inputmethod_up.json
@@ -1,0 +1,50 @@
+{
+  "title": "shift switch input method",
+  "rules": [
+    {
+      "description": "shift switch input method for Mac default up",
+      "manipulators": [
+        {
+          "from": {
+            "key_code": "left_shift"
+          },
+          "to": [
+            {
+              "key_code": "left_shift",
+              "lazy": true
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "spacebar",
+              "modifiers": [
+                "control"
+              ]
+            }
+          ],
+          "type": "basic"
+        },
+        {
+          "from": {
+            "key_code": "right_shift"
+          },
+          "to": [
+            {
+              "key_code": "right_shift",
+              "lazy": true
+            }
+          ],
+          "to_if_alone": [
+            {
+              "key_code": "spacebar",
+              "modifiers": [
+                "control"
+              ]
+            }
+          ],
+          "type": "basic"
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/shift_switch_inputmethod_next.json.js
+++ b/src/json/shift_switch_inputmethod_next.json.js
@@ -1,0 +1,60 @@
+// JavaScript should be written in ECMAScript 5.1.
+
+function main() {
+  console.log(
+    JSON.stringify(
+      {
+        title: 'shift switch input method',
+        rules: [
+          {
+            description: "shift switch input method for Mac default next",
+            manipulators: [
+              {
+                type: "basic",
+                from: {
+                  key_code: "left_shift"
+                },
+                to: [
+                  {
+                    key_code: "right_shift",
+                    lazy: true
+                  }
+                ],
+                to_if_alone: [
+                  {
+                    key_code: "spacebar",
+                    modifiers: ["control", "option"]
+                  }
+                ]
+              },
+              {
+                type: "basic",
+                from: {
+                  key_code: "right_shift"
+                },
+                to: [
+                  {
+                    key_code: "right_shift",
+                    lazy: true
+                  }
+                ],
+                to_if_alone: [
+                  {
+                    key_code: "spacebar",
+                    modifiers: ["control", "option"]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+      },
+      null,
+      '  '
+    )
+  )
+}
+
+main()
+
+

--- a/src/json/shift_switch_inputmethod_up.json.js
+++ b/src/json/shift_switch_inputmethod_up.json.js
@@ -1,0 +1,58 @@
+// JavaScript should be written in ECMAScript 5.1.
+
+function main() {
+  console.log(
+    JSON.stringify(
+      {
+        title: 'shift switch input method',
+        rules: [
+          {
+            description: "shift switch input method for Mac default up",
+            manipulators: [
+              {
+                from: {
+                  key_code: "left_shift",
+                },
+                to: [
+                  {
+                    key_code: "left_shift",
+                    lazy: true
+                  }
+                ],
+                to_if_alone: [
+                  {
+                    key_code: "spacebar",
+                    modifiers: ["control"]
+                  }
+                ],
+                type: "basic"
+              },
+              {
+                from: {
+                  key_code: "right_shift",
+                },
+                to: [
+                  {
+                    key_code: "right_shift",
+                    lazy: true
+                  }
+                ],
+                to_if_alone: [
+                  {
+                    key_code: "spacebar",
+                    modifiers: ["control"]
+                  }
+                ],
+                type: "basic"
+              }
+            ]
+          }
+        ],
+      },
+      null,
+      '  '
+    )
+  )
+}
+
+main()


### PR DESCRIPTION
It's customary for Chinese users to switch input methods with Shift.
Single press Shift switches input language, long press keeps original Shift function.
Verified and running correctly.