### PR TITLE
Add nowage_eng_char_on_kor (international): type English while staying in Korean input mode

### DIFF
--- a/public/extra_descriptions/nowage_eng_char_on_kor.html
+++ b/public/extra_descriptions/nowage_eng_char_on_kor.html
@@ -1,0 +1,111 @@
+<h3>What it does</h3>
+
+<p>
+  In Korean input mode, typing a few English characters normally means a round trip:
+  switch to English, type, switch back. This rule removes the round trip.
+  While <code>Insert</code> is held the input source is English; when you release it,
+  Korean comes back. No mode is left behind.
+</p>
+
+<table>
+  <tr><th>Action</th><th>Result</th></tr>
+  <tr><td>Hold <code>Insert</code>, type letters</td><td>English, as many characters as you like (<code>a p i</code> &rarr; <code>api</code>)</td></tr>
+  <tr><td>Hold <code>Insert</code>, tap <code>Home</code></td><td>Toggle capitals on/off — following letters stay uppercase</td></tr>
+  <tr><td>Hold <code>Insert</code>, <code>shift</code>+letter</td><td>A single capital (still works)</td></tr>
+  <tr><td>Release <code>Insert</code></td><td>Back to Korean; the capital toggle is reset</td></tr>
+  <tr><td><code>Insert</code> in English mode</td><td>Rule does not fire — <code>Insert</code> keeps its normal behaviour</td></tr>
+  <tr><td><code>Home</code> outside the layer</td><td>Rule does not fire — <code>Home</code> keeps its normal behaviour</td></tr>
+</table>
+
+<h3>한국어 요약</h3>
+
+<p>
+  이 규칙을 쓸 사람은 대부분 한국어 입력기 사용자이므로 요약을 한글로도 적는다.
+  <em>(This section repeats the above in Korean, for the users this rule is aimed at.)</em>
+</p>
+
+<p>
+  한글 입력 중 영문 몇 글자를 치려고 <b>한/영 전환 &rarr; 입력 &rarr; 한/영 전환</b>을 왕복하는 대신,
+  <code>Insert</code> 를 <b>누르고 있는 동안만</b> 영문이 나간다. 손을 떼면 한글로 돌아오며 모드가 남지 않는다.
+  레이어 안에서 <code>Home</code> 을 <b>탭</b>하면 대문자가 토글되고, 레이어 밖 <code>Insert</code>·<code>Home</code> 은 평소대로 동작한다.
+  전환 단축키가 <code>⇧space</code> 든 무엇이든 <b>무관</b>하다 &mdash; 이 규칙은 입력소스를 직접 지정하지 단축키를 흉내내지 않는다.
+</p>
+
+<h3>Requirements</h3>
+
+<p>No hardware and no external application is required. What the rule does need:</p>
+
+<table>
+  <tr><th>#</th><th>Requirement</th></tr>
+  <tr>
+    <td>A</td>
+    <td>
+      A physical key that actually sends <code>insert</code>, not claimed by another rule.
+      Which physical key emits <code>insert</code> differs between keyboards — check in
+      <b>Karabiner-EventViewer</b> first. On keyboards without one, change
+      <code>from.key_code</code> before importing.
+    </td>
+  </tr>
+  <tr>
+    <td>B</td>
+    <td>
+      <code>Home</code> must be free <b>while the layer is active</b>.
+      Outside the layer <code>Home</code> is untouched — the rule borrows it with a
+      <code>variable_if</code> condition instead of taking it away, so no key is permanently spent.
+    </td>
+  </tr>
+  <tr>
+    <td>C</td>
+    <td>
+      Korean and English input sources identifiable as <code>^ko$</code> / <code>^en$</code>
+      (the macOS defaults).
+    </td>
+  </tr>
+  <tr>
+    <td>D</td>
+    <td>
+      A Hangul IME that commits the composing syllable when it receives a space — the standard
+      behaviour of the macOS Korean input sources.
+    </td>
+  </tr>
+</table>
+
+<p>
+  <b>Your Korean/English switching shortcut does not matter.</b>
+  The rule changes the input source with <code>select_input_source</code>, it never sends a
+  switching shortcut, and the layer key consumes modifiers
+  (<code>mandatory: ["any"]</code>) so nothing leaks onto the keys it emits.
+</p>
+
+<h3>Why a composing syllable would otherwise be lost</h3>
+
+<p>
+  Hangul commits a syllable only when the next initial consonant arrives. If the input source is
+  changed while a syllable is still composing, the IME discards it instead of committing —
+  type <code>아</code> and switch, and the <code>아</code> is gone.
+</p>
+
+<p>
+  So the rule sends <code>space</code> and <code>delete_or_backspace</code> immediately before
+  switching: the space forces the commit, the backspace removes the space itself. Karabiner has no
+  condition for "IME is composing", so this is done unconditionally.
+</p>
+
+<h3>Variables</h3>
+
+<p>
+  Two variables are set: <code>keyboardLayoutSettingIsEng</code> (1 while the layer is active) and
+  <code>engCharUpper</code> (1 while capitals are toggled on). Both are reset when
+  <code>Insert</code> is released. If you already use a variable with either name, rename it in the
+  JSON before importing.
+</p>
+
+<h3>Source and documentation</h3>
+
+<p>
+  This rule is maintained in the open, together with four other rules by the same author:
+  <a href="https://github.com/Finfra/karabiner-extensions/tree/main/engCharOnKor" target="_blank">Finfra/karabiner-extensions &mdash; EngCharOnKor</a>.
+  The repository records why <code>Insert</code> was chosen over six other candidate triggers,
+  and why the capital toggle uses a variable rather than <code>sticky_modifier</code>
+  &mdash; useful if you want to move the layer to a different key.
+</p>

