### PR TITLE
docs(function-keys): improve description and fix logi logic

### DIFF
--- a/public/extra_descriptions/function_keys_supported_apps.html
+++ b/public/extra_descriptions/function_keys_supported_apps.html
@@ -1,37 +1,103 @@
 <p style="margin-top: 20px; font-weight: bold">
- Use Function Keys in supported applications, else use Media Keys
+  How it works
 </p>
 
 <p>
-  These keybindings ensure that F keys work as intended in supported applications. <br/><br/>
-  In all other applications, the F keys will work as media keys.
+  By default on macOS, function keys (F1-F12) act as media/system keys (brightness, volume, etc.).
+  This rule overrides that so F keys always behave as true function keys inside supported
+  applications, with no need to hold <code>Fn</code>.
 </p>
 
 <p>
-  Current list of supported applications where function keys will work as intended:
+  The behaviour depends on two things: whether the active app is in the supported list, and
+  whether you are using a Logitech keyboard.
 </p>
 
-<ul>
-  <li>VS Code</li>
-  <li>Jetbrains Goland</li>
-  <li>Jetbrains Rider</li>
-  <li>Jetbrains PyCharm</li>
-  <li>Jetbrains IntelliJ IDEA</li>
-  <li>Jetbrains PhpStorm</li>
-  <li>Jetbrains CLion</li>
-  <li>Jetbrains WebStorm</li>
-  <li>Jetbrains RubyMine</li>
-  <li>Jetbrains Datagrip</li>
-  <li>Jetbrains RustRover</li>
-  <li>Eclipse</li>
-  <li>XCode</li>
-  <li>iTerm2</li>
-  <li>Terminal</li>
-  <li>Adobe Photoshop</li>
-  <li>Adobe Premiere Pro</li>
-  <li>Adobe Illustrator</li>
-  <li>Adobe Audition</li>
-  <li>Adobe After Effects</li>
-  <li>Davinci Resolve</li>
-  <li>Textmate</li>
-</ul>
+<p style="margin-top: 20px; font-weight: bold">
+  Behaviour by scenario
+</p>
+
+<table class="table">
+  <tr>
+    <th style="width: 220px;">Scenario</th>
+    <th style="width: 80px;">Keys</th>
+    <th>Result</th>
+  </tr>
+  <tr>
+    <td>Supported app - any keyboard</td>
+    <td>F1-F12</td>
+    <td>True function key. Karabiner passes the keypress through unchanged.</td>
+  </tr>
+  <tr>
+    <td>Non-supported app - any keyboard</td>
+    <td>F1, F2</td>
+    <td>Media key. F1 = brightness down, F2 = brightness up.</td>
+  </tr>
+  <tr>
+    <td>Non-supported app - non-Logitech keyboard</td>
+    <td>F3-F12</td>
+    <td>Media key (see mapping table below). Karabiner remaps these to system actions.</td>
+  </tr>
+  <tr>
+    <td>Non-supported app - Logitech keyboard</td>
+    <td>F3-F12</td>
+    <td>Passed through unchanged. Logi Options+ handles the media mapping natively, so Karabiner leaves these alone to avoid conflicts.</td>
+  </tr>
+</table>
+
+<p style="margin-top: 20px; font-weight: bold">
+  Media key mapping (non-supported app, non-Logitech keyboard)
+</p>
+
+<table class="table">
+  <tr>
+    <th style="width: 100px;">Key</th>
+    <th>Media action</th>
+  </tr>
+  <tr><td>F1</td><td>Brightness down (all keyboards)</td></tr>
+  <tr><td>F2</td><td>Brightness up (all keyboards)</td></tr>
+  <tr><td>F3</td><td>Mission Control</td></tr>
+  <tr><td>F4</td><td>Spotlight</td></tr>
+  <tr><td>F5</td><td>Dictation</td></tr>
+  <tr><td>F6</td><td>No media action assigned - passes through as F6</td></tr>
+  <tr><td>F7</td><td>Rewind</td></tr>
+  <tr><td>F8</td><td>Play / Pause</td></tr>
+  <tr><td>F9</td><td>Fast Forward</td></tr>
+  <tr><td>F10</td><td>Mute</td></tr>
+  <tr><td>F11</td><td>Volume down</td></tr>
+  <tr><td>F12</td><td>Volume up</td></tr>
+</table>
+
+<p style="margin-top: 20px; font-weight: bold">
+  Supported applications (F keys always behave as true function keys)
+</p>
+
+<table class="table">
+  <tr>
+    <th style="width: 220px;">Application</th>
+    <th>Notes</th>
+  </tr>
+  <tr><td>VS Code</td><td>Includes VS Code Insiders</td></tr>
+  <tr><td>Cursor</td><td></td></tr>
+  <tr><td>JetBrains GoLand</td><td></td></tr>
+  <tr><td>JetBrains Rider</td><td></td></tr>
+  <tr><td>JetBrains PyCharm</td><td>Includes Community Edition</td></tr>
+  <tr><td>JetBrains IntelliJ IDEA</td><td>Includes Community Edition</td></tr>
+  <tr><td>JetBrains PhpStorm</td><td></td></tr>
+  <tr><td>JetBrains CLion</td><td></td></tr>
+  <tr><td>JetBrains WebStorm</td><td></td></tr>
+  <tr><td>JetBrains RubyMine</td><td></td></tr>
+  <tr><td>JetBrains DataGrip</td><td></td></tr>
+  <tr><td>JetBrains RustRover</td><td>Includes EAP builds</td></tr>
+  <tr><td>Eclipse</td><td></td></tr>
+  <tr><td>Xcode</td><td></td></tr>
+  <tr><td>iTerm2</td><td></td></tr>
+  <tr><td>Terminal</td><td>macOS built-in Terminal</td></tr>
+  <tr><td>Adobe Photoshop</td><td></td></tr>
+  <tr><td>Adobe Premiere Pro</td><td>Versions 23 and 24</td></tr>
+  <tr><td>Adobe Illustrator</td><td></td></tr>
+  <tr><td>Adobe Audition</td><td></td></tr>
+  <tr><td>Adobe After Effects</td><td></td></tr>
+  <tr><td>DaVinci Resolve</td><td></td></tr>
+  <tr><td>TextMate</td><td></td></tr>
+</table>

