### PR TITLE
Add Parallels Desktop Korean input toggle (한/영) rules

### DIFF
--- a/public/groups.json
+++ b/public/groups.json
@@ -1244,6 +1244,9 @@
           "path": "json/caps_lock_toggle_korean_english_include_parallels.json"
         },
         {
+          "path": "json/parallels_korean_input.json"
+        },
+        {
           "path": "json/korean_won_to_backtick_with_shortcut_preserved.json",
           "extra_description_path": "extra_descriptions/korean_won_to_backtick_with_shortcut_preserved.html"
         },
@@ -1967,7 +1970,7 @@
         },
         {
           "path": "json/hold_to_toggle_caps_lock.json"
-        },        
+        },
         {
           "path": "json/block_one_handed_combos.json"
         },

--- a/public/json/parallels_korean_input.json
+++ b/public/json/parallels_korean_input.json
@@ -1,0 +1,70 @@
+{
+    "title": "Parallels Desktop: Korean input toggle (한/영)",
+    "maintainers": [
+        "renovys"
+    ],
+    "rules": [
+        {
+            "description": "Korean toggle: right_option to f19 on macOS, pass through natively in Parallels",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "conditions": [
+                        {
+                            "type": "frontmost_application_unless",
+                            "bundle_identifiers": [
+                                "^com\\.parallels\\.desktop",
+                                "^com\\.parallels\\.vm",
+                                "^com\\.parallels\\.winapp\\."
+                            ]
+                        }
+                    ],
+                    "from": {
+                        "key_code": "right_option",
+                        "modifiers": {
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "f19"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "Korean toggle: f19 to right_option inside Parallels (bridge for right_command based setups)",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "conditions": [
+                        {
+                            "type": "frontmost_application_if",
+                            "bundle_identifiers": [
+                                "^com\\.parallels\\.desktop",
+                                "^com\\.parallels\\.vm",
+                                "^com\\.parallels\\.winapp\\."
+                            ]
+                        }
+                    ],
+                    "from": {
+                        "key_code": "f19",
+                        "modifiers": {
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "right_option"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Adds two rules for Korean (한/영) input switching inside a Parallels Desktop Windows guest.

### Why

A very common Korean setup on macOS maps the right Command key to the input-source switch:

- Karabiner simple modification: `right_command → f19`
- macOS system shortcut ("Select next source") bound to F19

With that setup, **macOS swallows F19 at the global hotkey layer even when Parallels is frontmost**, so no key reaches the guest at all. Nothing you configure inside Windows helps, because the key never arrives. Karabiner runs below that layer, so a complex modification can intercept it first.

### The rules

1. `right_option → f19`, excluded in Parallels — the same physical key toggles the input source on macOS, and passes through untouched to the guest, where Windows treats right Alt as 한/영 with a Korean 101-key layout.
2. `f19 → right_option` inside Parallels — a bridge for setups whose right Command already becomes F19 via a global simple modification, which would otherwise reach the guest as a meaningless F19.

Either rule can be enabled on its own depending on which key you use.

Bundle identifiers are scoped to `^com\.parallels\.desktop`, `^com\.parallels\.vm` and `^com\.parallels\.winapp\.` rather than `^com\.parallels\.`, so Parallels Toolbox (a plain macOS utility) is not affected.

### Verification

Tested on Parallels Desktop 26.4.0 with a Windows 11 Korean guest (`KBDKOR.DLL`, Korean input only), macOS 26.5.2, Karabiner-Elements 16.1.0, on both a MacBook internal keyboard and an external keyboard.

Confirmed by logging `KeyDown` virtual-key codes in a WinForms window inside the guest: a successful toggle arrives as VK `0xE5` (`VK_PROCESSKEY`), i.e. the Korean IME consumed the key, and Korean text then types correctly.

Longer write-up with the modifier-position and function-key pitfalls: https://github.com/renovys/karabiner-parallels-korean
