### PR TITLE
docs(extra_descriptions): improve descriptions for rules

### DIFF
--- a/public/extra_descriptions/google_chrome.html
+++ b/public/extra_descriptions/google_chrome.html
@@ -1,106 +1,133 @@
 <p style="margin-top: 20px; font-weight: bold">
- Hyper Key
+  Hyper Key
 </p>
 
 <p>
-  The caps lock hyper key is included for quick left handed access to all the shortcuts.
+  Includes the Caps Lock hyper key as the foundation for all Chrome shortcuts in this pack. Caps Lock is
+  remapped to a unique modifier combination (⌃⇧⌘) that doesn't conflict with any built-in Chrome or macOS
+  shortcut, giving you a dedicated left-hand anchor key that's fast to reach without lifting your hand off
+  the home row.
+</p>
+
+<p>
+  All shortcuts in this pack are built on top of the hyper key, so activating them is a single fluid
+  motion - hold Caps Lock and tap a letter - rather than awkward multi-finger contortions across the keyboard.
 </p>
 
 <table class="table">
   <tr>
     <td style="width: 300px;">Caps Lock</td>
     <td>
-      Maps to left control + left shift + right command (⌃⇧⌘).
-      The Caps lock is disabled.
+      Maps to left control + left shift + right command (⌃⇧⌘). Used as the hyper key for all Chrome
+      shortcuts in this pack. The Caps Lock function is not lost - use double-tap right shift instead.
     </td>
   </tr>
   <tr>
     <td style="width: 300px;">Double-tap right shift</td>
-    <td>Caps lock toggle</td>
+    <td>Toggle caps lock on/off</td>
   </tr>
 </table>
 
 <p style="margin-top: 20px; font-weight: bold">
-  Tab Management Keymappings
+  Tab Management
+</p>
+
+<p>
+  Shortcuts for managing tabs without reaching for the mouse. Switch between recent tabs, duplicate the
+  current tab, or pop a tab out into its own window - all from the home row.
 </p>
 
 <table class="table">
   <tr>
-    <td style="width: 300px;">Caps lock hyper key + a</td>
-    <td>Search Tabs</td>
+    <td style="width: 300px;">Caps Lock Hyper Key + a</td>
+    <td>Search tabs - quickly find and switch to any open tab by name</td>
   </tr>
   <tr>
-    <td style="width: 300px;">Caps lock hyper key + w</td>
-    <td>Toggle between last used tabs (requires <a target="_blank" href="https://chromewebstore.google.com/detail/clut-cycle-last-used-tabs/cobieddmkhhnbeldhncnfcgcaccmehgn">CLUT: Cycle Last Used Tabs extension</a>)</td>
-  </tr>
-  <tr>
-    <td style="width: 300px;">Caps lock hyper key + e</td>
+    <td style="width: 300px;">Caps Lock Hyper Key + w</td>
     <td>
-      Duplicate tab (requires <a target="_blank" href="https://chrome.google.com/webstore/detail/klehggjefofgiajjfpoebdidnpjmljhb">Duplicate Tab Shortcut extension</a>)
+      Toggle between last used tabs - jump back and forth between your two most recent tabs (requires
+      <a target="_blank" href="https://chromewebstore.google.com/detail/clut-cycle-last-used-tabs/cobieddmkhhnbeldhncnfcgcaccmehgn">CLUT: Cycle Last Used Tabs extension</a>)
     </td>
   </tr>
   <tr>
-    <td style="width: 300px;">Caps lock hyper key + t</td>
+    <td style="width: 300px;">Caps Lock Hyper Key + e</td>
     <td>
-      Move tab to a new window (requires <a target="_blank" href="https://chromewebstore.google.com/detail/pop-out-tabs-to-new-windo/lhnaddgiebpcecbcmfcjmlhinfpkkjii">Pop out tabs to new window extension</a>)
+      Duplicate the current tab - useful for keeping your original page open while exploring a new path
+      (requires <a target="_blank" href="https://chrome.google.com/webstore/detail/klehggjefofgiajjfpoebdidnpjmljhb">Duplicate Tab Shortcut extension</a>)
+    </td>
+  </tr>
+  <tr>
+    <td style="width: 300px;">Caps Lock Hyper Key + t</td>
+    <td>
+      Move the current tab to a new window - ideal for side-by-side comparisons or separating work contexts
+      (requires <a target="_blank" href="https://chromewebstore.google.com/detail/pop-out-tabs-to-new-windo/lhnaddgiebpcecbcmfcjmlhinfpkkjii">Pop out tabs to new window extension</a>)
     </td>
   </tr>
 </table>
 
 <p style="margin-top: 20px; font-weight: bold">
