### PR TITLE
Switch nowage_* rules to semantic versioning

### DIFF
--- a/public/json/nowage_eng_char_on_kor.json
+++ b/public/json/nowage_eng_char_on_kor.json
@@ -1,11 +1,11 @@
 {
-  "title": "Eng Char on Kor : https://github.com/Finfra/karabiner-extensions v2026.08.07",
+  "title": "Eng Char on Kor : https://github.com/Finfra/karabiner-extensions v1.0.0",
   "maintainers": [
     "nowage"
   ],
   "rules": [
     {
-      "description": "Eng Char on Kor : https://github.com/Finfra/karabiner-extensions v2026.08.07",
+      "description": "Eng Char on Kor : https://github.com/Finfra/karabiner-extensions v1.0.0",
       "manipulators": [
         {
           "type": "basic",

--- a/public/json/nowage_foot_pedal.json
+++ b/public/json/nowage_foot_pedal.json
@@ -1,11 +1,11 @@
 {
-  "title": "Foot Pedal : https://github.com/Finfra/karabiner-extensions v2026.07.26",
+  "title": "Foot Pedal : https://github.com/Finfra/karabiner-extensions v1.0.0",
   "maintainers": [
     "nowage"
   ],
   "rules": [
     {
-      "description": "Foot Pedal : https://github.com/Finfra/karabiner-extensions v2026.07.26",
+      "description": "Foot Pedal : https://github.com/Finfra/karabiner-extensions v1.0.0",
       "manipulators": [
         {
           "description": "hyper + pedal 1 -> redo",

--- a/public/json/nowage_n3sh_390.json
+++ b/public/json/nowage_n3sh_390.json
@@ -1,11 +1,11 @@
 {
-  "title": "n3sh(Nowage ShortHand for 3set 390) : https://github.com/Finfra/karabiner-extensions v2026.08.30",
+  "title": "n3sh(Nowage ShortHand for 3set 390) : https://github.com/Finfra/karabiner-extensions v0.9.0",
   "maintainers": [
     "nowage"
   ],
   "rules": [
     {
-      "description": "n3sh(Nowage ShortHand for 3set 390) : https://github.com/Finfra/karabiner-extensions v2026.08.30",
+      "description": "n3sh(Nowage ShortHand for 3set 390) : https://github.com/Finfra/karabiner-extensions v0.9.0",
       "manipulators": [
         {
           "from": {


### PR DESCRIPTION
Switches my three rules from date-based versions to semantic versioning.

| file | before | after |
| :--- | :--- | :--- |
| `nowage_foot_pedal.json` | `… v2026.07.26` | `Foot Pedal : https://github.com/Finfra/karabiner-extensions v1.0.0` |
| `nowage_eng_char_on_kor.json` | `… v2026.08.07` | `Eng Char on Kor : … v1.0.0` |
| `nowage_n3sh_390.json` | `… v2026.08.30` | `n3sh(Nowage ShortHand for 3set 390) : … v0.9.0` |

Only `title` and `description` change — **no manipulator is touched**, and
`groups.json` is unchanged. The version now lives in `Extensions/<name>/VERSION`
in the source repository and is stamped into the name by a tool, so the number a
user sees in Complex Modifications always matches a released commit.

`make all`: ok · `karabiner_cli --lint-complex-modifications`: ok for all three.
