### PR TITLE
Add nowage_n3sh_390 (international): Hangul shorthand for the Sebeolsik 390 layout

### DIFF
--- a/public/extra_descriptions/nowage_n3sh_390.html
+++ b/public/extra_descriptions/nowage_n3sh_390.html
@@ -1,0 +1,114 @@
+<h3>Read this first</h3>
+
+<p>
+  This rule is for the <b>Sebeolsik 390 (세벌식 390) Korean keyboard layout</b> and nothing else.
+  On Dubeolsik (두벌식) the same keys produce entirely different jamo, so the rule is not merely
+  useless there — it is wrong. It also stays asleep while you type in English, so it never gets in
+  the way of ordinary Latin typing.
+</p>
+
+<p>
+  What it does: press <b>two jamo keys at the same time</b> and one complete Hangul syllable is
+  emitted in a single stroke. 254 such chords are included, covering the particles, endings and
+  final-consonant syllables that dominate Korean text.
+</p>
+
+<p>
+  <b>The rest of this page is written in Korean.</b> What the rule produces <i>is</i> Hangul, and it
+  presumes a Korean layout the reader already types on — a translation would have no readers.
+  Installation, a one-page cheat sheet and a six-step learning drill are here:
+  <a href="https://finfra.github.io/karabiner-extensions/" target="_blank">finfra.github.io/karabiner-extensions</a>.
+</p>
+
+<h3>무엇을 하는 규칙인가</h3>
+
+<p>
+  세벌식 390 자판에서 <b>자모 2개를 동시에 눌러 완성형 한 글자를 한 번에 낸다.</b>
+  자주 나오는 조사·어미·받침 글자를 2타로 줄이는 것이 목적이고, 규칙은 254개다.
+</p>
+
+<table>
+  <tr><th>누르면</th><th>나온다</th><th>일반 타건</th></tr>
+  <tr><td><code>j</code> + <code>h</code></td><td>을␣</td><td>4타 (ㅇ ㅡ ㄹ ␣)</td></tr>
+  <tr><td><code>y</code> + <code>u</code></td><td>를␣</td><td>4타</td></tr>
+  <tr><td><code>h</code> + <code>l</code></td><td>는␣</td><td>4타</td></tr>
+  <tr><td><code>k</code> + <code>m</code></td><td>고␣</td><td>3타 (ㄱ ㅗ ␣)</td></tr>
+  <tr><td><code>j</code> + <code>i</code></td><td>있</td><td>3타 (ㅇ ㅣ ㅆ)</td></tr>
+</table>
+
+<ul>
+  <li><b>조사·어미는 뒤 공백까지 함께 나온다</b> — 그래서 <code>을</code>·<code>는</code>·<code>를</code> 의 일반 타건이 4타로 셈된다. <code>있</code> 처럼 공백이 안 붙는 규칙은 3타</li>
+  <li><b>두 키의 순서는 무관하다</b> — 모아치기(동시타)라 <code>j</code>+<code>h</code> 든 <code>h</code>+<code>j</code> 든 같다. 문서의 열 순서는 읽기 편의일 뿐</li>
+  <li>⇧·⌘·⌥ 로 층을 나눠 같은 자리에 다른 글자를 얹는다. <b>모디파이어는 자모보다 먼저 누른다</b> — 자모를 누른 뒤 모디파이어를 더하면 그 층이 잡히지 않는다</li>
+  <li>나오는 것은 대부분 <b>한 글자</b>다. 여러 글자가 나오는 규칙은 2건뿐이라 "단어를 펼치는" 도구는 아니다</li>
+</ul>
+
+<h3>쓰려면 무엇이 필요한가</h3>
+
+<table>
+  <tr><th>#</th><th>조건</th></tr>
+  <tr>
+    <td>A</td>
+    <td>
+      <b>세벌식 390 배열.</b> macOS 에 기본으로 들어 있다 (시스템 설정 → 키보드 → 입력 소스 →
+      편집 → <code>+</code> → 한국어 → 세벌식 390). 두벌식에서는 동작하지 않는다 —
+      <code>j</code>+<code>h</code> 가 "을" 이 되는 것은 그 자리에 ㅇ 과 ㅡㄹ 이 있기 때문이지
+      <code>j</code>·<code>h</code> 라는 글자에 의미가 있어서가 아니다
+    </td>
+  </tr>
+  <tr>
+    <td>B</td>
+    <td>
+      <b>한글 입력 상태.</b> 254건 전부가 조건 2개를 달고 있다 —
+      입력 소스가 <code>^ko$</code> 이고, 변수 <code>keyboardLayoutSettingIsEng</code> 가
+      <code>0</code> 일 것. 영문일 때는 규칙이 통째로 잠들어 Latin 타이핑을 방해하지 않는다
+    </td>
+  </tr>
+  <tr>
+    <td>C</td>
+    <td>
+      <b>두 키를 같은 순간에 받는 키보드.</b> 넣은 뒤 한글 상태에서 <code>c</code>+<code>v</code> 를
+      동시에 쳐서 <code>.</code> 하나가 나오면 준비가 끝난 것이다. 하나만 나오거나 순서가 뒤집히면
+      동시타 간격이 넓었던 것
+    </td>
+  </tr>
+  <tr>
+    <td>D</td>
+    <td>
+      ⚠️ <b>외우는 시간.</b> 254개는 설치해서 바로 쓰는 분량이 아니다 — 조사·어미(2단계)부터
+      익히면 나머지를 몰라도 이득이 나오도록 예비~6단계 커리큘럼을 짜 두었다.
+      하드웨어도 외부 앱도 필요 없다
+    </td>
+  </tr>
+</table>
+
+<h3>이 규칙이 하지 않는 것</h3>
+
+<p>
+  <b>변수를 쓰지 않는다 — 읽기만 한다.</b> <code>keyboardLayoutSettingIsEng</code> 를
+  조건으로 읽되 어디서도 세팅하지 않으므로(<code>set_variable</code> 0건), 그 변수를 쓰지 않는
+  환경에서는 값이 <code>0</code> 이라 그냥 동작한다. 같은 이름의 변수를 이미 쓰고 있다면
+  그쪽이 <code>1</code> 인 동안 이 규칙이 잠드는 것이 유일한 상호작용이다.
+</p>
+
+<p>
+  장치 조건(<code>device_if</code>)도 외부 앱 호출(<code>shell_command</code>)도 <b>0건</b>이다 —
+  하드웨어를 가리지 않고, 유료 앱을 요구하지 않으며, 규칙을 끄면 키보드는 완전히 평소대로
+  돌아온다. 254건 전부가 <code>simultaneous</code> 를 쓰는 <code>basic</code> manipulator 다.
+</p>
+
+<h3>문서와 소스</h3>
+
+<p>
+  자판 배치 치트시트·6단계 학습 드릴·규칙표 전문은
+  <a href="https://finfra.github.io/karabiner-extensions/" target="_blank">finfra.github.io/karabiner-extensions</a>
+  에 있다. 여기 요약만 읽고 254개를 마주하면 어디서 시작할지 알 수 없으므로,
+  <b>설치 → 치트시트 → 드릴</b> 순으로 읽기를 권한다.
+</p>
+
+<p>
+  규칙 정본(자모 조합표 md)과 그것을 이 JSON 으로 만드는 생성기는
+  <a href="https://github.com/Finfra/karabiner-extensions/tree/main/n3sh" target="_blank">Finfra/karabiner-extensions — n3sh</a>
+  에 공개돼 있다. 10년 넘게 개인 환경에서 굴려 온 체계이며, 여기 실린 것은
+  <b>390 판만</b>이다 (같은 저자의 최종식 배열 판은 수요가 확인되면 따로 낸다).
+</p>

