### PR TITLE
Update extra description for nowage_foot_pedal

### DIFF
--- a/public/extra_descriptions/nowage_foot_pedal.html
+++ b/public/extra_descriptions/nowage_foot_pedal.html
@@ -31,7 +31,8 @@
   keyboard. Each pedal therefore exposes six slots
   (no modifier, control, option, shift, command, hyper = control+option+shift+command),
   giving 18 actions in total.
-  Enable only the pedal layers you need; each pedal is a separate rule.
+  All 18 live in a <b>single rule</b>, so one toggle enables the whole set &mdash;
+  one physical device, one entry.
 </p>
 
 <table>
@@ -47,4 +48,13 @@
 <p>
   Because every manipulator is scoped by <code>device_if</code>, the normal
   <code>a</code> / <code>b</code> / <code>c</code> keys of your keyboard are never affected.
+</p>
+
+<h3>Source and documentation</h3>
+
+<p>
+  This rule is maintained in the open, together with four other rules by the same author:
+  <a href="https://github.com/Finfra/karabiner-extensions/tree/main/footPedal" target="_blank">Finfra/karabiner-extensions &mdash; FootPedal</a>.
+  The repository holds the layer tables, the device notes and the reasoning behind the six-slot
+  layout &mdash; useful if you want to remap a pedal rather than take the defaults.
 </p>


### PR DESCRIPTION
Documentation-only update for `nowage_foot_pedal` (added in #1982, simplified in #1984). No rule or manipulator is changed.

**1. Fix a stale sentence.** The description still said *"Enable only the pedal layers you need; each pedal is a separate rule."* — that was true of the original submission, but #1984 merged the three rules into one. It now says the 18 manipulators live in a single rule, so one toggle enables the whole set.

**2. Add a link to the source repository.** The rule is maintained in the open together with four other rules by the same author, and the repository carries the layer tables and device notes that do not fit in this page.

`make all` passes; the only modified file is the extra description.