### PR TITLE
Add DoubaoIME voice input switch rule

### DIFF
--- a/public/extra_descriptions/double_tap_right_command_switch_doubaoime.json.html
+++ b/public/extra_descriptions/double_tap_right_command_switch_doubaoime.json.html
@@ -1,0 +1,19 @@
+<p>
+  This rule is designed for using DoubaoIME as a temporary voice input mode while keeping another input source for regular typing.
+  <kbd>right_command</kbd> remains available as a normal modifier, and only a double tap triggers the workflow.
+</p>
+
+<ul>
+  <li>First double tap: switch to Doubao Pinyin, wait briefly, then tap <kbd>right_option</kbd> twice to start voice input.</li>
+  <li>Second double tap: tap <kbd>right_option</kbd> twice to stop voice input, wait for recognition to finish, then switch back to Rime.</li>
+</ul>
+
+<p>
+  By default, the second double tap switches back to Rime. To return to another input source, replace the Rime
+  <code>input_source_id</code> with your preferred input source ID before importing the rule.
+</p>
+
+<p>
+  See the original article for background and setup notes:
+  <a href="https://blog.cold04.com/p/doubaoime_easyswitch_karabiner/" target="_blank" rel="noopener noreferrer">DoubaoIME voice input quick switching with Karabiner-Elements</a>.
+</p>