--- a/public/json/function_keys_supported_apps.json
+++ b/public/json/function_keys_supported_apps.json
@@ -43,15 +43,9 @@
           ],
           "from": {
             "key_code": "f1",
-            "modifiers": {
-              "optional": ["any"]
-            }
+            "modifiers": { "optional": ["any"] }
           },
-          "to": [
-            {
-              "key_code": "f1"
-            }
-          ],
+          "to": [{ "key_code": "f1" }],
           "type": "basic"
         },
         {
@@ -92,15 +86,9 @@
           ],
           "from": {
             "key_code": "f2",
-            "modifiers": {
-              "optional": ["any"]
-            }
+            "modifiers": { "optional": ["any"] }
           },
-          "to": [
-            {
-              "key_code": "f2"
-            }
-          ],
+          "to": [{ "key_code": "f2" }],
           "type": "basic"
         },
         {
@@ -137,19 +125,22 @@
                 "^com\\.macromates\\.TextMate$"
               ],
               "type": "frontmost_application_if"
+            },
+            {
+              "identifiers": [
+                {
+                  "product_id": 45944,
+                  "vendor_id": 1133
+                }
+              ],
+              "type": "device_if"
             }
           ],
           "from": {
             "key_code": "f3",
-            "modifiers": {
-              "optional": ["any"]
-            }
+            "modifiers": { "optional": ["any"] }
           },