-  Misc Keymappings
+  Browser Actions
+</p>
+
+<p>
+  Common browser actions mapped to the hyper key for fast, consistent access without hunting through menus.
 </p>
 
 <table class="table">
   <tr>
-    <td style="width: 300px;">Caps lock hyper key + q</td>
+    <td style="width: 300px;">Caps Lock Hyper Key + q</td>
     <td>Switch between Google Chrome profiles</td>
   </tr>
   <tr>
-    <td style="width: 300px;">Caps lock hyper key + r</td>
-    <td>Reload page</td>
+    <td style="width: 300px;">Caps Lock Hyper Key + r</td>
+    <td>Reload the current page</td>
   </tr>
   <tr>
-    <td style="width: 300px;">Caps lock hyper key + s</td>
-    <td>Select address</td>
+    <td style="width: 300px;">Caps Lock Hyper Key + s</td>
+    <td>Select the address bar - jump straight to the URL for quick navigation or copying</td>
   </tr>
   <tr>
-    <td style="width: 300px;">Caps lock hyper key + d</td>
+    <td style="width: 300px;">Caps Lock Hyper Key + d</td>
     <td>Clear browsing history</td>
   </tr>
   <tr>
-    <td style="width: 300px;">Caps lock hyper key + f</td>
-    <td>Search the web</td>
+    <td style="width: 300px;">Caps Lock Hyper Key + f</td>
+    <td>Search the web - focuses the address bar ready for a new search query</td>
   </tr>
   <tr>
-    <td style="width: 300px;">Caps lock hyper key + g</td>
+    <td style="width: 300px;">Caps Lock Hyper Key + g</td>
     <td>View downloads</td>
   </tr>
 </table>
 
 <p style="margin-top: 20px; font-weight: bold">
-  Developer Tools Keymappings
+  Developer Tools
+</p>
+
+<p>
+  One-key access to Chrome's developer tools panels, so you can jump straight to the panel you need instead
+  of navigating through menus or remembering separate shortcuts for each panel.
 </p>
 
 <table class="table">
   <tr>
-    <td style="width: 300px;">Caps lock hyper key + 1</td>
-    <td>Developer Tools</td>
+    <td style="width: 300px;">Caps Lock Hyper Key + 1</td>
+    <td>Open developer tools</td>
   </tr>
   <tr>
-    <td style="width: 300px;">Caps lock hyper key + 2</td>
-    <td>Developer Console</td>
+    <td style="width: 300px;">Caps Lock Hyper Key + 2</td>
+    <td>Open developer console</td>
   </tr>
   <tr>
-    <td style="width: 300px;">Caps lock hyper key + 3</td>
-    <td>Developer Elements Panel</td>
+    <td style="width: 300px;">Caps Lock Hyper Key + 3</td>
+    <td>Open developer elements panel - inspect and modify the DOM and CSS</td>
   </tr>
   <tr>
-    <td style="width: 300px;">Caps lock hyper key + 4</td>
-    <td>View Source</td>
+    <td style="width: 300px;">Caps Lock Hyper Key + 4</td>
+    <td>View page source</td>
   </tr>
   <tr>
-    <td style="width: 300px;">Caps lock hyper key + q</td>
-    <td>Toggle device toolbar (when you already have a developer panel open)</td>
+    <td style="width: 300px;">Caps Lock Hyper Key + q</td>
+    <td>Toggle device toolbar (when a developer panel is already open) - simulate different screen sizes and devices</td>
   </tr>
 </table>

--- a/public/extra_descriptions/mac_osx.html
+++ b/public/extra_descriptions/mac_osx.html
@@ -1,82 +1,97 @@
 <p style="margin-top: 20px; font-weight: bold">
