### PR TITLE
Add Swedish ANSI keyboard ISO-style Enter area

### DIFF
--- a/public/json/swedish_ansi_iso_enter_area.json
+++ b/public/json/swedish_ansi_iso_enter_area.json
@@ -1,0 +1,78 @@
+{
+  "title": "Swedish ANSI keyboard ISO-style Enter area",
+  "maintainers": [
+    "misfitd4"
+  ],
+  "rules": [
+    {
+      "description": "Swedish ANSI keyboard: ISO-style Enter area",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "return_or_enter"
+          },
+          "to": [
+            {
+              "key_code": "keypad_enter"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "backslash",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "keypad_asterisk"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "backslash",
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ],
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "backslash"
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "backslash",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "keypad_enter"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/public/json/swedish_ansi_iso_enter_area.json
+++ b/public/json/swedish_ansi_iso_enter_area.json
@@ -1,78 +1,75 @@
 {
-  "title": "Swedish ANSI keyboard ISO-style Enter area",
-  "maintainers": [
-    "misfitd4"
-  ],
-  "rules": [
-    {
-      "description": "Swedish ANSI keyboard: ISO-style Enter area",
-      "manipulators": [
+    "title": "Swedish ANSI keyboard ISO-style Enter area",
+    "rules": [
         {
-          "type": "basic",
-          "from": {
-            "key_code": "return_or_enter"
-          },
-          "to": [
-            {
-              "key_code": "keypad_enter"
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "backslash",
-            "modifiers": {
-              "mandatory": [
-                "shift"
-              ],
-              "optional": [
-                "any"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "keypad_asterisk"
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "backslash",
-            "modifiers": {
-              "mandatory": [
-                "option"
-              ],
-              "optional": [
-                "any"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "backslash"
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "backslash",
-            "modifiers": {
-              "optional": [
-                "any"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "keypad_enter"
-            }
-          ]
+            "description": "Return and Backslash to Enter, with Shift+Backslash as * and Option+Backslash as '",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "return_or_enter"
+                    },
+                    "to": [
+                        {
+                            "key_code": "keypad_enter"
+                        }
+                    ]
+                },
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "backslash",
+                        "modifiers": {
+                            "mandatory": [
+                                "shift"
+                            ],
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "keypad_asterisk"
+                        }
+                    ]
+                },
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "backslash",
+                        "modifiers": {
+                            "mandatory": [
+                                "option"
+                            ],
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "backslash"
+                        }
+                    ]
+                },
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "backslash",
+                        "modifiers": {
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "keypad_enter"
+                        }
+                    ]
+                }
+            ]
         }
-      ]
-    }
-  ]
+    ]
 }


### PR DESCRIPTION
This rule is intended for users running the Swedish keyboard layout on ANSI keyboard hardware.

It recreates the larger ISO-style Enter area commonly found on Nordic keyboards:

* Return → Enter (keypad_enter)
* Backslash → Enter (keypad_enter)
* Shift+Backslash → *
* Option+Backslash → '

This helps users transitioning from ISO Nordic keyboards to ANSI hardware while preserving access to the original symbols.

Tested on:

* macOS
* Swedish keyboard layout
* ANSI keyboard
* Karabiner-Elements current release