### PR TITLE
Function keys remap Apple Silicon

### DIFF
--- a/public/json/fn_keys_as_standard_in_specific_apps_apple_silicon.json
+++ b/public/json/fn_keys_as_standard_in_specific_apps_apple_silicon.json
@@ -1,0 +1,874 @@
+{
+    "description": "Mac OSX: Use Function Keys in Supported Apps, else use Media Keys - Macbook M4 compatible",
+    "maintainers": ["mpelegrini"],
+    "manipulators": [
+        {
+            "conditions": [
+                {
+                    "bundle_identifiers": [
+                        "^com.microsoft.VSCode$",
+                        "^com.microsoft.VSCodeInsiders",
+                        "^com.jetbrains.goland$",
+                        "^com.jetbrains.rider$",
+                        "^com.jetbrains.pycharm$",
+                        "^com.jetbrains.pycharm.ce$",
+                        "^com.jetbrains.intellij$",
+                        "^com.jetbrains.intellij.ce$",
+                        "^com.jetbrains.PhpStorm$",
+                        "^com.jetbrains.CLion$",
+                        "^com.jetbrains.WebStorm$",
+                        "^com.jetbrains.rubymine$",
+                        "^com.jetbrains.datagrip$",
+                        "^com.jetbrains.rustrover-EAP$",
+                        "^com.jetbrains.rustrover$",
+                        "^com.googlecode.iterm2$",
+                        "^com.apple.Terminal$"
+                    ],
+                    "type": "frontmost_application_if"
+                }
+            ],
+            "from": {
+                "key_code": "f1",
+                "modifiers": { "optional": ["any"] }
+            },
+            "to": [
+                {
+                    "key_code": "f1",
+                    "modifiers": ["fn"]
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "bundle_identifiers": [
+                        "^com.microsoft.VSCode$",
+                        "^com.microsoft.VSCodeInsiders",
+                        "^com.jetbrains.goland$",
+                        "^com.jetbrains.rider$",
+                        "^com.jetbrains.pycharm$",
+                        "^com.jetbrains.pycharm.ce$",
+                        "^com.jetbrains.intellij$",
+                        "^com.jetbrains.intellij.ce$",
+                        "^com.jetbrains.PhpStorm$",
+                        "^com.jetbrains.CLion$",
+                        "^com.jetbrains.WebStorm$",
+                        "^com.jetbrains.rubymine$",
+                        "^com.jetbrains.datagrip$",
+                        "^com.jetbrains.rustrover-EAP$",
+                        "^com.jetbrains.rustrover$",
+                        "^com.googlecode.iterm2$",
+                        "^com.apple.Terminal$"
+                    ],
+                    "type": "frontmost_application_if"
+                }
+            ],
+            "from": {
+                "key_code": "f2",
+                "modifiers": { "optional": ["any"] }
+            },
+            "to": [
+                {
+                    "key_code": "f2",
+                    "modifiers": ["fn"]
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "bundle_identifiers": [
+                        "^com.microsoft.VSCode$",
+                        "^com.microsoft.VSCodeInsiders",
+                        "^com.jetbrains.goland$",
+                        "^com.jetbrains.rider$",
+                        "^com.jetbrains.pycharm$",
+                        "^com.jetbrains.pycharm.ce$",
+                        "^com.jetbrains.intellij$",
+                        "^com.jetbrains.intellij.ce$",
+                        "^com.jetbrains.PhpStorm$",
+                        "^com.jetbrains.CLion$",
+                        "^com.jetbrains.WebStorm$",
+                        "^com.jetbrains.rubymine$",
+                        "^com.jetbrains.datagrip$",
+                        "^com.jetbrains.rustrover-EAP$",
+                        "^com.jetbrains.rustrover$",
+                        "^com.googlecode.iterm2$",
+                        "^com.apple.Terminal$"
+                    ],
+                    "type": "frontmost_application_if"
+                }
+            ],
+            "from": {
+                "key_code": "f3",
+                "modifiers": { "optional": ["any"] }
+            },
+            "to": [
+                {
+                    "key_code": "f3",
+                    "modifiers": ["fn"]
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "bundle_identifiers": [
+                        "^com.microsoft.VSCode$",
+                        "^com.microsoft.VSCodeInsiders",
+                        "^com.jetbrains.goland$",
+                        "^com.jetbrains.rider$",
+                        "^com.jetbrains.pycharm$",
+                        "^com.jetbrains.pycharm.ce$",
+                        "^com.jetbrains.intellij$",
+                        "^com.jetbrains.intellij.ce$",
+                        "^com.jetbrains.PhpStorm$",
+                        "^com.jetbrains.CLion$",
+                        "^com.jetbrains.WebStorm$",
+                        "^com.jetbrains.rubymine$",
+                        "^com.jetbrains.datagrip$",
+                        "^com.jetbrains.rustrover-EAP$",
+                        "^com.jetbrains.rustrover$",
+                        "^com.googlecode.iterm2$",
+                        "^com.apple.Terminal$"
+                    ],
+                    "type": "frontmost_application_if"
+                }
+            ],
+            "from": {
+                "key_code": "f4",
+                "modifiers": { "optional": ["any"] }
+            },
+            "to": [
+                {
+                    "key_code": "f4",
+                    "modifiers": ["fn"]
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "bundle_identifiers": [
+                        "^com.microsoft.VSCode$",
+                        "^com.microsoft.VSCodeInsiders",
+                        "^com.jetbrains.goland$",
+                        "^com.jetbrains.rider$",
+                        "^com.jetbrains.pycharm$",
+                        "^com.jetbrains.pycharm.ce$",
+                        "^com.jetbrains.intellij$",
+                        "^com.jetbrains.intellij.ce$",
+                        "^com.jetbrains.PhpStorm$",
+                        "^com.jetbrains.CLion$",
+                        "^com.jetbrains.WebStorm$",
+                        "^com.jetbrains.rubymine$",
+                        "^com.jetbrains.datagrip$",
+                        "^com.jetbrains.rustrover-EAP$",
+                        "^com.jetbrains.rustrover$",
+                        "^com.googlecode.iterm2$",
+                        "^com.apple.Terminal$"
+                    ],
+                    "type": "frontmost_application_if"
+                }
+            ],
+            "from": {
+                "key_code": "f5",
+                "modifiers": { "optional": ["any"] }
+            },
+            "to": [
+                {
+                    "key_code": "f5",
+                    "modifiers": ["fn"]
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "bundle_identifiers": [
+                        "^com.microsoft.VSCode$",
+                        "^com.microsoft.VSCodeInsiders",
+                        "^com.jetbrains.goland$",
+                        "^com.jetbrains.rider$",
+                        "^com.jetbrains.pycharm$",
+                        "^com.jetbrains.pycharm.ce$",
+                        "^com.jetbrains.intellij$",
+                        "^com.jetbrains.intellij.ce$",
+                        "^com.jetbrains.PhpStorm$",
+                        "^com.jetbrains.CLion$",
+                        "^com.jetbrains.WebStorm$",
+                        "^com.jetbrains.rubymine$",
+                        "^com.jetbrains.datagrip$",
+                        "^com.jetbrains.rustrover-EAP$",
+                        "^com.jetbrains.rustrover$",
+                        "^com.googlecode.iterm2$",
+                        "^com.apple.Terminal$"
+                    ],
+                    "type": "frontmost_application_if"
+                }
+            ],
+            "from": {
+                "key_code": "f6",
+                "modifiers": { "optional": ["any"] }
+            },
+            "to": [
+                {
+                    "key_code": "f6",
+                    "modifiers": ["fn"]
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "bundle_identifiers": [
+                        "^com.microsoft.VSCode$",
+                        "^com.microsoft.VSCodeInsiders",
+                        "^com.jetbrains.goland$",
+                        "^com.jetbrains.rider$",
+                        "^com.jetbrains.pycharm$",
+                        "^com.jetbrains.pycharm.ce$",
+                        "^com.jetbrains.intellij$",
+                        "^com.jetbrains.intellij.ce$",
+                        "^com.jetbrains.PhpStorm$",
+                        "^com.jetbrains.CLion$",
+                        "^com.jetbrains.WebStorm$",
+                        "^com.jetbrains.rubymine$",
+                        "^com.jetbrains.datagrip$",
+                        "^com.jetbrains.rustrover-EAP$",
+                        "^com.jetbrains.rustrover$",
+                        "^com.googlecode.iterm2$",
+                        "^com.apple.Terminal$"
+                    ],
+                    "type": "frontmost_application_if"
+                }
+            ],
+            "from": {
+                "key_code": "f7",
+                "modifiers": { "optional": ["any"] }
+            },
+            "to": [
+                {
+                    "key_code": "f7",
+                    "modifiers": ["fn"]
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "bundle_identifiers": [
+                        "^com.microsoft.VSCode$",
+                        "^com.microsoft.VSCodeInsiders",
+                        "^com.jetbrains.goland$",
+                        "^com.jetbrains.rider$",
+                        "^com.jetbrains.pycharm$",
+                        "^com.jetbrains.pycharm.ce$",
+                        "^com.jetbrains.intellij$",
+                        "^com.jetbrains.intellij.ce$",
+                        "^com.jetbrains.PhpStorm$",
+                        "^com.jetbrains.CLion$",
+                        "^com.jetbrains.WebStorm$",
+                        "^com.jetbrains.rubymine$",
+                        "^com.jetbrains.datagrip$",
+                        "^com.jetbrains.rustrover-EAP$",
+                        "^com.jetbrains.rustrover$",
+                        "^com.googlecode.iterm2$",
+                        "^com.apple.Terminal$"
+                    ],
+                    "type": "frontmost_application_if"
+                }
+            ],
+            "from": {
+                "key_code": "f8",
+                "modifiers": { "optional": ["any"] }
+            },
+            "to": [
+                {
+                    "key_code": "f8",
+                    "modifiers": ["fn"]
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "bundle_identifiers": [
+                        "^com.microsoft.VSCode$",
+                        "^com.microsoft.VSCodeInsiders",
+                        "^com.jetbrains.goland$",
+                        "^com.jetbrains.rider$",
+                        "^com.jetbrains.pycharm$",
+                        "^com.jetbrains.pycharm.ce$",
+                        "^com.jetbrains.intellij$",
+                        "^com.jetbrains.intellij.ce$",
+                        "^com.jetbrains.PhpStorm$",
+                        "^com.jetbrains.CLion$",
+                        "^com.jetbrains.WebStorm$",
+                        "^com.jetbrains.rubymine$",
+                        "^com.jetbrains.datagrip$",
+                        "^com.jetbrains.rustrover-EAP$",
+                        "^com.jetbrains.rustrover$",
+                        "^com.googlecode.iterm2$",
+                        "^com.apple.Terminal$"
+                    ],
+                    "type": "frontmost_application_if"
+                }
+            ],
+            "from": {
+                "key_code": "f9",
+                "modifiers": { "optional": ["any"] }
+            },
+            "to": [
+                {
+                    "key_code": "f9",
+                    "modifiers": ["fn"]
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "bundle_identifiers": [
+                        "^com.microsoft.VSCode$",
+                        "^com.microsoft.VSCodeInsiders",
+                        "^com.jetbrains.goland$",
+                        "^com.jetbrains.rider$",
+                        "^com.jetbrains.pycharm$",
+                        "^com.jetbrains.pycharm.ce$",
+                        "^com.jetbrains.intellij$",
+                        "^com.jetbrains.intellij.ce$",
+                        "^com.jetbrains.PhpStorm$",
+                        "^com.jetbrains.CLion$",
+                        "^com.jetbrains.WebStorm$",
+                        "^com.jetbrains.rubymine$",
+                        "^com.jetbrains.datagrip$",
+                        "^com.jetbrains.rustrover-EAP$",
+                        "^com.jetbrains.rustrover$",
+                        "^com.googlecode.iterm2$",
+                        "^com.apple.Terminal$"
+                    ],
+                    "type": "frontmost_application_if"
+                }
+            ],
+            "from": {
+                "key_code": "f10",
+                "modifiers": { "optional": ["any"] }
+            },
+            "to": [
+                {
+                    "key_code": "f10",
+                    "modifiers": ["fn"]
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "bundle_identifiers": [
+                        "^com.microsoft.VSCode$",
+                        "^com.microsoft.VSCodeInsiders",
+                        "^com.jetbrains.goland$",
+                        "^com.jetbrains.rider$",
+                        "^com.jetbrains.pycharm$",
+                        "^com.jetbrains.pycharm.ce$",
+                        "^com.jetbrains.intellij$",
+                        "^com.jetbrains.intellij.ce$",
+                        "^com.jetbrains.PhpStorm$",
+                        "^com.jetbrains.CLion$",
+                        "^com.jetbrains.WebStorm$",
+                        "^com.jetbrains.rubymine$",
+                        "^com.jetbrains.datagrip$",
+                        "^com.jetbrains.rustrover-EAP$",
+                        "^com.jetbrains.rustrover$",
+                        "^com.googlecode.iterm2$",
+                        "^com.apple.Terminal$"
+                    ],
+                    "type": "frontmost_application_if"
+                }
+            ],
+            "from": {
+                "key_code": "f11",
+                "modifiers": { "optional": ["any"] }
+            },
+            "to": [
+                {
+                    "key_code": "f11",
+                    "modifiers": ["fn"]
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "bundle_identifiers": [
+                        "^com.microsoft.VSCode$",
+                        "^com.microsoft.VSCodeInsiders",
+                        "^com.jetbrains.goland$",
+                        "^com.jetbrains.rider$",
+                        "^com.jetbrains.pycharm$",
+                        "^com.jetbrains.pycharm.ce$",
+                        "^com.jetbrains.intellij$",
+                        "^com.jetbrains.intellij.ce$",
+                        "^com.jetbrains.PhpStorm$",
+                        "^com.jetbrains.CLion$",
+                        "^com.jetbrains.WebStorm$",
+                        "^com.jetbrains.rubymine$",
+                        "^com.jetbrains.datagrip$",
+                        "^com.jetbrains.rustrover-EAP$",
+                        "^com.jetbrains.rustrover$",
+                        "^com.googlecode.iterm2$",
+                        "^com.apple.Terminal$"
+                    ],
+                    "type": "frontmost_application_if"
+                }
+            ],
+            "from": {
+                "key_code": "f12",
+                "modifiers": { "optional": ["any"] }
+            },
+            "to": [
+                {
+                    "key_code": "f12",
+                    "modifiers": ["fn"]
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "bundle_identifiers": [
+                        "^com.microsoft.VSCode$",
+                        "^com.microsoft.VSCodeInsiders",
+                        "^com.jetbrains.goland$",
+                        "^com.jetbrains.rider$",
+                        "^com.jetbrains.pycharm$",
+                        "^com.jetbrains.pycharm.ce$",
+                        "^com.jetbrains.intellij$",
+                        "^com.jetbrains.intellij.ce$",
+                        "^com.jetbrains.PhpStorm$",
+                        "^com.jetbrains.CLion$",
+                        "^com.jetbrains.WebStorm$",
+                        "^com.jetbrains.rubymine$",
+                        "^com.jetbrains.datagrip$",
+                        "^com.jetbrains.rustrover-EAP$",
+                        "^com.jetbrains.rustrover$",
+                        "^com.googlecode.iterm2$",
+                        "^com.apple.Terminal$"
+                    ],
+                    "type": "frontmost_application_unless"
+                }
+            ],
+            "from": {
+                "key_code": "f1",
+                "modifiers": { "optional": ["any"] }
+            },
+            "to": [{ "consumer_key_code": "display_brightness_decrement" }],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "bundle_identifiers": [
+                        "^com.microsoft.VSCode$",
+                        "^com.microsoft.VSCodeInsiders",
+                        "^com.jetbrains.goland$",
+                        "^com.jetbrains.rider$",
+                        "^com.jetbrains.pycharm$",
+                        "^com.jetbrains.pycharm.ce$",
+                        "^com.jetbrains.intellij$",
+                        "^com.jetbrains.intellij.ce$",
+                        "^com.jetbrains.PhpStorm$",
+                        "^com.jetbrains.CLion$",
+                        "^com.jetbrains.WebStorm$",
+                        "^com.jetbrains.rubymine$",
+                        "^com.jetbrains.datagrip$",
+                        "^com.jetbrains.rustrover-EAP$",
+                        "^com.jetbrains.rustrover$",
+                        "^com.googlecode.iterm2$",
+                        "^com.apple.Terminal$"
+                    ],
+                    "type": "frontmost_application_unless"
+                }
+            ],
+            "from": {
+                "key_code": "f2",
+                "modifiers": { "optional": ["any"] }
+            },
+            "to": [{ "consumer_key_code": "display_brightness_increment" }],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "bundle_identifiers": [
+                        "^com.microsoft.VSCode$",
+                        "^com.microsoft.VSCodeInsiders",
+                        "^com.jetbrains.goland$",
+                        "^com.jetbrains.rider$",
+                        "^com.jetbrains.pycharm$",
+                        "^com.jetbrains.pycharm.ce$",
+                        "^com.jetbrains.intellij$",
+                        "^com.jetbrains.intellij.ce$",
+                        "^com.jetbrains.PhpStorm$",
+                        "^com.jetbrains.CLion$",
+                        "^com.jetbrains.WebStorm$",
+                        "^com.jetbrains.rubymine$",
+                        "^com.jetbrains.datagrip$",
+                        "^com.jetbrains.rustrover-EAP$",
+                        "^com.jetbrains.rustrover$",
+                        "^com.googlecode.iterm2$",
+                        "^com.apple.Terminal$"
+                    ],
+                    "type": "frontmost_application_unless"
+                },
+                {
+                    "identifiers": [{ "vendor_id": 1133 }],
+                    "type": "device_unless"
+                }
+            ],
+            "from": {
+                "key_code": "f3",
+                "modifiers": { "optional": ["any"] }
+            },
+            "to": [{ "apple_vendor_keyboard_key_code": "mission_control" }],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "bundle_identifiers": [
+                        "^com.microsoft.VSCode$",
+                        "^com.microsoft.VSCodeInsiders",
+                        "^com.jetbrains.goland$",
+                        "^com.jetbrains.rider$",
+                        "^com.jetbrains.pycharm$",
+                        "^com.jetbrains.pycharm.ce$",
+                        "^com.jetbrains.intellij$",
+                        "^com.jetbrains.intellij.ce$",
+                        "^com.jetbrains.PhpStorm$",
+                        "^com.jetbrains.CLion$",
+                        "^com.jetbrains.WebStorm$",
+                        "^com.jetbrains.rubymine$",
+                        "^com.jetbrains.datagrip$",
+                        "^com.jetbrains.rustrover-EAP$",
+                        "^com.jetbrains.rustrover$",
+                        "^com.googlecode.iterm2$",
+                        "^com.apple.Terminal$"
+                    ],
+                    "type": "frontmost_application_unless"
+                },
+                {
+                    "identifiers": [{ "vendor_id": 1133 }],
+                    "type": "device_unless"
+                }
+            ],
+            "from": {
+                "key_code": "f4",
+                "modifiers": { "optional": ["any"] }
+            },
+            "to": [{ "apple_vendor_keyboard_key_code": "spotlight" }],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "bundle_identifiers": [
+                        "^com.microsoft.VSCode$",
+                        "^com.microsoft.VSCodeInsiders",
+                        "^com.jetbrains.goland$",
+                        "^com.jetbrains.rider$",
+                        "^com.jetbrains.pycharm$",
+                        "^com.jetbrains.pycharm.ce$",
+                        "^com.jetbrains.intellij$",
+                        "^com.jetbrains.intellij.ce$",
+                        "^com.jetbrains.PhpStorm$",
+                        "^com.jetbrains.CLion$",
+                        "^com.jetbrains.WebStorm$",
+                        "^com.jetbrains.rubymine$",
+                        "^com.jetbrains.datagrip$",
+                        "^com.jetbrains.rustrover-EAP$",
+                        "^com.jetbrains.rustrover$",
+                        "^com.googlecode.iterm2$",
+                        "^com.apple.Terminal$"
+                    ],
+                    "type": "frontmost_application_unless"
+                },
+                {
+                    "identifiers": [{ "vendor_id": 1133 }],
+                    "type": "device_unless"
+                }
+            ],
+            "from": {
+                "key_code": "f5",
+                "modifiers": { "optional": ["any"] }
+            },
+            "to": [{ "consumer_key_code": "dictation" }],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "bundle_identifiers": [
+                        "^com.microsoft.VSCode$",
+                        "^com.microsoft.VSCodeInsiders",
+                        "^com.jetbrains.goland$",
+                        "^com.jetbrains.rider$",
+                        "^com.jetbrains.pycharm$",
+                        "^com.jetbrains.pycharm.ce$",
+                        "^com.jetbrains.intellij$",
+                        "^com.jetbrains.intellij.ce$",
+                        "^com.jetbrains.PhpStorm$",
+                        "^com.jetbrains.CLion$",
+                        "^com.jetbrains.WebStorm$",
+                        "^com.jetbrains.rubymine$",
+                        "^com.jetbrains.datagrip$",
+                        "^com.jetbrains.rustrover-EAP$",
+                        "^com.jetbrains.rustrover$",
+                        "^com.googlecode.iterm2$",
+                        "^com.apple.Terminal$"
+                    ],
+                    "type": "frontmost_application_unless"
+                },
+                {
+                    "identifiers": [{ "vendor_id": 1133 }],
+                    "type": "device_unless"
+                }
+            ],
+            "from": {
+                "key_code": "f6",
+                "modifiers": { "optional": ["any"] }
+            },
+            "to": [{ "key_code": "f6" }],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "bundle_identifiers": [
+                        "^com.microsoft.VSCode$",
+                        "^com.microsoft.VSCodeInsiders",
+                        "^com.jetbrains.goland$",
+                        "^com.jetbrains.rider$",
+                        "^com.jetbrains.pycharm$",
+                        "^com.jetbrains.pycharm.ce$",
+                        "^com.jetbrains.intellij$",
+                        "^com.jetbrains.intellij.ce$",
+                        "^com.jetbrains.PhpStorm$",
+                        "^com.jetbrains.CLion$",
+                        "^com.jetbrains.WebStorm$",
+                        "^com.jetbrains.rubymine$",
+                        "^com.jetbrains.datagrip$",
+                        "^com.jetbrains.rustrover-EAP$",
+                        "^com.jetbrains.rustrover$",
+                        "^com.googlecode.iterm2$",
+                        "^com.apple.Terminal$"
+                    ],
+                    "type": "frontmost_application_unless"
+                },
+                {
+                    "identifiers": [{ "vendor_id": 1133 }],
+                    "type": "device_unless"
+                }
+            ],
+            "from": {
+                "key_code": "f7",
+                "modifiers": { "optional": ["any"] }
+            },
+            "to": [{ "consumer_key_code": "rewind" }],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "bundle_identifiers": [
+                        "^com.microsoft.VSCode$",
+                        "^com.microsoft.VSCodeInsiders",
+                        "^com.jetbrains.goland$",
+                        "^com.jetbrains.rider$",
+                        "^com.jetbrains.pycharm$",
+                        "^com.jetbrains.pycharm.ce$",
+                        "^com.jetbrains.intellij$",
+                        "^com.jetbrains.intellij.ce$",
+                        "^com.jetbrains.PhpStorm$",
+                        "^com.jetbrains.CLion$",
+                        "^com.jetbrains.WebStorm$",
+                        "^com.jetbrains.rubymine$",
+                        "^com.jetbrains.datagrip$",
+                        "^com.jetbrains.rustrover-EAP$",
+                        "^com.jetbrains.rustrover$",
+                        "^com.googlecode.iterm2$",
+                        "^com.apple.Terminal$"
+                    ],
+                    "type": "frontmost_application_unless"
+                },
+                {
+                    "identifiers": [{ "vendor_id": 1133 }],
+                    "type": "device_unless"
+                }
+            ],
+            "from": {
+                "key_code": "f8",
+                "modifiers": { "optional": ["any"] }
+            },
+            "to": [{ "consumer_key_code": "play_or_pause" }],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "bundle_identifiers": [
+                        "^com.microsoft.VSCode$",
+                        "^com.microsoft.VSCodeInsiders",
+                        "^com.jetbrains.goland$",
+                        "^com.jetbrains.rider$",
+                        "^com.jetbrains.pycharm$",
+                        "^com.jetbrains.pycharm.ce$",
+                        "^com.jetbrains.intellij$",
+                        "^com.jetbrains.intellij.ce$",
+                        "^com.jetbrains.PhpStorm$",
+                        "^com.jetbrains.CLion$",
+                        "^com.jetbrains.WebStorm$",
+                        "^com.jetbrains.rubymine$",
+                        "^com.jetbrains.datagrip$",
+                        "^com.jetbrains.rustrover-EAP$",
+                        "^com.jetbrains.rustrover$",
+                        "^com.googlecode.iterm2$",
+                        "^com.apple.Terminal$"
+                    ],
+                    "type": "frontmost_application_unless"
+                },
+                {
+                    "identifiers": [{ "vendor_id": 1133 }],
+                    "type": "device_unless"
+                }
+            ],
+            "from": {
+                "key_code": "f9",
+                "modifiers": { "optional": ["any"] }
+            },
+            "to": [{ "consumer_key_code": "fastforward" }],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "bundle_identifiers": [
+                        "^com.microsoft.VSCode$",
+                        "^com.microsoft.VSCodeInsiders",
+                        "^com.jetbrains.goland$",
+                        "^com.jetbrains.rider$",
+                        "^com.jetbrains.pycharm$",
+                        "^com.jetbrains.pycharm.ce$",
+                        "^com.jetbrains.intellij$",
+                        "^com.jetbrains.intellij.ce$",
+                        "^com.jetbrains.PhpStorm$",
+                        "^com.jetbrains.CLion$",
+                        "^com.jetbrains.WebStorm$",
+                        "^com.jetbrains.rubymine$",
+                        "^com.jetbrains.datagrip$",
+                        "^com.jetbrains.rustrover-EAP$",
+                        "^com.jetbrains.rustrover$",
+                        "^com.googlecode.iterm2$",
+                        "^com.apple.Terminal$"
+                    ],
+                    "type": "frontmost_application_unless"
+                },
+                {
+                    "identifiers": [{ "vendor_id": 1133 }],
+                    "type": "device_unless"
+                }
+            ],
+            "from": {
+                "key_code": "f10",
+                "modifiers": { "optional": ["any"] }
+            },
+            "to": [{ "consumer_key_code": "mute" }],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "bundle_identifiers": [
+                        "^com.microsoft.VSCode$",
+                        "^com.microsoft.VSCodeInsiders",
+                        "^com.jetbrains.goland$",
+                        "^com.jetbrains.rider$",
+                        "^com.jetbrains.pycharm$",
+                        "^com.jetbrains.pycharm.ce$",
+                        "^com.jetbrains.intellij$",
+                        "^com.jetbrains.intellij.ce$",
+                        "^com.jetbrains.PhpStorm$",
+                        "^com.jetbrains.CLion$",
+                        "^com.jetbrains.WebStorm$",
+                        "^com.jetbrains.rubymine$",
+                        "^com.jetbrains.datagrip$",
+                        "^com.jetbrains.rustrover-EAP$",
+                        "^com.jetbrains.rustrover$",
+                        "^com.googlecode.iterm2$",
+                        "^com.apple.Terminal$"
+                    ],
+                    "type": "frontmost_application_unless"
+                },
+                {
+                    "identifiers": [{ "vendor_id": 1133 }],
+                    "type": "device_unless"
+                }
+            ],
+            "from": {
+                "key_code": "f11",
+                "modifiers": { "optional": ["any"] }
+            },
+            "to": [{ "consumer_key_code": "volume_decrement" }],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "bundle_identifiers": [
+                        "^com.microsoft.VSCode$",
+                        "^com.microsoft.VSCodeInsiders",
+                        "^com.jetbrains.goland$",
+                        "^com.jetbrains.rider$",
+                        "^com.jetbrains.pycharm$",
+                        "^com.jetbrains.pycharm.ce$",
+                        "^com.jetbrains.intellij$",
+                        "^com.jetbrains.intellij.ce$",
+                        "^com.jetbrains.PhpStorm$",
+                        "^com.jetbrains.CLion$",
+                        "^com.jetbrains.WebStorm$",
+                        "^com.jetbrains.rubymine$",
+                        "^com.jetbrains.datagrip$",
+                        "^com.jetbrains.rustrover-EAP$",
+                        "^com.jetbrains.rustrover$",
+                        "^com.googlecode.iterm2$",
+                        "^com.apple.Terminal$"
+                    ],
+                    "type": "frontmost_application_unless"
+                },
+                {
+                    "identifiers": [{ "vendor_id": 1133 }],
+                    "type": "device_unless"
+                }
+            ],
+            "from": {
+                "key_code": "f12",
+                "modifiers": { "optional": ["any"] }
+            },
+            "to": [{ "consumer_key_code": "volume_increment" }],
+            "type": "basic"
+        }
+    ]
+}


### PR DESCRIPTION
In Apple-Silicon/newer-keyboard the physical F-row reports a plain Keyboard-page usage code (e.g. f7) for the raw HID event regardless of whether Fn is held — the "media key vs. function key" distinction

The actual "still needs fn" symptom comes from Java AWT on macOS, not the hardware: when fnState=0, AWT only sets the Function modifier flag on a KeyEvent if the OS says Fn was involved, and JetBrains IDEs bind actions like fn F7 requiring that flag. This has been AWT/macOS behavior for years, independent of chip architecture — it just becomes more noticeable on newer keyboards (especially external ones, Studio Display keyboard, etc.) where the dual-role F-key handling is implemented slightly differently at the driver level than older pre-T2 Macs.

Tested on M4 with Jetbrains, VSCode and other apps