- Hyper Keys
+  Hyper Keys
 </p>
 
 <p>
-  Includes 3 hyper keys for maximum flexibility.
+  Remaps three underused keys into powerful "hyper" modifier keys. Each produces a unique modifier combination
+  that doesn't conflict with any built-in macOS or application shortcut, giving you a dedicated namespace of
+  conflict-free custom shortcuts across your entire system.
 </p>
 
 <table class="table">
   <tr>
-    <td style="width: 200px;">Right Option</td>
-    <td>
-      Maps to left shift + left option + left command (⌃⇧⌥⌘)
-    </td>
-  </tr>
-  <tr>
     <td style="width: 200px;">Caps Lock</td>
     <td>
-      Maps to left control + left shift + right command (⌃⇧⌘)
-      The Caps lock is disabled.
+      Maps to left control + left shift + right command (⌃⇧⌘) - use this as your primary hyper key for
+      app-level shortcuts. The Caps Lock function is not lost - use double-tap right shift instead (see below).
     </td>
   </tr>
   <tr>
     <td style="width: 200px;">Tab (held down)</td>
     <td>
-      Maps to left control + left command (⌃⌘)
+      Maps to left control + left command (⌃⌘) when held - a secondary hyper key. Tap Tab normally to type a
+      tab character as usual.
+    </td>
+  </tr>
+  <tr>
+    <td style="width: 200px;">Right Option</td>
+    <td>
+      Maps to left control + left shift + left option + left command (⌃⇧⌥⌘) - an additional hyper key for
+      extra shortcut capacity.
     </td>
   </tr>
 </table>
 
 <p style="margin-top: 20px; font-weight: bold">
- Toggle Caps Lock
+  Toggle Caps Lock
 </p>
 
 <p>
-  Since the Caps Lock key is set up as a hyper key, double-tap the right shift key to toggle Caps lock.
+  Because Caps Lock is repurposed as a hyper key, this rule restores caps lock functionality via a double-tap
+  of the right shift key. This is intentionally a two-step gesture to prevent accidental activation.
 </p>
 
 <table class="table">
   <tr>
     <td style="width: 200px;">Double-tap right shift</td>
-    <td>caps lock toggle</td>
+    <td>Toggle caps lock on/off</td>
   </tr>
 </table>
 
 <p style="margin-top: 20px; font-weight: bold">
-  Closing Applications
+  Prevent Accidentally Closing Applications
 </p>
 
 <p>
-  Since it's easy to accidentally hit CMD + Q and close an application, I've changed this so that you need to hit CMD + q, q to close an application.
+  CMD + Q sits right next to CMD + W (close tab), making it easy to accidentally quit an entire application
+  instead of just closing a tab. This rule requires a deliberate double-tap of Q while holding CMD, so a
+  single mis-press does nothing.
 </p>
 
 <table class="table">
   <tr>
     <td style="width: 200px;">cmd + double-tap q</td>
-    <td>close application</td>
+    <td>Quit application</td>
   </tr>
 </table>
 
 <p style="margin-top: 20px; font-weight: bold">
-   Disable minimising windows on Mac OSX.
+  Disable Hiding and Minimising Windows
 </p>
 
 <p>
-   Minimising windows on OSX is annoying as the windows disappear and leads to unnecessary friction to find the windows and open them again.
+  CMD + H hides the frontmost application and CMD + Option + H hides all other applications. These shortcuts
+  are easy to hit by accident and send windows to the Dock where they are out of sight and require extra
+  clicks to recover. Disabling them eliminates that friction and keeps your workspace predictable.
 </p>
 
 <table class="table">
   <tr>
-    <td style="width: 400px;">cmd + h (minimise the active application window)</td>
+    <td style="width: 400px;">cmd + h (hide the active application)</td>
     <td>
-      Keybinding is disabled
+      Disabled
     </td>
   </tr>
   <tr>
-    <td style="width: 400px;">cmd + option + h + m (minimise all application windows)</td>
+    <td style="width: 400px;">cmd + option + h (hide all other applications)</td>
     <td>
-      Keybinding is disabled
+      Disabled
+    </td>
+  </tr>
+  <tr>
+    <td style="width: 400px;">cmd + option + m (minimise all windows)</td>
+    <td>
+      Disabled
     </td>
   </tr>
 </table>