--- a/public/groups.json
+++ b/public/groups.json
@@ -1127,6 +1127,10 @@
           "path": "json/right-ctrl-doubao-voice-input.json"
         },
         {
+          "path": "json/double_tap_right_command_switch_doubaoime.json",
+          "extra_description_path": "extra_descriptions/double_tap_right_command_switch_doubaoime.json.html"
+        },
+        {
           "path": "json/japanese.json"
         },
         {

--- a/public/json/double_tap_right_command_switch_doubaoime.json
+++ b/public/json/double_tap_right_command_switch_doubaoime.json
@@ -1,0 +1,168 @@
+{
+  "title": "Double tap right_command to switch DoubaoIME voice input (rev 1)",
+  "maintainers": [
+    "Coldin04"
+  ],
+  "rules": [
+    {
+      "description": "Double tap right_command to enter DoubaoIME voice input; double tap again to stop voice input and switch back to Rime.",
+      "manipulators": [
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "double_tap_right_command_switch_doubaoime_tapped_once",
+              "value": 1
+            },
+            {
+              "type": "variable_unless",
+              "name": "double_tap_right_command_switch_doubaoime_active",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "right_command",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "select_input_source": {
+                "input_source_id": "^com\\.bytedance\\.inputmethod\\.doubaoime\\.pinyin$"
+              }
+            },
+            {
+              "key_code": "vk_none",
+              "hold_down_milliseconds": 300
+            },
+            {
+              "key_code": "right_option",
+              "hold_down_milliseconds": 60
+            },
+            {
+              "key_code": "right_option",
+              "hold_down_milliseconds": 60
+            },
+            {
+              "set_variable": {
+                "name": "double_tap_right_command_switch_doubaoime_active",
+                "value": 1
+              }
+            },
+            {
+              "set_variable": {
+                "name": "double_tap_right_command_switch_doubaoime_tapped_once",
+                "value": 0
+              }
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "double_tap_right_command_switch_doubaoime_tapped_once",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "double_tap_right_command_switch_doubaoime_active",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "right_command",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_option",
+              "hold_down_milliseconds": 60
+            },
+            {
+              "key_code": "right_option",
+              "hold_down_milliseconds": 60
+            },
+            {
+              "key_code": "vk_none",
+              "hold_down_milliseconds": 5000
+            },
+            {
+              "select_input_source": {
+                "input_source_id": "^im\\.rime\\.inputmethod\\.Squirrel\\.Hans$"
+              }
+            },
+            {
+              "set_variable": {
+                "name": "double_tap_right_command_switch_doubaoime_active",
+                "value": 0
+              }
+            },
+            {
+              "set_variable": {
+                "name": "double_tap_right_command_switch_doubaoime_tapped_once",
+                "value": 0
+              }
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "right_command",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "parameters": {
+            "basic.to_delayed_action_delay_milliseconds": 450,
+            "basic.to_if_alone_timeout_milliseconds": 250
+          },
+          "to": [
+            {
+              "key_code": "right_command",
+              "lazy": true
+            }
+          ],
+          "to_if_alone": [
+            {
+              "set_variable": {
+                "name": "double_tap_right_command_switch_doubaoime_tapped_once",
+                "value": 1
+              }
+            }
+          ],
+          "to_delayed_action": {
+            "to_if_canceled": [
+              {
+                "set_variable": {
+                  "name": "double_tap_right_command_switch_doubaoime_tapped_once",
+                  "value": 0
+                }
+              }
+            ],
+            "to_if_invoked": [
+              {
+                "set_variable": {
+                  "name": "double_tap_right_command_switch_doubaoime_tapped_once",
+                  "value": 0
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/double_tap_right_command_switch_doubaoime.json.js
+++ b/src/json/double_tap_right_command_switch_doubaoime.json.js
@@ -1,0 +1,173 @@
+// JavaScript should be written in ECMAScript 5.1.
+
+var doubaoInputSourceId = '^com\\.bytedance\\.inputmethod\\.doubaoime\\.pinyin$'
+var returnInputSourceId = '^im\\.rime\\.inputmethod\\.Squirrel\\.Hans$'
+var returnInputSourceName = 'Rime'
+
+function main() {
+  console.log(
+    JSON.stringify(
+      {
+        title: 'Double tap right_command to switch DoubaoIME voice input (rev 1)',
+        maintainers: ['Coldin04'],
+        rules: [
+          {
+            description:
+              'Double tap right_command to enter DoubaoIME voice input; double tap again to stop voice input and switch back to ' +
+              returnInputSourceName +
+              '.',
+            manipulators: [
+              {
+                type: 'basic',
+                conditions: [
+                  {
+                    type: 'variable_if',
+                    name: 'double_tap_right_command_switch_doubaoime_tapped_once',
+                    value: 1,
+                  },
+                  {
+                    type: 'variable_unless',
+                    name: 'double_tap_right_command_switch_doubaoime_active',
+                    value: 1,
+                  },
+                ],
+                from: {
+                  key_code: 'right_command',
+                  modifiers: { optional: ['any'] },
+                },
+                to: [
+                  {
+                    select_input_source: {
+                      input_source_id: doubaoInputSourceId,
+                    },
+                  },
+                  {
+                    key_code: 'vk_none',
+                    hold_down_milliseconds: 300,
+                  },
+                  {
+                    key_code: 'right_option',
+                    hold_down_milliseconds: 60,
+                  },
+                  {
+                    key_code: 'right_option',
+                    hold_down_milliseconds: 60,
+                  },
+                  {
+                    set_variable: {
+                      name: 'double_tap_right_command_switch_doubaoime_active',
+                      value: 1,
+                    },
+                  },
+                  {
+                    set_variable: {
+                      name: 'double_tap_right_command_switch_doubaoime_tapped_once',
+                      value: 0,
+                    },
+                  },
+                ],
+              },
+              {
+                type: 'basic',
+                conditions: [
+                  {
+                    type: 'variable_if',
+                    name: 'double_tap_right_command_switch_doubaoime_tapped_once',
+                    value: 1,
+                  },
+                  {
+                    type: 'variable_if',
+                    name: 'double_tap_right_command_switch_doubaoime_active',
+                    value: 1,
+                  },
+                ],
+                from: {
+                  key_code: 'right_command',
+                  modifiers: { optional: ['any'] },
+                },
+                to: [
+                  {
+                    key_code: 'right_option',
+                    hold_down_milliseconds: 60,
+                  },
+                  {
+                    key_code: 'right_option',
+                    hold_down_milliseconds: 60,
+                  },
+                  {
+                    key_code: 'vk_none',
+                    hold_down_milliseconds: 5000,
+                  },
+                  {
+                    select_input_source: {
+                      input_source_id: returnInputSourceId,
+                    },
+                  },
+                  {
+                    set_variable: {
+                      name: 'double_tap_right_command_switch_doubaoime_active',
+                      value: 0,
+                    },
+                  },
+                  {
+                    set_variable: {
+                      name: 'double_tap_right_command_switch_doubaoime_tapped_once',
+                      value: 0,
+                    },
+                  },
+                ],
+              },
+              {
+                type: 'basic',
+                from: {
+                  key_code: 'right_command',
+                  modifiers: { optional: ['any'] },
+                },
+                parameters: {
+                  'basic.to_delayed_action_delay_milliseconds': 450,
+                  'basic.to_if_alone_timeout_milliseconds': 250,
+                },
+                to: [
+                  {
+                    key_code: 'right_command',
+                    lazy: true,
+                  },
+                ],
+                to_if_alone: [
+                  {
+                    set_variable: {
+                      name: 'double_tap_right_command_switch_doubaoime_tapped_once',
+                      value: 1,
+                    },
+                  },
+                ],
+                to_delayed_action: {
+                  to_if_canceled: [
+                    {
+                      set_variable: {
+                        name: 'double_tap_right_command_switch_doubaoime_tapped_once',
+                        value: 0,
+                      },
+                    },
+                  ],
+                  to_if_invoked: [
+                    {
+                      set_variable: {
+                        name: 'double_tap_right_command_switch_doubaoime_tapped_once',
+                        value: 0,
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+      null,
+      '  '
+    )
+  )
+}
+
+main()


### PR DESCRIPTION
## Summary
- Add a DoubaoIME voice input switch rule triggered by double tapping right_command.
- Keep right_command available as a normal modifier unless double tapped.
- Add an extra description with customization notes and the original article link.

## Validation
- Ran make all
- Tested locally in Karabiner-Elements