### PR TITLE
fix: DoubaoIME voice input trigger

### DIFF
--- a/public/extra_descriptions/double_tap_right_command_switch_doubaoime.json.html
+++ b/public/extra_descriptions/double_tap_right_command_switch_doubaoime.json.html
@@ -4,8 +4,8 @@
 </p>
 
 <ul>
-  <li>First double tap: switch to Doubao Pinyin, wait briefly, then tap <kbd>right_option</kbd> twice to start voice input.</li>
-  <li>Second double tap: tap <kbd>right_option</kbd> twice to stop voice input, wait for recognition to finish, then switch back to Rime.</li>
+  <li>First double tap: switch to Doubao Pinyin, wait briefly, then tap <kbd>right_option</kbd> once to start voice input.</li>
+  <li>Second double tap: tap <kbd>right_option</kbd> once to stop voice input, wait for recognition to finish, then switch back to Rime.</li>
 </ul>
 
 <p>

--- a/public/json/double_tap_right_command_switch_doubaoime.json
+++ b/public/json/double_tap_right_command_switch_doubaoime.json
@@ -1,5 +1,5 @@
 {
-  "title": "Double tap right_command to switch DoubaoIME voice input (rev 1)",
+  "title": "Double tap right_command to switch DoubaoIME voice input (rev 2)",
   "maintainers": [
     "Coldin04"
   ],
@@ -37,11 +37,7 @@
             },
             {
               "key_code": "vk_none",
-              "hold_down_milliseconds": 300
-            },
-            {
-              "key_code": "right_option",
-              "hold_down_milliseconds": 60
+              "hold_down_milliseconds": 800
             },
             {
               "key_code": "right_option",
@@ -89,12 +85,8 @@
               "hold_down_milliseconds": 60
             },
             {
-              "key_code": "right_option",
-              "hold_down_milliseconds": 60
-            },
-            {
               "key_code": "vk_none",
-              "hold_down_milliseconds": 5000
+              "hold_down_milliseconds": 3500
             },
             {
               "select_input_source": {

--- a/src/json/double_tap_right_command_switch_doubaoime.json.js
+++ b/src/json/double_tap_right_command_switch_doubaoime.json.js
@@ -8,7 +8,7 @@ function main() {
   console.log(
     JSON.stringify(
       {
-        title: 'Double tap right_command to switch DoubaoIME voice input (rev 1)',
+        title: 'Double tap right_command to switch DoubaoIME voice input (rev 2)',
         maintainers: ['Coldin04'],
         rules: [
           {
@@ -43,11 +43,7 @@ function main() {
                   },
                   {
                     key_code: 'vk_none',
-                    hold_down_milliseconds: 300,
-                  },
-                  {
-                    key_code: 'right_option',
-                    hold_down_milliseconds: 60,
+                    hold_down_milliseconds: 800,
                   },
                   {
                     key_code: 'right_option',
@@ -91,12 +87,8 @@ function main() {
                     hold_down_milliseconds: 60,
                   },
                   {
-                    key_code: 'right_option',
-                    hold_down_milliseconds: 60,
-                  },
-                  {
                     key_code: 'vk_none',
-                    hold_down_milliseconds: 5000,
+                    hold_down_milliseconds: 3500,
                   },
                   {
                     select_input_source: {


### PR DESCRIPTION
## Summary

DoubaoIME recently shipped an update that changed the voice input trigger from double-tapping Option to pressing Option once.

This PR updates the `double_tap_right_command_switch_doubaoime` rule accordingly:

- Start voice input: switch to DoubaoIME, wait briefly, then press `right_option` once.
- Stop voice input: press `right_option` once, wait for recognition to finish, then switch back to Rime.
- Update the rule revision from `rev 1` to `rev 2`.
- Update the extra description text from “tap right_option twice” to “tap right_option once”.

## Validation

- Ran `make all` successfully.
