### PR TITLE
Fix Control+Space exact matching in windows_style_IME_switcher

### DIFF
--- a/public/json/windows_style_IME_switcher.json
+++ b/public/json/windows_style_IME_switcher.json
@@ -90,9 +90,6 @@
             "modifiers": {
               "mandatory": [
                 "control"
-              ],
-              "optional": [
-                "any"
               ]
             }
           },
@@ -123,9 +120,6 @@
             "modifiers": {
               "mandatory": [
                 "control"
-              ],
-              "optional": [
-                "any"
               ]
             }
           },


### PR DESCRIPTION
Follow-up to #1972.

## Summary
- Fix Control+Space matching in windows_style_IME_switcher to require the exact Control+Space shortcut.
- Remove optional "any" modifiers from both Control+Space manipulators.
- Keep the existing English -> next input source and non-English -> English behavior unchanged.
- Allow shortcuts with extra modifiers, such as Control+Command+Space, to pass through to macOS or other apps.

## Validation
- make all