--- a/public/extra_descriptions/mac_osx_disable_minimising_windows.html
+++ b/public/extra_descriptions/mac_osx_disable_minimising_windows.html
@@ -1,22 +1,30 @@
 <p style="margin-top: 20px; font-weight: bold">
- Disable minimising windows on Mac OSX.
+  Disable Hiding and Minimising Windows
 </p>
 
 <p>
- Minimising windows on OSX is annoying as the windows disappear and leads to unnecessary friction to find the windows and open them again.
+  CMD + H hides the frontmost application and CMD + Option + H hides all other applications. These shortcuts
+  are easy to hit by accident and send windows to the Dock where they are out of sight and require extra
+  clicks to recover. Disabling them eliminates that friction and keeps your workspace predictable.
 </p>
 
 <table class="table">
   <tr>
-    <td style="width: 400px;">cmd + h (minimise the active application window)</td>
+    <td style="width: 400px;">cmd + h (hide the active application)</td>
     <td>
-      Keybinding is disabled
+      Disabled
     </td>
   </tr>
   <tr>
-    <td style="width: 400px;">cmd + option + h + m (minimise all application windows)</td>
+    <td style="width: 400px;">cmd + option + h (hide all other applications)</td>
     <td>
-      Keybinding is disabled
+      Disabled
+    </td>
+  </tr>
+  <tr>
+    <td style="width: 400px;">cmd + option + m (minimise all windows)</td>
+    <td>
+      Disabled
     </td>
   </tr>
 </table>

--- a/public/extra_descriptions/mac_osx_double_tap_q_close_application.html
+++ b/public/extra_descriptions/mac_osx_double_tap_q_close_application.html
@@ -1,0 +1,16 @@
+<p style="margin-top: 20px; font-weight: bold">
+  Prevent Accidentally Closing Applications
+</p>
+
+<p>
+  CMD + Q sits right next to CMD + W (close tab), making it easy to accidentally quit an entire application
+  instead of just closing a tab. This rule requires a deliberate double-tap of Q while holding CMD, so a
+  single mis-press does nothing.
+</p>
+
+<table class="table">
+  <tr>
+    <td style="width: 200px;">cmd + double-tap q</td>
+    <td>Quit application</td>
+  </tr>
+</table>

--- a/public/extra_descriptions/slack.html
+++ b/public/extra_descriptions/slack.html
@@ -1,86 +1,109 @@
 <p style="margin-top: 20px; font-weight: bold">
- Hyper Key
+  Hyper Key
 </p>
 
 <p>
-  The caps lock hyper key is included for quick left handed access to all the shortcuts.
+  Includes the Caps Lock hyper key as the foundation for all Slack shortcuts in this pack. Caps Lock is
+  remapped to a unique modifier combination (⌃⇧⌘) that doesn't conflict with any built-in Slack or macOS
+  shortcut, giving you a dedicated left-hand anchor key that's fast to reach without lifting your hand off
+  the home row.
+</p>
+
+<p>
+  All shortcuts in this pack are built on top of the hyper key, so activating them is a single fluid
+  motion - hold Caps Lock and tap a letter or number - rather than awkward multi-finger contortions across
+  the keyboard.
 </p>
 
 <table class="table">
   <tr>
     <td style="width: 350px;">Caps Lock</td>
     <td>
-      Maps to left control + left shift + right command (⌃⇧⌘).
-      The Caps lock is disabled.
+      Maps to left control + left shift + right command (⌃⇧⌘). Used as the hyper key for all Slack
+      shortcuts in this pack. The Caps Lock function is not lost - use double-tap right shift instead.
     </td>
   </tr>
   <tr>
     <td style="width: 350px;">Double-tap right shift</td>
-    <td>Caps lock toggle</td>
+    <td>Toggle caps lock on/off</td>
   </tr>
 </table>
 
 <p style="margin-top: 20px; font-weight: bold">
-  Searching and Navigation
+  Navigation
+</p>
+
+<p>
+  Jump directly to the views you use most in Slack without clicking through the sidebar. Get to unread
+  messages, DMs, and activity notifications instantly.
 </p>
 
 <table class="table">
   <tr>
