### PR TITLE
Simplify nowage foot pedal: merge 3 rules into 1

### DIFF
--- a/public/json/nowage_foot_pedal.json
+++ b/public/json/nowage_foot_pedal.json
@@ -5,7 +5,7 @@
   ],
   "rules": [
     {
-      "description": "Foot pedal 1 (left, sends 'a'): editing layer. pedal=copy, control+pedal=cut, option+pedal=paste, shift+pedal=paste without formatting, command+pedal=undo, hyper+pedal=redo. Requires a USB foot switch with vendor_id 6790 (0x1a86) / product_id 57382 (0xe026).",
+      "description": "USB Foot Pedal (3 pedals). Pedal 1 (left, 'a') = editing: copy, control=cut, option=paste, shift=paste-without-formatting, command=undo, hyper=redo. Pedal 2 (middle, 'b') = navigation: page down, control=page up, option=end, shift=home, command=Mission Control, hyper=Launchpad. Pedal 3 (right, 'c') = media: play/pause, control=rewind, option=fast-forward, shift=mute, command=volume down, hyper=volume up. Requires a USB foot switch with vendor_id 6790 (0x1a86) / product_id 57382 (0xe026).",
       "manipulators": [
         {
           "description": "hyper + pedal 1 -> redo",
@@ -193,12 +193,7 @@
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "description": "Foot pedal 2 (middle, sends 'b'): navigation layer. pedal=page down, control+pedal=page up, option+pedal=end, shift+pedal=home, command+pedal=Mission Control, hyper+pedal=Launchpad. Requires a USB foot switch with vendor_id 6790 (0x1a86) / product_id 57382 (0xe026).",
-      "manipulators": [
+        },
         {
           "description": "hyper + pedal 2 -> Launchpad",
           "type": "basic",
@@ -364,12 +359,7 @@
               "key_code": "page_down"
             }
           ]
-        }
-      ]
-    },
-    {
-      "description": "Foot pedal 3 (right, sends 'c'): media layer. pedal=play/pause, control+pedal=rewind, option+pedal=fast-forward, shift+pedal=mute, command+pedal=volume down, hyper+pedal=volume up. Requires a USB foot switch with vendor_id 6790 (0x1a86) / product_id 57382 (0xe026).",
-      "manipulators": [
+        },
         {
           "description": "hyper + pedal 3 -> volume up",
           "type": "basic",


### PR DESCRIPTION
Follow-up to #1982.

The current `nowage_foot_pedal.json` exposes **three** rules (one per pedal), which makes the importer show three separate toggles for what is really one 3-pedal device. This PR merges them into a **single rule** with all 18 manipulators.

- No behaviour change: same `device_if` (vendor_id 6790 / product_id 57382), same `from` key_codes (a / b / c), same `to` actions.
- Rule count: 3 → 1. Users now enable the full editing / navigation / media layer set with one toggle.
- `karabiner_cli --lint-complex-modifications`: ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)