--- a/public/groups.json
+++ b/public/groups.json
@@ -1291,6 +1291,10 @@
           "extra_description_path": "extra_descriptions/nowage_eng_char_on_kor.html"
         },
         {
+          "path": "json/nowage_n3sh_390.json",
+          "extra_description_path": "extra_descriptions/nowage_n3sh_390.html"
+        },
+        {
           "path": "json/Option+numbers_to_lithuanian_symbols.json"
         },
         {

--- a/public/json/nowage_n3sh_390.json
+++ b/public/json/nowage_n3sh_390.json
@@ -1,0 +1,10966 @@
+{
+  "title": "n3sh - Hangul shorthand for the Sebeolsik 390 layout (Korean only)",
+  "maintainers": [
+    "nowage"
+  ],
+  "rules": [
+    {
+      "description": "For the Sebeolsik 390 (세벌식 390) Korean keyboard layout only - it does nothing on Dubeolsik, and it stays asleep while you type in English. Press two jamo keys at the same time and one complete Hangul syllable comes out in a single stroke; 254 such chords are included. Because what the rule produces is Hangul itself, the description below is written in Korean. Guide, cheat sheet and a six-step drill: https://finfra.github.io/karabiner-extensions/ | 세벌식 390 자판에서 자모 2개를 동시에 눌러 완성형 한 글자를 한 번에 낸다. 자주 나오는 조사·어미·받침 글자를 2타로 줄이는 것이 목적이다 - `j`+`h` → `을 `(4타 → 2타) · `k`+`m` → `고 `(3타 → 2타) · `j`+`i` → `있`(3타 → 2타). 조사·어미는 뒤 공백까지 함께 나오고, ⇧·⌘·⌥ 로 층을 나눠 같은 자리에 다른 글자를 얹는다 (모디파이어는 자모보다 먼저 누른다). 모아치기라 두 키의 순서는 무관하다. 한글 입력 상태에서만 동작하므로(`keyboardLayoutSettingIsEng == 0`) 영문 타이핑은 방해받지 않는다. ⚠️ 254개는 설치하고 바로 쓰는 분량이 아니다 - 조사·어미(2단계)부터 익히면 나머지를 몰라도 이득이 나오도록 예비~6단계 커리큘럼을 짜 두었다. 설치·치트시트·학습 단계는 위 사이트에 있다.",
+      "manipulators": [
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "c"
+              },
+              {
+                "key_code": "v"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "period"
+              },
+              {
+                "key_code": "comma"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "n"
+              },
+              {
+                "key_code": "j"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "n"
+            },
+            {
+              "key_code": "n"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "j"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "k"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "l"
+              },
+              {
+                "key_code": "k"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "l"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "u"
+              },
+              {
+                "key_code": "i"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "u"
+            },
+            {
+              "key_code": "u"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "semicolon"
+              },
+              {
+                "key_code": "p"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "semicolon"
+            },
+            {
+              "key_code": "semicolon"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "f"
+              },
+              {
+                "key_code": "d"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "6"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "e"
+              },
+              {
+                "key_code": "r"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "5"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "r"
+              },
+              {
+                "key_code": "t"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "7"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "f"
+              },
+              {
+                "key_code": "r"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "r",
+              "modifiers": "shift"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "d"
+              },
+              {
+                "key_code": "c"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "d"
+              },
+              {
+                "key_code": "e"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "m"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "f"
+              },
+              {
+                "key_code": "e"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "h"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "w"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "h"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "w"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "y"
+              },
+              {
+                "key_code": "u"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "y"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "w"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "y"
+              },
+              {
+                "key_code": "u"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "y"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "w"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "y"
+              },
+              {
+                "key_code": "i"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "y"
+            },
+            {
+              "key_code": "v"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "u"
+              },
+              {
+                "key_code": "o"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "u"
+            },
+            {
+              "key_code": "v"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "l"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "s"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "l"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "s"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "l"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "s"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "l"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "s"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "l"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "s"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "l"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "s"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "l"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "s"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "l"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "s"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "l"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "s"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "l"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "s"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "m"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "v"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "m"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "v"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "period"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "period"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "period"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "period"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "period"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "f"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "period"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "period"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "period"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "period"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "period"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "f"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "spacebar"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "c"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "y"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "s"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "n"
+              },
+              {
+                "key_code": "quote"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "n"
+            },
+            {
+              "key_code": "t"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "m"
+              },
+              {
+                "key_code": "comma"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "m"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "w"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "m"
+              },
+              {
+                "key_code": "spacebar"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "m"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "s"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "n"
+              },
+              {
+                "key_code": "spacebar"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "n"
+            },
+            {
+              "key_code": "b"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "spacebar"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "c"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "i"
+              },
+              {
+                "key_code": "spacebar"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "i"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "s"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "i"
+              },
+              {
+                "key_code": "spacebar"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "i"
+            },
+            {
+              "key_code": "e"
+            },
+            {
+              "key_code": "s"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "u"
+              },
+              {
+                "key_code": "spacebar"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "u"
+            },
+            {
+              "key_code": "t"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "u"
+              },
+              {
+                "key_code": "spacebar"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "u"
+            },
+            {
+              "key_code": "c"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "u"
+              },
+              {
+                "key_code": "spacebar"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "u"
+            },
+            {
+              "key_code": "t"
+            },
+            {
+              "key_code": "s"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "8"
+              },
+              {
+                "key_code": "spacebar"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "8"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "2"
+              },
+              {
+                "key_code": "3"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "s"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "1"
+              },
+              {
+                "key_code": "3"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "s",
+              "modifiers": "shift"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "u"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "u"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "u"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "u"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "u"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "u"
+            },
+            {
+              "key_code": "f"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "m"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "m"
+            },
+            {
+              "key_code": "r"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "m"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "m"
+            },
+            {
+              "key_code": "r"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "m"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "m"
+            },
+            {
+              "key_code": "r"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "m"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "m"
+            },
+            {
+              "key_code": "r"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "d"
+              },
+              {
+                "key_code": "period"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "6"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "d"
+              },
+              {
+                "key_code": "period"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "6"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "d"
+              },
+              {
+                "key_code": "period"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "6"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "d"
+              },
+              {
+                "key_code": "period"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "6"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "d"
+              },
+              {
+                "key_code": "period"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "6"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "f"
+              },
+              {
+                "key_code": "period"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "f"
+              },
+              {
+                "key_code": "period"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "f"
+              },
+              {
+                "key_code": "period"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "return_or_enter"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "t"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "return_or_enter"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "t"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "return_or_enter"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "t"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "o"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "o"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "o"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "o"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "l"
+              },
+              {
+                "key_code": "quote"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "4"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "l"
+              },
+              {
+                "key_code": "quote"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "4"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "l"
+              },
+              {
+                "key_code": "quote"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "4"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "l"
+              },
+              {
+                "key_code": "quote"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "4"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "l"
+              },
+              {
+                "key_code": "quote"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "4"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "quote"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "4"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "quote"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "4"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "quote"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "4"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "v"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "v"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "v"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "n"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "n"
+            },
+            {
+              "key_code": "v"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "n"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "n"
+            },
+            {
+              "key_code": "v"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "n"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "n"
+            },
+            {
+              "key_code": "v"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "c"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "c"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "c"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "quote"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "b"
+            },
+            {
+              "key_code": "s"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "quote"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "b"
+            },
+            {
+              "key_code": "s"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "quote"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "b"
+            },
+            {
+              "key_code": "s"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "quote"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "b"
+            },
+            {
+              "key_code": "s"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "quote"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "b"
+            },
+            {
+              "key_code": "s"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "u"
+              },
+              {
+                "key_code": "l"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "u"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "r"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "u"
+              },
+              {
+                "key_code": "l"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "u"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "r"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "u"
+              },
+              {
+                "key_code": "l"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "u"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "r"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "u"
+              },
+              {
+                "key_code": "l"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "u"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "r"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "u"
+              },
+              {
+                "key_code": "l"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "u"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "r"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "y"
+              },
+              {
+                "key_code": "8"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "y"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "y"
+              },
+              {
+                "key_code": "8"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "y"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "y"
+              },
+              {
+                "key_code": "8"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "y"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "j"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "j"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "j"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "u"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "u"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "u"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "i"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "6"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "i"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "6"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "i"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "6"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "o"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "o"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "o"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "y"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "y"
+            },
+            {
+              "key_code": "r"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "y"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "y"
+            },
+            {
+              "key_code": "r"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "y"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "y"
+            },
+            {
+              "key_code": "r"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "y"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "y"
+            },
+            {
+              "key_code": "r"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "y"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "y"
+            },
+            {
+              "key_code": "r"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "l"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "l"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "l"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "l"
+              },
+              {
+                "key_code": "comma"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "9"
+            },
+            {
+              "key_code": "t"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "l"
+              },
+              {
+                "key_code": "comma"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "9"
+            },
+            {
+              "key_code": "t"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "l"
+              },
+              {
+                "key_code": "comma"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "9"
+            },
+            {
+              "key_code": "t"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "l"
+              },
+              {
+                "key_code": "comma"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "9"
+            },
+            {
+              "key_code": "t"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "semicolon"
+              },
+              {
+                "key_code": "quote"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "semicolon"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "semicolon"
+              },
+              {
+                "key_code": "quote"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "semicolon"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "semicolon"
+              },
+              {
+                "key_code": "quote"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "semicolon"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "semicolon"
+              },
+              {
+                "key_code": "quote"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "semicolon"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "f"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "semicolon"
+              },
+              {
+                "key_code": "quote"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "semicolon"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "i"
+              },
+              {
+                "key_code": "semicolon"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "i"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "y"
+              },
+              {
+                "key_code": "7"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "y"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "y"
+              },
+              {
+                "key_code": "7"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "y"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "m"
+              },
+              {
+                "key_code": "l"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "m"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "z"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "m"
+              },
+              {
+                "key_code": "l"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "m"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "z"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "m"
+              },
+              {
+                "key_code": "l"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "m"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "z"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "m"
+              },
+              {
+                "key_code": "l"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "m"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "z"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "m"
+              },
+              {
+                "key_code": "l"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "m"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "z"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "m"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "z"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "m"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "z"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "m"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "z"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "m"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "z"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "m"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "z"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "u"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "z"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "u"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "z"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "u"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "z"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "u"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "option"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "z"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "u"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "z"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "p"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "period"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "p"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "p"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift",
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "b",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "spacebar"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "c"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "spacebar"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "c"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "a"
+              },
+              {
+                "key_code": "w"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "a",
+              "modifiers": "shift"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "w"
+              },
+              {
+                "key_code": "q"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "w",
+              "modifiers": "shift"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "z"
+              },
+              {
+                "key_code": "s"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "z",
+              "modifiers": "shift"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "q"
+              },
+              {
+                "key_code": "2"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "q",
+              "modifiers": "shift"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "1"
+              },
+              {
+                "key_code": "w"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "1",
+              "modifiers": "shift"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "s"
+              },
+              {
+                "key_code": "a"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "s",
+              "modifiers": "shift"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "x"
+              },
+              {
+                "key_code": "z"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "x",
+              "modifiers": "shift"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "f"
+              },
+              {
+                "key_code": "spacebar"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "f"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "r"
+              },
+              {
+                "key_code": "spacebar"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "r"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "v"
+              },
+              {
+                "key_code": "spacebar"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "d"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "t"
+              },
+              {
+                "key_code": "spacebar"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "9"
+            },
+            {
+              "key_code": "t"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "c"
+              },
+              {
+                "key_code": "spacebar"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "9"
+            },
+            {
+              "key_code": "c"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "d"
+              },
+              {
+                "key_code": "spacebar"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "9"
+            },
+            {
+              "key_code": "d"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "g"
+              },
+              {
+                "key_code": "spacebar"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "8"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "1"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "1",
+              "modifiers": "shift"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "2"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "c"
+            },
+            {
+              "key_code": "2"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "3"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "3"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "1"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "1",
+              "modifiers": "shift"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "2"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "r"
+            },
+            {
+              "key_code": "2"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "3"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "3"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "u"
+              },
+              {
+                "key_code": "1"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "u"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "1",
+              "modifiers": "shift"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "u"
+              },
+              {
+                "key_code": "2"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "u"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "r"
+            },
+            {
+              "key_code": "2"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "u"
+              },
+              {
+                "key_code": "3"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "u"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "3"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "y"
+              },
+              {
+                "key_code": "1"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "y"
+            },
+            {
+              "key_code": "t"
+            },
+            {
+              "key_code": "1"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "y"
+              },
+              {
+                "key_code": "2"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "y"
+            },
+            {
+              "key_code": "r"
+            },
+            {
+              "key_code": "2"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "y"
+              },
+              {
+                "key_code": "3"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "y"
+            },
+            {
+              "key_code": "v"
+            },
+            {
+              "key_code": "3"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "i"
+              },
+              {
+                "key_code": "1"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "i"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "1",
+              "modifiers": "shift"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "i"
+              },
+              {
+                "key_code": "2"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "i"
+            },
+            {
+              "key_code": "e"
+            },
+            {
+              "key_code": "2"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "i"
+              },
+              {
+                "key_code": "3"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "i"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "3"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "semicolon"
+              },
+              {
+                "key_code": "1"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "semicolon"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "1",
+              "modifiers": "shift"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "semicolon"
+              },
+              {
+                "key_code": "2"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "semicolon"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "2"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "semicolon"
+              },
+              {
+                "key_code": "3"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "semicolon"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "3"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "n"
+              },
+              {
+                "key_code": "1"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "n"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "v",
+              "modifiers": "shift"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "n"
+              },
+              {
+                "key_code": "2"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "n"
+            },
+            {
+              "key_code": "e"
+            },
+            {
+              "key_code": "2"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "n"
+              },
+              {
+                "key_code": "3"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "n"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "3"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "1"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "1",
+              "modifiers": "shift"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "2"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "2"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "3"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "3"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "l"
+              },
+              {
+                "key_code": "1"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "1",
+              "modifiers": "shift"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "l"
+              },
+              {
+                "key_code": "2"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "e"
+            },
+            {
+              "key_code": "2"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "l"
+              },
+              {
+                "key_code": "3"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "3"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "o"
+              },
+              {
+                "key_code": "1"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "o"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "1",
+              "modifiers": "shift"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "o"
+              },
+              {
+                "key_code": "2"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "o"
+            },
+            {
+              "key_code": "e"
+            },
+            {
+              "key_code": "2"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "o"
+              },
+              {
+                "key_code": "3"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "o"
+            },
+            {
+              "key_code": "b"
+            },
+            {
+              "key_code": "3"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "0"
+              },
+              {
+                "key_code": "2"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "0"
+            },
+            {
+              "key_code": "e"
+            },
+            {
+              "key_code": "2"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "0"
+              },
+              {
+                "key_code": "3"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "0"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "3"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "quote"
+              },
+              {
+                "key_code": "2"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "quote"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "2"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "quote"
+              },
+              {
+                "key_code": "3"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "quote"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "3"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "p"
+              },
+              {
+                "key_code": "2"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "p"
+            },
+            {
+              "key_code": "e"
+            },
+            {
+              "key_code": "2"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "p"
+              },
+              {
+                "key_code": "3"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "p"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "3"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "m"
+              },
+              {
+                "key_code": "2"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "m"
+            },
+            {
+              "key_code": "r"
+            },
+            {
+              "key_code": "2"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "m"
+              },
+              {
+                "key_code": "3"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "m"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "3"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "open_bracket"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "2"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "comma"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "t"
+            },
+            {
+              "key_code": "x",
+              "modifiers": "shift"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "o"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "t"
+            },
+            {
+              "key_code": "2"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "p"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "e"
+            },
+            {
+              "key_code": "2"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "close_bracket"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "9"
+            },
+            {
+              "key_code": "t"
+            },
+            {
+              "key_code": "s"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "backslash"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "9"
+            },
+            {
+              "key_code": "t"
+            },
+            {
+              "key_code": "w"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "hyphen"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "d",
+              "modifiers": "shift"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "0"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "v",
+              "modifiers": "shift"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "j"
+              },
+              {
+                "key_code": "i"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "2"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "h"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "r"
+            },
+            {
+              "key_code": "s"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "o"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "t"
+            },
+            {
+              "key_code": "q"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "k"
+              },
+              {
+                "key_code": "comma"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "k"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "s",
+              "modifiers": "shift"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "m"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "t"
+            },
+            {
+              "key_code": "1"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "p"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "e"
+            },
+            {
+              "key_code": "s"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "open_bracket"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "c"
+            },
+            {
+              "key_code": "q"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "y"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "z"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "i"
+              },
+              {
+                "key_code": "9"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "i"
+            },
+            {
+              "key_code": "9"
+            },
+            {
+              "key_code": "t"
+            },
+            {
+              "key_code": "w"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "i"
+              },
+              {
+                "key_code": "o"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "i"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "s",
+              "modifiers": "shift"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "l"
+              },
+              {
+                "key_code": "i"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "v"
+            },
+            {
+              "key_code": "1"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "l"
+              },
+              {
+                "key_code": "o"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "s",
+              "modifiers": "shift"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "l"
+              },
+              {
+                "key_code": "spacebar"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "b"
+            },
+            {
+              "key_code": "w"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "l"
+              },
+              {
+                "key_code": "period"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "t"
+            },
+            {
+              "key_code": "x"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "m"
+              },
+              {
+                "key_code": "period"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "m"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "w"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "o"
+              },
+              {
+                "key_code": "p"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "o"
+            },
+            {
+              "key_code": "f"
+            },
+            {
+              "key_code": "s",
+              "modifiers": "shift"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "u"
+              },
+              {
+                "key_code": "8"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "u"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "s"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "u"
+              },
+              {
+                "key_code": "open_bracket"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "u"
+            },
+            {
+              "key_code": "slash"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "w"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "u"
+              },
+              {
+                "key_code": "p"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "u"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "w"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "u"
+              },
+              {
+                "key_code": "k"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "u"
+            },
+            {
+              "key_code": "u"
+            },
+            {
+              "key_code": "t"
+            },
+            {
+              "key_code": "1"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "9"
+              },
+              {
+                "key_code": "s"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "j"
+            },
+            {
+              "key_code": "9"
+            },
+            {
+              "key_code": "d"
+            },
+            {
+              "key_code": "s"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "u"
+              },
+              {
+                "key_code": "0"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "u"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "a"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "m"
+              },
+              {
+                "key_code": "n"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "m"
+            },
+            {
+              "key_code": "b"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "l"
+              },
+              {
+                "key_code": "p"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "x"
+            },
+            {
+              "key_code": "comma"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "l"
+              },
+              {
+                "key_code": "p"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "l"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "x"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "m"
+              },
+              {
+                "key_code": "quote"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "m"
+            },
+            {
+              "key_code": "r"
+            },
+            {
+              "key_code": "a"
+            },
+            {
+              "key_code": "comma"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "m"
+              },
+              {
+                "key_code": "quote"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "command"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "m"
+            },
+            {
+              "key_code": "r"
+            },
+            {
+              "key_code": "a"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "n"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "v"
+            },
+            {
+              "key_code": "1"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "period"
+              }
+            ]
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "a"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        },
+        {
+          "from": {
+            "simultaneous": [
+              {
+                "key_code": "h"
+              },
+              {
+                "key_code": "period"
+              }
+            ],
+            "modifiers": {
+              "mandatory": [
+                "shift"
+              ]
+            }
+          },
+          "to": [
+            {
+              "key_code": "h"
+            },
+            {
+              "key_code": "g"
+            },
+            {
+              "key_code": "a"
+            },
+            {
+              "key_code": "slash",
+              "modifiers": "shift"
+            },
+            {
+              "key_code": "spacebar"
+            }
+          ],
+          "type": "basic",
+          "conditions": [
+            {
+              "input_sources": [
+                {
+                  "language": "^ko$"
+                }
+              ],
+              "type": "input_source_if"
+            },
+            {
+              "type": "variable_if",
+              "name": "keyboardLayoutSettingIsEng",
+              "value": 0
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds `nowage_n3sh_390` to the **International (Language Specific)** group.

## What it does

For the **Sebeolsik 390 (세벌식 390)** Korean keyboard layout: press two jamo keys at
the same time and one complete Hangul syllable is emitted in a single stroke. 254 such
chords are included, covering the particles, endings and final-consonant syllables that
dominate Korean text (e.g. `j`+`h` → `을 `, 4 keystrokes → 2).

The rule is dormant unless both conditions hold, so it never interferes with Latin typing:

- input source matches `^ko$`
- variable `keyboardLayoutSettingIsEng` is `0`

`device_if` 0 · `shell_command` 0 · `set_variable` 0 — no hardware, no external
application, and the variable above is only *read*, never written, so it defaults to `0`
in environments that do not use it.

## Description language

The `extra_description` opens in English (what it is, that it is Sebeolsik-390-only) and
then continues in Korean. The rule produces Hangul jamo and presumes a Korean layout the
reader already types on, so a full translation would have no readers. This mirrors what a
few existing entries in this group already do.

## Documentation

254 chords are not something you install and use immediately, so the rule links to a guide
with an installation walkthrough, a one-page cheat sheet and a six-step learning drill:
https://finfra.github.io/karabiner-extensions/

Source and the generator that produces this JSON:
https://github.com/Finfra/karabiner-extensions/tree/main/n3sh

## Checks

- `karabiner_cli --lint-complex-modifications`: ok
- `make all`: ok