--- a/public/groups.json
+++ b/public/groups.json
@@ -1354,6 +1354,10 @@
         },
         {
           "path": "json/slovenian_punctuation_ansi.json"
+        },
+        {
+          "path": "json/nowage_eng_char_on_kor.json",
+          "extra_description_path": "extra_descriptions/nowage_eng_char_on_kor.html"
         }
       ]
     },

--- a/public/json/nowage_eng_char_on_kor.json
+++ b/public/json/nowage_eng_char_on_kor.json
@@ -1,0 +1,1018 @@
+{
+  "title": "Type English while staying in Korean input mode (hold Insert)",
+  "maintainers": [
+    "nowage"
+  ],
+  "rules": [
+    {
+      "description": "Type English without leaving the Korean input source. Hold Insert: the input source switches to English for as long as the key is held, and returns to Korean when you release it. Tap Home while holding Insert to toggle capital letters (useful for API, URL and other runs of uppercase); the toggle resets when Insert is released. Shift+letter also works for a single capital. A composing Hangul syllable is committed before the switch, so typing English right after a half-finished syllable does not discard it. Requirements: (1) a physical key that sends 'insert' and is not claimed by another rule; (2) Home must be free *while the layer is active* - outside the layer Home behaves normally; (3) Korean and English input sources identifiable as ^ko$ / ^en$; (4) a Hangul IME that commits the composing syllable on space. Your Korean/English switching shortcut does not matter.",
+      "manipulators": [
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "insert",
+            "modifiers": {
+              "mandatory": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "engCharUpper",
+                "value": 0
+              }
+            },
+            {
+              "key_code": "spacebar",
+              "hold_down_milliseconds": 10
+            },
+            {
+              "key_code": "delete_or_backspace",
+              "hold_down_milliseconds": 10
+            },
+            {
+              "key_code": "vk_none",
+              "hold_down_milliseconds": 30
+            },
+            {
+              "set_variable": {
+                "name": "keyboardLayoutSettingIsEng",
+                "value": 1
+              }
+            },
+            {
+              "select_input_source": {
+                "language": "^en$"
+              }
+            }
+          ],
+          "to_after_key_up": [
+            {
+              "set_variable": {
+                "name": "keyboardLayoutSettingIsEng",
+                "value": 0
+              }
+            },
+            {
+              "select_input_source": {
+                "language": "^ko$"
+              }
+            },
+            {
+              "set_variable": {
+                "name": "engCharUpper",
+                "value": 0
+              }
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "input_source_if",
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ]
+            }
+          ],
+          "from": {
+            "key_code": "insert"
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "engCharUpper",
+                "value": 0
+              }
+            },
+            {
+              "key_code": "spacebar",
+              "hold_down_milliseconds": 10
+            },
+            {
+              "key_code": "delete_or_backspace",
+              "hold_down_milliseconds": 10
+            },
+            {
+              "key_code": "vk_none",
+              "hold_down_milliseconds": 30
+            },
+            {
+              "set_variable": {
+                "name": "keyboardLayoutSettingIsEng",
+                "value": 1
+              }
+            },
+            {
+              "select_input_source": {
+                "language": "^en$"
+              }
+            }
+          ],
+          "to_after_key_up": [
+            {
+              "set_variable": {
+                "name": "keyboardLayoutSettingIsEng",
+                "value": 0
+              }
+            },
+            {
+              "select_input_source": {
+                "language": "^ko$"
+              }
+            },
+            {
+              "set_variable": {
+                "name": "engCharUpper",
+                "value": 0
+              }
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "home",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "engCharUpper",
+                "value": 0
+              }
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 0
+            }
+          ],
+          "from": {
+            "key_code": "home",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "set_variable": {
+                "name": "engCharUpper",
+                "value": 1
+              }
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "a",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "a",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "b",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "b",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "c",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "c",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "d",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "d",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "e",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "e",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "f",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "f",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "g",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "g",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "h",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "h",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "i",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "i",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "k",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "l",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "l",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "m",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "m",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "n",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "n",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "o",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "o",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "p",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "p",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "q",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "q",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "r",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "r",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "s",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "s",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "t",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "t",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "u",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "u",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "v",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "v",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "w",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "w",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "x",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "x",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "y",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "y",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "conditions": [
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 1
+            },
+            {
+              "type": "variable_if",
+              "name": "engCharUpper",
+              "value": 1
+            }
+          ],
+          "from": {
+            "key_code": "z",
+            "modifiers": {
+              "optional": [
+                "any"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "z",
+              "modifiers": [
+                "left_shift"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds one rule to the **international** group. No hardware and no external application is required; `device_if` and `shell_command` are both unused.

### What it does

Typing a few English characters while in Korean input mode normally means a round trip — switch to English, type, switch back. Holding `Insert` makes the input source English for as long as the key is held, and releasing it returns to Korean. **No mode is left behind**, so it does not matter what the user's language-switch shortcut is: the rule selects the input source directly (`select_input_source` with `^en$` / `^ko$`) rather than imitating a shortcut.

Tapping `Home` inside the layer toggles capitals, so consecutive uppercase does not require holding shift. Outside the layer, `Insert` and `Home` both keep their normal behaviour — the layer borrows `Home` only while it is active, so no key is permanently taken.

30 manipulators in a single rule (layer 2 + capital toggle 2 + letters 26). Digits and symbols need no manipulator; they pass through.

### Notes for review

- **Why not `sticky_modifier`** for the capital toggle: it passed lint but behaves as one-shot in practice — only the first letter came out uppercase. A variable is used instead.
- The rule sends `space` + `delete_or_backspace` immediately before switching. Hangul commits a syllable only when the next consonant arrives, so an in-progress syllable would otherwise be discarded on switch. Karabiner has no "IME is composing" condition, hence it is unconditional.
- Requirements A–D (a key that emits `insert`, `Home` free inside the layer, input sources identifiable as `^ko$`/`^en$`, a Hangul IME that commits on space) are spelled out in the extra description.
- The extra description repeats its summary in Korean, since the users this rule targets are Korean IME users. Existing entries in this group do the same (`korean-japanese-english.json`, `for_korean_keyboard.json`).

`make all` passes and `karabiner_cli --lint-complex-modifications` reports ok. The only pre-existing file touched is `public/groups.json` (4 added lines).