-          "to": [
-            {
-              "key_code": "f3"
-            }
-          ],
+          "to": [{ "key_code": "f3" }],
           "type": "basic"
         },
         {
@@ -186,19 +177,22 @@
                 "^com\\.macromates\\.TextMate$"
               ],
               "type": "frontmost_application_if"
+            },
+            {
+              "identifiers": [
+                {
+                  "product_id": 45944,
+                  "vendor_id": 1133
+                }
+              ],
+              "type": "device_if"
             }
           ],
           "from": {
             "key_code": "f4",
-            "modifiers": {
-              "optional": ["any"]
-            }
+            "modifiers": { "optional": ["any"] }
           },
-          "to": [
-            {
-              "key_code": "f4"
-            }
-          ],
+          "to": [{ "key_code": "f4" }],
           "type": "basic"
         },
         {
@@ -239,15 +233,9 @@
           ],
           "from": {
             "key_code": "f5",
-            "modifiers": {
-              "optional": ["any"]
-            }
+            "modifiers": { "optional": ["any"] }
           },
-          "to": [
-            {
-              "key_code": "f5"
-            }
-          ],
+          "to": [{ "key_code": "f5" }],
           "type": "basic"
         },
         {
@@ -288,15 +276,9 @@
           ],
           "from": {
             "key_code": "f6",
-            "modifiers": {
-              "optional": ["any"]
-            }
+            "modifiers": { "optional": ["any"] }
           },
-          "to": [
-            {
-              "key_code": "f6"
-            }
-          ],
+          "to": [{ "key_code": "f6" }],
           "type": "basic"
         },
         {
@@ -337,15 +319,9 @@
           ],
           "from": {
             "key_code": "f7",
-            "modifiers": {
-              "optional": ["any"]
-            }
+            "modifiers": { "optional": ["any"] }
           },
-          "to": [
-            {
-              "key_code": "f7"
-            }
-          ],
+          "to": [{ "key_code": "f7" }],
           "type": "basic"
         },
         {
@@ -386,15 +362,9 @@
           ],
           "from": {
             "key_code": "f8",
-            "modifiers": {
-              "optional": ["any"]
-            }
+            "modifiers": { "optional": ["any"] }
           },
-          "to": [
-            {
-              "key_code": "f8"
-            }
-          ],
+          "to": [{ "key_code": "f8" }],
           "type": "basic"
         },
         {
@@ -435,15 +405,9 @@
           ],
           "from": {
             "key_code": "f9",
-            "modifiers": {
-              "optional": ["any"]
-            }
+            "modifiers": { "optional": ["any"] }
           },
-          "to": [
-            {
-              "key_code": "f9"
-            }
-          ],
+          "to": [{ "key_code": "f9" }],
           "type": "basic"
         },
         {
@@ -484,15 +448,9 @@
           ],
           "from": {
             "key_code": "f10",
-            "modifiers": {
-              "optional": ["any"]
-            }
+            "modifiers": { "optional": ["any"] }
           },
-          "to": [
-            {
-              "key_code": "f10"
-            }
-          ],
+          "to": [{ "key_code": "f10" }],
           "type": "basic"
         },
         {
@@ -533,15 +491,9 @@
           ],
           "from": {
             "key_code": "f11",
-            "modifiers": {
-              "optional": ["any"]
-            }
+            "modifiers": { "optional": ["any"] }
           },
-          "to": [
-            {
-              "key_code": "f11"
-            }
-          ],
+          "to": [{ "key_code": "f11" }],
           "type": "basic"
         },
         {
@@ -582,15 +534,9 @@
           ],
           "from": {
             "key_code": "f12",
-            "modifiers": {
-              "optional": ["any"]
-            }
+            "modifiers": { "optional": ["any"] }
           },
