### PR TITLE
Add "Mouse as a trackpad replacement" rules (Spaces on side buttons, Mission Control / App Exposé on middle button)

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -154,6 +154,9 @@
           "extra_description_path": "extra_descriptions/mouse3_app_switcher.json.html"
         },
         {
+          "path": "json/mouse_trackpad_replacement.json"
+        },
+        {
           "path": "json/r_cmd_to_l_ctrl_and_space.json",
           "extra_description_path": "extra_descriptions/r_cmd_to_l_ctrl_and_space.json.html"
         },

--- a/public/json/mouse_trackpad_replacement.json
+++ b/public/json/mouse_trackpad_replacement.json
@@ -1,0 +1,67 @@
+{
+  "title": "Mouse as a trackpad replacement (side buttons switch Spaces, middle button for Mission Control / App Exposé) (rev 1)",
+  "maintainers": ["TyndaleLym"],
+  "rules": [
+    {
+      "description": "Side buttons to switch Spaces: button4 to next desktop (^→), button5 to previous desktop (^←) (rev 1)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "pointing_button": "button4",
+            "modifiers": { "optional": ["any"] }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow",
+              "modifiers": ["left_control"],
+              "repeat": false
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "pointing_button": "button5",
+            "modifiers": { "optional": ["any"] }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow",
+              "modifiers": ["left_control"],
+              "repeat": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Middle button (button3): single click for Mission Control / all windows (^↑), long press for App Exposé / windows of the front app (^↓) (rev 1)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "pointing_button": "button3",
+            "modifiers": { "optional": ["any"] }
+          },
+          "parameters": {
+            "basic.to_if_alone_timeout_milliseconds": 300,
+            "basic.to_if_held_down_threshold_milliseconds": 300
+          },
+          "to_if_alone": [
+            {
+              "key_code": "up_arrow",
+              "modifiers": ["left_control"]
+            }
+          ],
+          "to_if_held_down": [
+            {
+              "key_code": "down_arrow",
+              "modifiers": ["left_control"]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This adds a small package that turns extra mouse buttons into trackpad-style navigation on macOS, so a regular mouse can cover the gestures usually done on a trackpad.

## Rules (each can be enabled independently)

1. **Side buttons switch Spaces** — `button4` → next desktop (`^→`), `button5` → previous desktop (`^←`).
2. **Middle button (`button3`)** — single click (< 300 ms) opens Mission Control / all windows (`^↑`); long press (≥ 300 ms) opens App Exposé / windows of the front app (`^↓`).

## Notes

- Validated locally with `make all`.
- Registered in the **OS Functionality** group in `public/groups.json`, next to the existing mouse desktop-switcher rules.
- The single-click vs. long-press middle-button behavior isn't covered by the existing `mouse3_app_switcher` / `mouse_buttons_4_5_desktop_switch` rules, so this packages all three buttons into one cohesive trackpad-replacement set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)