### PR TITLE
uk_to_us: swap # and £ (shift+3 / option+3)

### DIFF
--- a/public/json/uk_to_us.json
+++ b/public/json/uk_to_us.json
@@ -3,8 +3,70 @@
   "maintainers": ["mngyuan"],
   "rules": [
     {
-      "description": "UK→US Mac. Remap `~ to left shift and §± to `~. Requires proper keyboard setup in System Preferences->Keyboard->Change Keyboard Type...",
+      "description": "UK→US Mac. Remap `~ to left shift, §± to `~, and swap # and £ (shift/option+3). Requires proper keyboard setup in System Preferences->Keyboard->Change Keyboard Type...",
       "manipulators": [
+        {
+          "from": {
+            "key_code": "3",
+            "modifiers": {
+              "mandatory": ["shift"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "3",
+              "modifiers": ["option"]
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452
+                },
+                {
+                  "vendor_id": 76
+                },
+                {
+                  "is_built_in_keyboard": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "from": {
+            "key_code": "3",
+            "modifiers": {
+              "mandatory": ["option"]
+            }
+          },
+          "to": [
+            {
+              "key_code": "3",
+              "modifiers": ["shift"]
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 1452
+                },
+                {
+                  "vendor_id": 76
+                },
+                {
+                  "is_built_in_keyboard": true
+                }
+              ]
+            }
+          ]
+        },
         {
           "from": {
             "key_code": "grave_accent_and_tilde",


### PR DESCRIPTION
A small follow-up to #1539, which added this rule. The rule already makes the built-in MacBook keyboard on a UK Mac resemble the US one for `` `~ `` and `§±`, but the number row was left alone. This swaps `shift+3` to `#` and `option+3` to `£`, to match the US Mac keyboard. I haven't swapped the € shortcut as I don't touch type this and therefore having it match the legends on the keycaps makes more sense to me.

Both new manipulators use `mandatory` modifiers with no `optional` ones, so combinations like `cmd+shift+3` and `cmd+shift+ctrl+3` don't match and the macOS screenshot shortcuts keep working. They're scoped with the same Apple `device_if` identifiers as the rest of the rule; I left off the `device_unless` on `product_id: 592` that the `` `~ ``/`§±` manipulators depend on; on the wireless Apple keyboards the handling for those keys is different (IIRC it doesn't require swapping).

Verified on a UK built-in keyboard with the British input source.