-    <td style="width: 350px;">Caps Lock Hyper key + a</td>
-    <td>Quick search</td>
+    <td style="width: 350px;">Caps Lock Hyper Key + a</td>
+    <td>Quick search - fuzzy search across channels, people, and messages</td>
   </tr>
   <tr>
-    <td style="width: 350px;">Caps Lock Hyper key + 1</td>
-    <td>Navigate to activity</td>
+    <td style="width: 350px;">Caps Lock Hyper Key + 1</td>
+    <td>Activity - view all recent notifications and mentions in one place</td>
   </tr>
   <tr>
-    <td style="width: 350px;">Caps Lock Hyper key + 2</td>
-    <td>Navigate to DMs</td>
+    <td style="width: 350px;">Caps Lock Hyper Key + 2</td>
+    <td>Direct messages - jump to your DM list</td>
   </tr>
   <tr>
-    <td style="width: 350px;">Caps Lock Hyper key + 3</td>
-    <td>Navigate to all unread messages</td>
+    <td style="width: 350px;">Caps Lock Hyper Key + 3</td>
+    <td>All unread messages - see every unread message across all channels at a glance</td>
   </tr>
 </table>
 
 <p style="margin-top: 20px; font-weight: bold">
-  Formatting and Messages
+  Message Formatting
+</p>
+
+<p>
+  Format messages without reaching for the toolbar. Useful when sharing code snippets, commands, or
+  quoting someone's message in a reply.
 </p>
 
 <table class="table">
   <tr>
-    <td style="width: 350px;">Caps Lock Hyper key + q</td>
-    <td>Format selection as quote</td>
+    <td style="width: 350px;">Caps Lock Hyper Key + s</td>
+    <td>Inline code format - wrap selected text in backticks for inline code</td>
   </tr>
   <tr>
-    <td style="width: 350px;">Caps Lock Hyper key + s</td>
-    <td>Code format</td>
+    <td style="width: 350px;">Caps Lock Hyper Key + d</td>
+    <td>Code block - wrap selected text in a multi-line code block</td>
   </tr>
   <tr>
-    <td style="width: 350px;">Caps Lock Hyper key + d</td>
-    <td>Code block</td>
+    <td style="width: 350px;">Caps Lock Hyper Key + q</td>
+    <td>Quote - format selected text as a block quote</td>
   </tr>
   <tr>
-    <td style="width: 350px;">Caps Lock Hyper key + f</td>
-    <td>Upload file</td>
-  </tr>
-  <tr>
-    <td style="width: 350px;">Caps Lock Hyper key + g</td>
-    <td>Add hyperlink</td>
+    <td style="width: 350px;">Caps Lock Hyper Key + g</td>
+    <td>Hyperlink - add a hyperlink to selected text</td>
   </tr>
 </table>
 
 <p style="margin-top: 20px; font-weight: bold">
-  Other Shortcuts
+  Actions
+</p>
+
+<p>
+  Common Slack actions mapped to the hyper key for quick access without hunting through menus.
 </p>
 
 <table class="table">
   <tr>
-    <td style="width: 350px;">Caps Lock Hyper key + e</td>
-    <td>Set status</td>
+    <td style="width: 350px;">Caps Lock Hyper Key + w</td>
+    <td>Toggle sidebar - hide or show the channel sidebar to reclaim screen space</td>
   </tr>
   <tr>
-    <td style="width: 350px;">Slack: Caps Lock Hyper key + w</td>
-    <td>Toggle sidebar</td>
+    <td style="width: 350px;">Caps Lock Hyper Key + e</td>
+    <td>Set status - quickly update your Slack status</td>
+  </tr>
+  <tr>
+    <td style="width: 350px;">Caps Lock Hyper Key + f</td>
+    <td>Upload file - open the file picker to attach a file to your message</td>
   </tr>
 </table>

--- a/public/extra_descriptions/vs_code.html
+++ b/public/extra_descriptions/vs_code.html
@@ -1,40 +1,54 @@
 <p style="margin-top: 20px; font-weight: bold">
- Hyper Key
+  Hyper Key
 </p>
 
 <p>
