### PR TITLE
Add Readline-like keybindings for TIC-80

### DIFF
--- a/public/json/tic80_readline_keybindings.json
+++ b/public/json/tic80_readline_keybindings.json
@@ -1,0 +1,420 @@
+{
+  "title": "TIC-80 Readline-like keybindings",
+  "maintainers": [
+    "Athesto"
+  ],
+  "rules": [
+    {
+      "description": "Readline-like keybindings for the TIC-80 console and editor",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "j",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "return_or_enter"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.nesbox\\.tic$"
+              ],
+              "file_paths": [
+                "^/Applications/tic80\\.app/Contents/MacOS/tic80$"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "b",
+            "modifiers": {
+              "mandatory": [
+                "control",
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow",
+              "modifiers": [
+                "option",
+                "shift"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.nesbox\\.tic$"
+              ],
+              "file_paths": [
+                "^/Applications/tic80\\.app/Contents/MacOS/tic80$"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "f",
+            "modifiers": {
+              "mandatory": [
+                "control",
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow",
+              "modifiers": [
+                "option",
+                "shift"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.nesbox\\.tic$"
+              ],
+              "file_paths": [
+                "^/Applications/tic80\\.app/Contents/MacOS/tic80$"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "h",
+            "modifiers": {
+              "mandatory": [
+                "control",
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_or_backspace",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.nesbox\\.tic$"
+              ],
+              "file_paths": [
+                "^/Applications/tic80\\.app/Contents/MacOS/tic80$"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "h",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_or_backspace"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.nesbox\\.tic$"
+              ],
+              "file_paths": [
+                "^/Applications/tic80\\.app/Contents/MacOS/tic80$"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "m",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "return_or_enter"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.nesbox\\.tic$"
+              ],
+              "file_paths": [
+                "^/Applications/tic80\\.app/Contents/MacOS/tic80$"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "n",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "down_arrow"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.nesbox\\.tic$"
+              ],
+              "file_paths": [
+                "^/Applications/tic80\\.app/Contents/MacOS/tic80$"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "open_bracket",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "escape"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.nesbox\\.tic$"
+              ],
+              "file_paths": [
+                "^/Applications/tic80\\.app/Contents/MacOS/tic80$"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "p",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "up_arrow"
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.nesbox\\.tic$"
+              ],
+              "file_paths": [
+                "^/Applications/tic80\\.app/Contents/MacOS/tic80$"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "u",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k",
+              "modifiers": [
+                "control"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.nesbox\\.tic$"
+              ],
+              "file_paths": [
+                "^/Applications/tic80\\.app/Contents/MacOS/tic80$"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "w",
+            "modifiers": {
+              "mandatory": [
+                "control"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_or_backspace",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.nesbox\\.tic$"
+              ],
+              "file_paths": [
+                "^/Applications/tic80\\.app/Contents/MacOS/tic80$"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "b",
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "left_arrow",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.nesbox\\.tic$"
+              ],
+              "file_paths": [
+                "^/Applications/tic80\\.app/Contents/MacOS/tic80$"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "d",
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "delete_forward",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.nesbox\\.tic$"
+              ],
+              "file_paths": [
+                "^/Applications/tic80\\.app/Contents/MacOS/tic80$"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "basic",
+          "from": {
+            "key_code": "f",
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "right_arrow",
+              "modifiers": [
+                "option"
+              ]
+            }
+          ],
+          "conditions": [
+            {
+              "type": "frontmost_application_if",
+              "bundle_identifiers": [
+                "^com\\.nesbox\\.tic$"
+              ],
+              "file_paths": [
+                "^/Applications/tic80\\.app/Contents/MacOS/tic80$"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/json/tic80_readline_keybindings.json.js
+++ b/src/json/tic80_readline_keybindings.json.js
@@ -20,7 +20,7 @@
 //  CONFIGURATION
 //------------------------------------------------------------------------------
 
-const keyBindings = [
+const bindings = [
   { from: '<C-j>', to: 'return_or_enter' },
   { from: 'C-M-b', to: 'O-S-left_arrow' },
   { from: 'C-M-f', to: 'O-S-right_arrow' },
@@ -56,19 +56,19 @@ const appConditions = [
   },
 ]
 
-const ruleMetadata = {
+const metadata = {
   title: 'TIC-80 Readline-like keybindings',
 
-  description: 'Readline-like keybindings for the TIC-80 console and editor',
-
   maintainers: ['Athesto'],
+
+  description: 'Readline-like keybindings for the TIC-80 console and editor',
 }
 
 //------------------------------------------------------------------------------
 //  FUNCTIONS
 //------------------------------------------------------------------------------
 
-function generateKeyBindingPackage(keyBindings, conditions, ruleMetadata) {
+function generateKarabinerBindings(bindings, conditions, metadata) {
   const modifierBySymbol = {
     C: 'control',
     M: 'option',
@@ -87,7 +87,8 @@ function generateKeyBindingPackage(keyBindings, conditions, ruleMetadata) {
       const modifier = modifierBySymbol[modifierSymbol]
 
       if (!modifier) {
-        throw new Error('Unknown modifier "{modifier}" in shortcut "{shortcut}"'.replace('{modifier}', modifierSymbol).replace('{shortcut}', shortcut))
+        const errorMessage = 'Unknown modifier "{symbol}" in shortcut "{shortcut}"'
+        throw new Error(errorMessage.replace('{symbol}', modifierSymbol).replace('{shortcut}', shortcut))
       }
 
       return modifier
@@ -99,49 +100,45 @@ function generateKeyBindingPackage(keyBindings, conditions, ruleMetadata) {
     }
   }
 
-  function createManipulator(keyBinding) {
-    // Build from Event
-    const fromShortcut = parseShortcut(keyBinding.from)
-    const fromEvent = {
+  function createManipulator(binding) {
+    // Build from event
+    const fromShortcut = parseShortcut(binding.from)
+    const fromShortcutEvent = {
       key_code: fromShortcut.key,
     }
     if (fromShortcut.modifiers.length > 0) {
-      fromEvent.modifiers = {
+      fromShortcutEvent.modifiers = {
         mandatory: fromShortcut.modifiers,
       }
     }
 
-    // Build to Event
-    const toShortcut = parseShortcut(keyBinding.to)
-    const toEvent = {
+    // Build to event
+    const toShortcut = parseShortcut(binding.to)
+    const toShortcutEvent = {
       key_code: toShortcut.key,
     }
     if (toShortcut.modifiers.length > 0) {
-      toEvent.modifiers = toShortcut.modifiers
+      toShortcutEvent.modifiers = toShortcut.modifiers
     }
 
     return {
       type: 'basic',
-      from: fromEvent,
-      to: [toEvent],
-      conditions: conditions,
+      from: fromShortcutEvent,
+      to: [toShortcutEvent],
+      conditions,
     }
   }
 
-  const manipulators = keyBindings.map(createManipulator)
-
-  const rule = {
-    description: ruleMetadata.description,
-    manipulators: manipulators,
+  return {
+    title: metadata.title,
+    maintainers: metadata.maintainers,
+    rules: [
+      {
+        description: metadata.description,
+        manipulators: bindings.map(createManipulator),
+      },
+    ],
   }
-
-  const keyBindingPackage = {
-    title: ruleMetadata.title,
-    maintainers: ruleMetadata.maintainers,
-    rules: [rule],
-  }
-
-  return keyBindingPackage
 }
 
 //------------------------------------------------------------------------------
@@ -149,9 +146,9 @@ function generateKeyBindingPackage(keyBindings, conditions, ruleMetadata) {
 //------------------------------------------------------------------------------
 
 function main() {
-  const keyBindingPackage = generateKeyBindingPackage(keyBindings, appConditions, ruleMetadata)
+  const tic80Bindings = generateKarabinerBindings(bindings, appConditions, metadata)
 
-  console.log(JSON.stringify(keyBindingPackage, null, 2))
+  console.log(JSON.stringify(tic80Bindings, null, 2))
 }
 
 main()

--- a/src/json/tic80_readline_keybindings.json.js
+++ b/src/json/tic80_readline_keybindings.json.js
@@ -1,0 +1,157 @@
+// JavaScript should be written in ECMAScript 5.1.
+
+/**
+ * Readline-like keybindings for TIC-80
+ *
+ * Karabiner-Elements rule generator that uses Vim-style key notation,
+ * such as C-a, M-b, <C-d>, and C-M-h, to define shortcuts.
+ *
+ * The generated rules add Readline-like editing and navigation
+ * shortcuts to the TIC-80 console and editor.
+ *
+ * Version: 0.1.0
+ * Author: Gustavo Mejía (https://github.com/athesto)
+ * Issues: https://github.com/Athesto/KE-complex_modifications/issues
+ * Created: 2026
+ * License: Unlicense (https://unlicense.org/)
+ */
+
+//------------------------------------------------------------------------------
+//  CONFIGURATION
+//------------------------------------------------------------------------------
+
+const keyBindings = [
+  { from: '<C-j>', to: 'return_or_enter' },
+  { from: 'C-M-b', to: 'O-S-left_arrow' },
+  { from: 'C-M-f', to: 'O-S-right_arrow' },
+  { from: 'C-M-h', to: 'M-delete_or_backspace' },
+  { from: 'C-h', to: 'delete_or_backspace' },
+  { from: 'C-m', to: 'return_or_enter' },
+  { from: 'C-n', to: 'down_arrow' },
+  { from: 'C-open_bracket', to: 'escape' },
+  { from: 'C-p', to: 'up_arrow' },
+  { from: 'C-u', to: 'C-k' },
+  { from: 'C-w', to: 'M-delete_or_backspace' },
+  { from: 'M-b', to: 'M-left_arrow' },
+  { from: 'M-d', to: 'M-delete_forward' },
+  { from: 'M-f', to: 'M-right_arrow' },
+
+  // the following keybindings override existing standard editor shortcuts
+  // if you use vim or emacs keybindings, you may want to comment them out
+  // { from: 'C-a', to: 'home' }, // conflicts with select all
+  // { from: 'C-b', to: 'left_arrow' }, // conflicts with bookmarks
+  // { from: 'C-d', to: 'delete_forward' }, // conflicts with duplicate line
+  // { from: 'C-e', to: 'end' }, // already implemented
+  // { from: 'C-f', to: 'right_arrow' }, // conflicts with find
+  // { from: 'C-l', to: 'C-k' }, // conflicts with cursor centering
+]
+
+const appConditions = [
+  {
+    type: 'frontmost_application_if',
+
+    bundle_identifiers: ['^com\\.nesbox\\.tic$'],
+
+    file_paths: ['^/Applications/tic80\\.app/Contents/MacOS/tic80$'],
+  },
+]
+
+const ruleMetadata = {
+  title: 'TIC-80 Readline-like keybindings',
+
+  description: 'Readline-like keybindings for the TIC-80 console and editor',
+
+  maintainers: ['Athesto'],
+}
+
+//------------------------------------------------------------------------------
+//  FUNCTIONS
+//------------------------------------------------------------------------------
+
+function generateKeyBindingPackage(keyBindings, conditions, ruleMetadata) {
+  const modifierBySymbol = {
+    C: 'control',
+    M: 'option',
+    O: 'option',
+    S: 'shift',
+    D: 'command',
+  }
+
+  function parseShortcut(shortcut) {
+    const normalizedShortcut = shortcut.replace(/^</, '').replace(/>$/, '')
+
+    const shortcutTokens = normalizedShortcut.split('-')
+    const key = shortcutTokens.pop()
+
+    const modifiers = shortcutTokens.map(function (modifierSymbol) {
+      const modifier = modifierBySymbol[modifierSymbol]
+
+      if (!modifier) {
+        throw new Error('Unknown modifier "{modifier}" in shortcut "{shortcut}"'.replace('{modifier}', modifierSymbol).replace('{shortcut}', shortcut))
+      }
+
+      return modifier
+    })
+
+    return {
+      key: key,
+      modifiers: modifiers,
+    }
+  }
+
+  function createManipulator(keyBinding) {
+    // Build from Event
+    const fromShortcut = parseShortcut(keyBinding.from)
+    const fromEvent = {
+      key_code: fromShortcut.key,
+    }
+    if (fromShortcut.modifiers.length > 0) {
+      fromEvent.modifiers = {
+        mandatory: fromShortcut.modifiers,
+      }
+    }
+
+    // Build to Event
+    const toShortcut = parseShortcut(keyBinding.to)
+    const toEvent = {
+      key_code: toShortcut.key,
+    }
+    if (toShortcut.modifiers.length > 0) {
+      toEvent.modifiers = toShortcut.modifiers
+    }
+
+    return {
+      type: 'basic',
+      from: fromEvent,
+      to: [toEvent],
+      conditions: conditions,
+    }
+  }
+
+  const manipulators = keyBindings.map(createManipulator)
+
+  const rule = {
+    description: ruleMetadata.description,
+    manipulators: manipulators,
+  }
+
+  const keyBindingPackage = {
+    title: ruleMetadata.title,
+    maintainers: ruleMetadata.maintainers,
+    rules: [rule],
+  }
+
+  return keyBindingPackage
+}
+
+//------------------------------------------------------------------------------
+//  MAIN / ENTRY POINT
+//------------------------------------------------------------------------------
+
+function main() {
+  const keyBindingPackage = generateKeyBindingPackage(keyBindings, appConditions, ruleMetadata)
+
+  console.log(JSON.stringify(keyBindingPackage, null, 2))
+}
+
+main()


### PR DESCRIPTION
## Introduction

Hi! 
My name is Gustavo Mejía and I've been using Karabiner-Elements for some of 
my keyboard customizations, and while working with TIC-80 I wanted to bring 
some of the Readline-like shortcuts I normally use in the terminal to its console 
and editor.

I ended up creating a small JavaScript generator for the bindings and thought
it could be useful to contribute it here. I've tried to keep the configuration
separate from the generation logic so that the same approach can be easily
adapted to other applications or sets of keybindings.

I'm happy to make any changes needed to better match the conventions of the
project.

## Summary

This PR adds Readline-like keybindings for the TIC-80 console and editor.

The rule uses Vim-style shortcut notation to generate the corresponding
Karabiner-Elements manipulators and is scoped to the TIC-80 application.

## How it works

The JavaScript file is organized into three main sections:

1. **Configuration**
   - `keyBindings` defines the shortcuts using compact Vim-style notation,
     such as `C-n`, `M-f`, or `C-M-b`.
   - `appConditions` defines where the generated Karabiner rules apply.
   - `ruleMetadata` contains the title, description, and maintainers.

2. **Functions**
   - `parseShortcut()` parses the shortcut notation into a key and its
     modifiers.
   - `createManipulator()` converts each key binding into a Karabiner
     manipulator.
   - `generateKeyBindingPackage()` combines the generated manipulators,
     conditions, and metadata into the final rule package.

3. **Main / Entry Point**
   - `main()` passes the configuration to the generator and prints the final
     JSON expected by the Karabiner complex modifications build process.

The general flow is:

    Configuration
        ↓
    Parse shortcuts
        ↓
    Create manipulators
        ↓
    Generate rule package
        ↓
    Output JSON

## Reusing the generator

The generator is intentionally separated from its configuration so that a
similar rule can be created mostly by changing the configuration at the top
of the file.

For example:

    const keyBindings = [
      { from: 'C-n', to: 'down_arrow' },
      { from: 'C-p', to: 'up_arrow' },
      { from: 'M-f', to: 'M-right_arrow' },
    ]

The target application can be changed through `appConditions`, while
`ruleMetadata` describes the generated rule.

In most cases, the parsing and generation functions should not need to be
modified.