### PR TITLE
Add nowage foot pedal rules (3-pedal USB foot switch)

### DIFF
--- a/public/extra_descriptions/nowage_foot_pedal.html
+++ b/public/extra_descriptions/nowage_foot_pedal.html
@@ -1,0 +1,50 @@
+<h3>Hardware requirement</h3>
+
+<p>
+  These rules only fire while a 3-pedal USB foot switch is connected.
+  The device is matched by <code>device_if</code> with
+  <code>vendor_id: 6790</code> (0x1a86, QinHeng Electronics / WCH) and
+  <code>product_id: 57382</code> (0xe026).
+  This is the controller used by the common low-cost triple foot switch sold under many brands
+  (PCsensor, KKmoon and similar OEM variants).
+</p>
+
+<p>
+  Check your own device in <b>Karabiner-EventViewer &rarr; Devices</b>.
+  If your vendor / product id differs, edit the <code>device_if</code> conditions in the JSON
+  before importing.
+</p>
+
+<h3>Factory key assignment</h3>
+
+<p>
+  The pedals are expected to send plain <code>a</code>, <code>b</code>, <code>c</code>
+  (left / middle / right), which is the factory default of these switches.
+  If the pedals were re-programmed with the vendor's Windows configuration tool,
+  change the <code>from.key_code</code> values accordingly.
+</p>
+
+<h3>Why the modifier layers</h3>
+
+<p>
+  A foot switch has only three buttons, but a foot press can be combined with modifiers held on the
+  keyboard. Each pedal therefore exposes six slots
+  (no modifier, control, option, shift, command, hyper = control+option+shift+command),
+  giving 18 actions in total.
+  Enable only the pedal layers you need; each pedal is a separate rule.
+</p>
+
+<table>
+  <tr><th>Modifier</th><th>Pedal 1 (editing)</th><th>Pedal 2 (navigation)</th><th>Pedal 3 (media)</th></tr>
+  <tr><td>(none)</td><td>copy</td><td>page down</td><td>play / pause</td></tr>
+  <tr><td>control</td><td>cut</td><td>page up</td><td>rewind</td></tr>
+  <tr><td>option</td><td>paste</td><td>end</td><td>fast-forward</td></tr>
+  <tr><td>shift</td><td>paste without formatting</td><td>home</td><td>mute</td></tr>
+  <tr><td>command</td><td>undo</td><td>Mission Control</td><td>volume down</td></tr>
+  <tr><td>hyper</td><td>redo</td><td>Launchpad</td><td>volume up</td></tr>
+</table>
+
+<p>
+  Because every manipulator is scoped by <code>device_if</code>, the normal
+  <code>a</code> / <code>b</code> / <code>c</code> keys of your keyboard are never affected.
+</p>

--- a/public/groups.json
+++ b/public/groups.json
@@ -1791,6 +1791,10 @@
         {
           "path": "json/glove_80_lower_level_mouse_bindings.json",
           "extra_description_path": "extra_descriptions/glove_80_lower_level_mouse_bindings.html"
+        },
+        {
+          "path": "json/nowage_foot_pedal.json",
+          "extra_description_path": "extra_descriptions/nowage_foot_pedal.html"
         }
       ]
     },