-          "to": [
-            {
-              "key_code": "f12"
-            }
-          ],
+          "to": [{ "key_code": "f12" }],
           "type": "basic"
         },
         {
@@ -631,15 +577,9 @@
           ],
           "from": {
             "key_code": "f1",
-            "modifiers": {
-              "optional": ["any"]
-            }
+            "modifiers": { "optional": ["any"] }
           },
-          "to": [
-            {
-              "consumer_key_code": "display_brightness_decrement"
-            }
-          ],
+          "to": [{ "consumer_key_code": "display_brightness_decrement" }],
           "type": "basic"
         },
         {
@@ -680,15 +620,9 @@
           ],
           "from": {
             "key_code": "f2",
-            "modifiers": {
-              "optional": ["any"]
-            }
+            "modifiers": { "optional": ["any"] }
           },
-          "to": [
-            {
-              "consumer_key_code": "display_brightness_increment"
-            }
-          ],
+          "to": [{ "consumer_key_code": "display_brightness_increment" }],
           "type": "basic"
         },
         {
@@ -725,19 +659,17 @@
                 "^com\\.macromates\\.TextMate$"
               ],
               "type": "frontmost_application_unless"
+            },
+            {
+              "identifiers": [{ "vendor_id": 1133 }],
+              "type": "device_unless"
             }
           ],
           "from": {
             "key_code": "f3",
-            "modifiers": {
-              "optional": ["any"]
-            }
+            "modifiers": { "optional": ["any"] }
           },
-          "to": [
-            {
-              "apple_vendor_keyboard_key_code": "mission_control"
-            }
-          ],
+          "to": [{ "apple_vendor_keyboard_key_code": "mission_control" }],
           "type": "basic"
         },
         {
@@ -774,19 +706,17 @@
                 "^com\\.macromates\\.TextMate$"
               ],
               "type": "frontmost_application_unless"
+            },
+            {
+              "identifiers": [{ "vendor_id": 1133 }],
+              "type": "device_unless"
             }
           ],
           "from": {
             "key_code": "f4",
-            "modifiers": {
-              "optional": ["any"]
-            }
+            "modifiers": { "optional": ["any"] }
           },
-          "to": [
-            {
-              "apple_vendor_keyboard_key_code": "spotlight"
-            }
-          ],
+          "to": [{ "apple_vendor_keyboard_key_code": "spotlight" }],
           "type": "basic"
         },
         {
@@ -823,19 +753,17 @@
                 "^com\\.macromates\\.TextMate$"
               ],
               "type": "frontmost_application_unless"
+            },
+            {
+              "identifiers": [{ "vendor_id": 1133 }],
+              "type": "device_unless"
             }
           ],
           "from": {
             "key_code": "f5",
-            "modifiers": {
-              "optional": ["any"]
-            }
+            "modifiers": { "optional": ["any"] }
           },
-          "to": [
-            {
-              "consumer_key_code": "dictation"
-            }
-          ],
+          "to": [{ "consumer_key_code": "dictation" }],
           "type": "basic"
         },
         {
@@ -872,19 +800,17 @@
                 "^com\\.macromates\\.TextMate$"
               ],
               "type": "frontmost_application_unless"
+            },
+            {
+              "identifiers": [{ "vendor_id": 1133 }],
+              "type": "device_unless"
             }
           ],
           "from": {
             "key_code": "f6",
-            "modifiers": {
-              "optional": ["any"]
-            }
+            "modifiers": { "optional": ["any"] }
           },
-          "to": [
-            {
-              "key_code": "f6"
-            }
-          ],
+          "to": [{ "key_code": "f6" }],
           "type": "basic"
         },
         {
@@ -921,19 +847,17 @@
                 "^com\\.macromates\\.TextMate$"
               ],
               "type": "frontmost_application_unless"
+            },
+            {
+              "identifiers": [{ "vendor_id": 1133 }],
+              "type": "device_unless"
             }
           ],
           "from": {
             "key_code": "f7",
-            "modifiers": {
-              "optional": ["any"]
-            }
+            "modifiers": { "optional": ["any"] }
           },
