### PR TITLE
Unify rule names for nowage_* rules (name, source URL, version)

### DIFF
--- a/public/extra_descriptions/nowage_n3sh_390.html
+++ b/public/extra_descriptions/nowage_n3sh_390.html
@@ -20,6 +20,12 @@
   <a href="https://finfra.github.io/karabiner-extensions/" target="_blank">finfra.github.io/karabiner-extensions</a>.
 </p>
 
+<p>
+  Once imported, the rule appears in <b>Complex Modifications</b> as
+  <code>n3sh(Nowage ShortHand for 3set 390) : https://github.com/Finfra/karabiner-extensions v&lt;date&gt;</code>
+  — the trailing date is the rule version, so you can tell which revision you have.
+</p>
+
 <h3>무엇을 하는 규칙인가</h3>
 
 <p>

--- a/public/json/nowage_eng_char_on_kor.json
+++ b/public/json/nowage_eng_char_on_kor.json
@@ -1,11 +1,11 @@
 {
-  "title": "Type English while staying in Korean input mode (hold Insert)",
+  "title": "Eng Char on Kor : https://github.com/Finfra/karabiner-extensions v2026.08.07",
   "maintainers": [
     "nowage"
   ],
   "rules": [
     {
-      "description": "Type English without leaving the Korean input source. Hold Insert: the input source switches to English for as long as the key is held, and returns to Korean when you release it. Tap Home while holding Insert to toggle capital letters (useful for API, URL and other runs of uppercase); the toggle resets when Insert is released. Shift+letter also works for a single capital. A composing Hangul syllable is committed before the switch, so typing English right after a half-finished syllable does not discard it. Requirements: (1) a physical key that sends 'insert' and is not claimed by another rule; (2) Home must be free *while the layer is active* - outside the layer Home behaves normally; (3) Korean and English input sources identifiable as ^ko$ / ^en$; (4) a Hangul IME that commits the composing syllable on space. Your Korean/English switching shortcut does not matter.",
+      "description": "Eng Char on Kor : https://github.com/Finfra/karabiner-extensions v2026.08.07",
       "manipulators": [
         {
           "type": "basic",

--- a/public/json/nowage_foot_pedal.json
+++ b/public/json/nowage_foot_pedal.json
@@ -1,11 +1,11 @@
 {
-  "title": "USB Foot Pedal (3 pedals) - Editing / Navigation / Media layers",
+  "title": "Foot Pedal : https://github.com/Finfra/karabiner-extensions v2026.07.26",
   "maintainers": [
     "nowage"
   ],
   "rules": [
     {
-      "description": "USB Foot Pedal (3 pedals). Pedal 1 (left, 'a') = editing: copy, control=cut, option=paste, shift=paste-without-formatting, command=undo, hyper=redo. Pedal 2 (middle, 'b') = navigation: page down, control=page up, option=end, shift=home, command=Mission Control, hyper=Launchpad. Pedal 3 (right, 'c') = media: play/pause, control=rewind, option=fast-forward, shift=mute, command=volume down, hyper=volume up. Requires a USB foot switch with vendor_id 6790 (0x1a86) / product_id 57382 (0xe026).",
+      "description": "Foot Pedal : https://github.com/Finfra/karabiner-extensions v2026.07.26",
       "manipulators": [
         {
           "description": "hyper + pedal 1 -> redo",

--- a/public/json/nowage_n3sh_390.json
+++ b/public/json/nowage_n3sh_390.json
@@ -1,11 +1,11 @@
 {
-  "title": "n3sh - Hangul shorthand for the Sebeolsik 390 layout (Korean only)",
+  "title": "n3sh(Nowage ShortHand for 3set 390) : https://github.com/Finfra/karabiner-extensions v2026.08.30",
   "maintainers": [
     "nowage"
   ],
   "rules": [
     {
-      "description": "For the Sebeolsik 390 (세벌식 390) Korean keyboard layout only - it does nothing on Dubeolsik, and it stays asleep while you type in English. Press two jamo keys at the same time and one complete Hangul syllable comes out in a single stroke; 254 such chords are included. Because what the rule produces is Hangul itself, the description below is written in Korean. Guide, cheat sheet and a six-step drill: https://finfra.github.io/karabiner-extensions/ | 세벌식 390 자판에서 자모 2개를 동시에 눌러 완성형 한 글자를 한 번에 낸다. 자주 나오는 조사·어미·받침 글자를 2타로 줄이는 것이 목적이다 - `j`+`h` → `을 `(4타 → 2타) · `k`+`m` → `고 `(3타 → 2타) · `j`+`i` → `있`(3타 → 2타). 조사·어미는 뒤 공백까지 함께 나오고, ⇧·⌘·⌥ 로 층을 나눠 같은 자리에 다른 글자를 얹는다 (모디파이어는 자모보다 먼저 누른다). 모아치기라 두 키의 순서는 무관하다. 한글 입력 상태에서만 동작하므로(`keyboardLayoutSettingIsEng == 0`) 영문 타이핑은 방해받지 않는다. ⚠️ 254개는 설치하고 바로 쓰는 분량이 아니다 - 조사·어미(2단계)부터 익히면 나머지를 몰라도 이득이 나오도록 예비~6단계 커리큘럼을 짜 두었다. 설치·치트시트·학습 단계는 위 사이트에 있다.",
+      "description": "n3sh(Nowage ShortHand for 3set 390) : https://github.com/Finfra/karabiner-extensions v2026.08.30",
       "manipulators": [
         {
           "from": {


### PR DESCRIPTION
Updates the rule/ruleset names of my three registered rules so that each one identifies
itself in a single line.

## Why

The `description` of a rule is what Karabiner-Elements shows in the user's
**Complex Modifications** list. My rules carried a full explanatory paragraph there, so
after importing them the list rendered several lines of prose per rule and the entries
were hard to tell apart. That text belongs in `extra_description`, which already holds it.

## What changed

Each rule now uses the same short line for both `title` and `description`:

| file | name |
| :--- | :--- |
| `nowage_n3sh_390.json` | `n3sh(Nowage ShortHand for 3set 390) : https://github.com/Finfra/karabiner-extensions v2026.08.30` |
| `nowage_foot_pedal.json` | `Foot Pedal : https://github.com/Finfra/karabiner-extensions v2026.07.26` |
| `nowage_eng_char_on_kor.json` | `Eng Char on Kor : https://github.com/Finfra/karabiner-extensions v2026.08.07` |

The trailing date is the rule version, and the URL is where the rule is maintained, so a
user who finds the entry months later can tell which revision they have and where to look.

**No manipulator is touched** — the behaviour of all three rules is unchanged. The
`nowage_n3sh_390` extra description also gains one short paragraph telling the reader
what name to expect in the list.

`groups.json` is unchanged; all three are already registered.

## Checks

- `make all`: ok
- `karabiner_cli --lint-complex-modifications`: ok for all three