--- a/public/json/nowage_foot_pedal.json
+++ b/public/json/nowage_foot_pedal.json
@@ -1,0 +1,542 @@
+{
+  "title": "USB Foot Pedal (3 pedals) - Editing / Navigation / Media layers",
+  "maintainers": [
+    "nowage"
+  ],
+  "rules": [
+    {
+      "description": "Foot pedal 1 (left, sends 'a'): editing layer. pedal=copy, control+pedal=cut, option+pedal=paste, shift+pedal=paste without formatting, command+pedal=undo, hyper+pedal=redo. Requires a USB foot switch with vendor_id 6790 (0x1a86) / product_id 57382 (0xe026).",
+      "manipulators": [
+        {
+          "description": "hyper + pedal 1 -> redo",
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 6790,
+                  "product_id": 57382
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "mandatory": [
+                "control",
+                "option",
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "z",
+              "modifiers": [
+                "left_command",
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "description": "command + pedal 1 -> undo",
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 6790,
+                  "product_id": 57382
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "z",
+              "modifiers": [
+                "left_command"
+              ]
+            }
+          ]
+        },
+        {
+          "description": "shift + pedal 1 -> paste without formatting",
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 6790,
+                  "product_id": 57382
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "v",
+              "modifiers": [
+                "left_command",
+                "left_option",
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "description": "option + pedal 1 -> paste",
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 6790,
+                  "product_id": 57382
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "v",
+              "modifiers": [
+                "left_command"
+              ]
+            }
+          ]
+        },
+        {
+          "description": "control + pedal 1 -> cut",
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 6790,
+                  "product_id": 57382
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "x",
+              "modifiers": [
+                "left_command"
+              ]
+            }
+          ]
+        },
+        {
+          "description": "pedal 1 -> copy",
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 6790,
+                  "product_id": 57382
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "a"
+          },
+          "to": [
+            {
+              "key_code": "c",
+              "modifiers": [
+                "left_command"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Foot pedal 2 (middle, sends 'b'): navigation layer. pedal=page down, control+pedal=page up, option+pedal=end, shift+pedal=home, command+pedal=Mission Control, hyper+pedal=Launchpad. Requires a USB foot switch with vendor_id 6790 (0x1a86) / product_id 57382 (0xe026).",
+      "manipulators": [
+        {
+          "description": "hyper + pedal 2 -> Launchpad",
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 6790,
+                  "product_id": 57382
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "b",
+            "modifiers": {
+              "mandatory": [
+                "control",
+                "option",
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "launchpad"
+            }
+          ]
+        },
+        {
+          "description": "command + pedal 2 -> Mission Control",
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 6790,
+                  "product_id": 57382
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "b",
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "mission_control"
+            }
+          ]
+        },
+        {
+          "description": "shift + pedal 2 -> home",
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 6790,
+                  "product_id": 57382
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "b",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "home"
+            }
+          ]
+        },
+        {
+          "description": "option + pedal 2 -> end",
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 6790,
+                  "product_id": 57382
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "b",
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "end"
+            }
+          ]
+        },
+        {
+          "description": "control + pedal 2 -> page up",
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 6790,
+                  "product_id": 57382
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "b",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "page_up"
+            }
+          ]
+        },
+        {
+          "description": "pedal 2 -> page down",
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 6790,
+                  "product_id": 57382
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "b"
+          },
+          "to": [
+            {
+              "key_code": "page_down"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Foot pedal 3 (right, sends 'c'): media layer. pedal=play/pause, control+pedal=rewind, option+pedal=fast-forward, shift+pedal=mute, command+pedal=volume down, hyper+pedal=volume up. Requires a USB foot switch with vendor_id 6790 (0x1a86) / product_id 57382 (0xe026).",
+      "manipulators": [
+        {
+          "description": "hyper + pedal 3 -> volume up",
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 6790,
+                  "product_id": 57382
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "c",
+            "modifiers": {
+              "mandatory": [
+                "control",
+                "option",
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "volume_increment"
+            }
+          ]
+        },
+        {
+          "description": "command + pedal 3 -> volume down",
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 6790,
+                  "product_id": 57382
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "c",
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "volume_decrement"
+            }
+          ]
+        },
+        {
+          "description": "shift + pedal 3 -> mute",
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 6790,
+                  "product_id": 57382
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "c",
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "mute"
+            }
+          ]
+        },
+        {
+          "description": "option + pedal 3 -> fast-forward",
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 6790,
+                  "product_id": 57382
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "c",
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "fastforward"
+            }
+          ]
+        },
+        {
+          "description": "control + pedal 3 -> rewind",
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 6790,
+                  "product_id": 57382
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "c",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "rewind"
+            }
+          ]
+        },
+        {
+          "description": "pedal 3 -> play/pause",
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 6790,
+                  "product_id": 57382
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "c"
+          },
+          "to": [
+            {
+              "key_code": "play_or_pause"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add complex modifications for a 3-pedal USB foot switch (`vendor_id` 6790 / `product_id` 57382), a common low-cost OEM device (PCsensor, KKmoon and similar).

### What is added

- `public/json/nowage_foot_pedal.json` — 3 rules, one per pedal, 6 manipulators each
- `public/extra_descriptions/nowage_foot_pedal.html` — hardware requirement, factory key assignment, layer table
- `public/groups.json` — one entry in the `device-specific` group

### Layout

A foot switch has only three buttons, so each pedal is combined with keyboard modifiers to expose six slots (none / control / option / shift / command / hyper), giving 18 actions.

| Modifier | Pedal 1 (editing) | Pedal 2 (navigation) | Pedal 3 (media) |
| --- | --- | --- | --- |
| (none) | copy | page down | play / pause |
| control | cut | page up | rewind |
| option | paste | end | fast-forward |
| shift | paste without formatting | home | mute |
| command | undo | Mission Control | volume down |
| hyper | redo | Launchpad | volume up |

### Notes

- All actions use standard Karabiner key codes, so no external application is required.
- Every manipulator is scoped by `device_if`, so the normal `a` / `b` / `c` keys of the keyboard are never affected.
- The pedals are expected to send plain `a`, `b`, `c` (factory default). The extra description explains how to adjust `from.key_code` and `device_if` for other devices.
- Each pedal is a separate rule, so users can enable only the layers they need.

Verified locally with `make all` (lint and Prettier pass, no reformatting of the added files).