-          "to": [
-            {
-              "consumer_key_code": "rewind"
-            }
-          ],
+          "to": [{ "consumer_key_code": "rewind" }],
           "type": "basic"
         },
         {
@@ -970,19 +894,17 @@
                 "^com\\.macromates\\.TextMate$"
               ],
               "type": "frontmost_application_unless"
+            },
+            {
+              "identifiers": [{ "vendor_id": 1133 }],
+              "type": "device_unless"
             }
           ],
           "from": {
             "key_code": "f8",
-            "modifiers": {
-              "optional": ["any"]
-            }
+            "modifiers": { "optional": ["any"] }
           },
-          "to": [
-            {
-              "consumer_key_code": "play_or_pause"
-            }
-          ],
+          "to": [{ "consumer_key_code": "play_or_pause" }],
           "type": "basic"
         },
         {
@@ -1019,19 +941,17 @@
                 "^com\\.macromates\\.TextMate$"
               ],
               "type": "frontmost_application_unless"
+            },
+            {
+              "identifiers": [{ "vendor_id": 1133 }],
+              "type": "device_unless"
             }
           ],
           "from": {
             "key_code": "f9",
-            "modifiers": {
-              "optional": ["any"]
-            }
+            "modifiers": { "optional": ["any"] }
           },
-          "to": [
-            {
-              "consumer_key_code": "fastforward"
-            }
-          ],
+          "to": [{ "consumer_key_code": "fastforward" }],
           "type": "basic"
         },
         {
@@ -1068,19 +988,17 @@
                 "^com\\.macromates\\.TextMate$"
               ],
               "type": "frontmost_application_unless"
+            },
+            {
+              "identifiers": [{ "vendor_id": 1133 }],
+              "type": "device_unless"
             }
           ],
           "from": {
             "key_code": "f10",
-            "modifiers": {
-              "optional": ["any"]
-            }
+            "modifiers": { "optional": ["any"] }
           },
-          "to": [
-            {
-              "consumer_key_code": "mute"
-            }
-          ],
+          "to": [{ "consumer_key_code": "mute" }],
           "type": "basic"
         },
         {
@@ -1117,19 +1035,17 @@
                 "^com\\.macromates\\.TextMate$"
               ],
               "type": "frontmost_application_unless"
+            },
+            {
+              "identifiers": [{ "vendor_id": 1133 }],
+              "type": "device_unless"
             }
           ],
           "from": {
             "key_code": "f11",
-            "modifiers": {
-              "optional": ["any"]
-            }
+            "modifiers": { "optional": ["any"] }
           },
-          "to": [
-            {
-              "consumer_key_code": "volume_decrement"
-            }
-          ],
+          "to": [{ "consumer_key_code": "volume_decrement" }],
           "type": "basic"
         },
         {
@@ -1166,19 +1082,17 @@
                 "^com\\.macromates\\.TextMate$"
               ],
               "type": "frontmost_application_unless"
+            },
+            {
+              "identifiers": [{ "vendor_id": 1133 }],
+              "type": "device_unless"
             }
           ],
           "from": {
             "key_code": "f12",
-            "modifiers": {
-              "optional": ["any"]
-            }
+            "modifiers": { "optional": ["any"] }
           },
-          "to": [
-            {
-              "consumer_key_code": "volume_increment"
-            }
-          ],
+          "to": [{ "consumer_key_code": "volume_increment" }],
           "type": "basic"
         }
       ]


### PR DESCRIPTION
- rewrite html with scenario table covering all 4 cases
- clarify that supported apps always get true f keys regardless of keyboard
- clarify logitech keyboards are excluded from f3-f12 media remaps only
- add f1-f12 media key mapping table
- add missing apps: cursor, vs code insiders
- scope f3/f4 supported-app pass-through to logitech keyboard only
- add device_unless to all f3-f12 media key manipulators