-  The caps lock hyper key is included for quick left handed access to all the shortcuts.
+  Includes the Caps Lock hyper key as the foundation for all VS Code shortcuts in this pack. Caps Lock is
+  remapped to a unique modifier combination (⌃⇧⌘) that doesn't conflict with any built-in VS Code or macOS
+  shortcut, giving you a dedicated left-hand anchor key that's fast to reach without lifting your hand off
+  the home row.
+</p>
+
+<p>
+  All shortcuts in this pack are built on top of the hyper key, so activating them is a single fluid
+  motion - hold Caps Lock and tap a letter - rather than awkward multi-finger contortions across the keyboard.
 </p>
 
 <table class="table">
   <tr>
     <td style="width: 300px;">Caps Lock</td>
     <td>
-      Maps to left control + left shift + right command (⌃⇧⌘). The Caps lock key functionality is disabled.
+      Maps to left control + left shift + right command (⌃⇧⌘). Used as the hyper key for all VS Code
+      shortcuts in this pack. The Caps Lock function is not lost - use double-tap right shift instead.
     </td>
   </tr>
   <tr>
     <td style="width: 300px;">Double-tap right shift</td>
-    <td>Caps lock toggle</td>
+    <td>Toggle caps lock on/off</td>
   </tr>
 </table>
 
 <p style="margin-top: 20px; font-weight: bold">
-  Searching
+  Searching and Navigation
+</p>
+
+<p>
+  Quick access to VS Code's most-used search and navigation commands, all reachable from the home row via
+  the hyper key.
 </p>
 
 <table class="table">
   <tr>
     <td style="width: 300px;">Caps Lock Hyper Key + a</td>
-    <td>Quick open (search for a file)</td>
+    <td>Quick open - fuzzy search and open any file in the workspace</td>
   </tr>
   <tr>
     <td style="width: 300px;">Caps Lock Hyper Key + s</td>
-    <td>Navigate symbols (search symbols)</td>
+    <td>Go to symbol - search all symbols (functions, classes, variables) in the current file</td>
   </tr>
   <tr>
     <td style="width: 300px;">Caps Lock Hyper Key + d</td>
-    <td>Command palette</td>
+    <td>Command palette - access any VS Code command by name</td>
   </tr>
 </table>
 
@@ -42,10 +56,15 @@
   Toggle Panels and Zen Mode
 </p>
 
+<p>
+  Instantly show or hide VS Code panels to reclaim screen space when you need to focus, or bring them back
+  when you need context. Zen mode removes all chrome (sidebar, panels, tabs) for distraction-free coding.
+</p>
+
 <table class="table">
   <tr>
     <td style="width: 300px;">Caps Lock Hyper Key + q</td>
-    <td>Toggle Zen mode</td>
+    <td>Toggle zen mode</td>
   </tr>
   <tr>
     <td style="width: 300px;">Caps Lock Hyper Key + w</td>
@@ -57,15 +76,17 @@
   </tr>
   <tr>
     <td style="width: 300px;">Right cmd</td>
-    <td>Toggle Zen mode</td>
+    <td>Toggle zen mode</td>
   </tr>
 </table>
 
 <p style="margin-top: 20px; font-weight: bold">
-  keybindings.json in Visual Studio Code
+  Required: keybindings.json in Visual Studio Code
 </p>
+
 <p>
-  Add the following entry to your keybindings.json in Visual Studio Code. This is to ensure that the editor pane is focused when activating the Zen mode shortcuts.
+  Add the following entry to your keybindings.json in Visual Studio Code. This ensures the editor pane is
+  focused when activating the zen mode shortcuts, so they work correctly regardless of which panel is active.
 </p>
 
 <pre><code>


### PR DESCRIPTION
- Expand hyper key sections with conflict-free modifier explanation and ergonomic benefits across mac_osx, vs_code, chrome, and slack
- Add lead-in paragraphs to each section explaining purpose and benefits
- Expand shortcut rows with context on what each command does
- Fix stale copy (caps lock disabled -> double-tap right shift restores it)
- Add mac_osx_double_tap_q_close_application.html (new file)
- Sync mac_osx_disable_minimising_windows.html with improved mac_osx copy
- Rename vague section headings (Misc Keymappings -> Browser Actions, etc.)