### PR TITLE
feat(final-cut-pro): add middle-click horizontal timeline scroll rule

### DIFF
--- a/public/extra_descriptions/final_cut_pro.html
+++ b/public/extra_descriptions/final_cut_pro.html
@@ -1,3 +1,20 @@
+<p>
+  A set of mouse and keyboard shortcuts for Final Cut Pro that make common editing tasks faster - scrolling the timeline, trimming clips, making cuts, and adjusting zoom - without having to switch tools manually.
+</p>
+
+<p style="margin-top: 20px; font-weight: bold">
+  Scroll the timeline with the mouse
+</p>
+
+<table class="table">
+  <tr>
+    <td style="width: 300px;">Button 3 (middle-click, hold and drag)</td>
+    <td>
+      Switches to the hand tool and scrolls the timeline horizontally while held. Releasing the button automatically reverts back to the select tool.
+    </td>
+  </tr>
+</table>
+
 <p style="margin-top: 20px; font-weight: bold">
   Trim clips with the mouse
 </p>

--- a/public/json/final_cut_pro.json
+++ b/public/json/final_cut_pro.json
@@ -3,6 +3,23 @@
   "maintainers": ["thecarlo"],
   "rules": [
     {
+      "description": "Final Cut Pro: mouse button 3 → horizontal timeline scroll (hold to drag, release to revert to select tool)",
+      "manipulators": [
+        {
+          "conditions": [
+            {
+              "bundle_identifiers": ["^com\\.apple\\.FinalCut$"],
+              "type": "frontmost_application_if"
+            }
+          ],
+          "from": { "pointing_button": "button3" },
+          "to": [{ "key_code": "h" }, { "pointing_button": "button1" }],
+          "to_after_key_up": [{ "key_code": "a" }],
+          "type": "basic"
+        }
+      ]
+    },
+    {
       "description": "Final Cut Pro: left option + left click → trim start (option + [)",
       "manipulators": [
         {


### PR DESCRIPTION
- add button 3 rule to scroll timeline horizontally while held
- add intro paragraph to extra descriptions HTML
- add "scroll the timeline with the mouse" section with description