### PR TITLE
Fix Spotlight shortcuts in Windows Keyboard for Mac

### DIFF
--- a/public/json/windows_keyboard_for_mac.json
+++ b/public/json/windows_keyboard_for_mac.json
@@ -3030,11 +3030,8 @@
           },
           "to": [
             {
-              "software_function": {
-                "open_application": {
-                  "bundle_identifier": "com.apple.Spotlight"
-                }
-              }
+              "apple_vendor_keyboard_key_code": "spotlight",
+              "repeat": false
             }
           ],
           "conditions": [
@@ -3093,11 +3090,8 @@
           },
           "to": [
             {
-              "software_function": {
-                "open_application": {
-                  "bundle_identifier": "com.apple.Spotlight"
-                }
-              }
+              "apple_vendor_keyboard_key_code": "spotlight",
+              "repeat": false
             }
           ],
           "conditions": [
@@ -3820,11 +3814,8 @@
           "description": "Tap the Windows key to open Spotlight.",
           "to_if_alone": [
             {
-              "software_function": {
-                "open_application": {
-                  "bundle_identifier": "com.apple.Spotlight"
-                }
-              }
+              "apple_vendor_keyboard_key_code": "spotlight",
+              "repeat": false
             }
           ],
           "parameters": {
@@ -3884,11 +3875,8 @@
           "description": "Tap the Windows key to open Spotlight.",
           "to_if_alone": [
             {
-              "software_function": {
-                "open_application": {
-                  "bundle_identifier": "com.apple.Spotlight"
-                }
-              }
+              "apple_vendor_keyboard_key_code": "spotlight",
+              "repeat": false
             }
           ],
           "parameters": {

--- a/src/json/windows_keyboard_for_mac.json.js
+++ b/src/json/windows_keyboard_for_mac.json.js
@@ -316,14 +316,15 @@ function main() {
     basic('right_arrow', ['option'], [toKey('close_bracket', ['left_command'])], [remoteUnless], 'Alt+Right navigates forward.')
   )
 
+  // Use the native Spotlight key; launching the app can leave its UI hidden on Tahoe.
   // Windows-key actions. Standard PC keyboards report the Windows key as
   // Command on macOS, so no modifier swap is required by this edition.
   manipulators.push(
     basic('spacebar', ['command'], [toKey('spacebar', ['left_control'])], [remoteUnless], 'Win+Space invokes the standard macOS next-input-source shortcut.'),
     basic('e', ['command'], [{ software_function: { open_application: { bundle_identifier: 'com.apple.finder' } } }], [remoteUnless], 'Win+E opens Finder.'),
     basic('i', ['command'], [{ software_function: { open_application: { bundle_identifier: 'com.apple.systempreferences' } } }], [remoteUnless], 'Win+I opens System Settings.'),
-    basic('r', ['command'], [{ software_function: { open_application: { bundle_identifier: 'com.apple.Spotlight' } } }], [remoteUnless], 'Win+R opens Spotlight.'),
-    basic('s', ['command'], [{ software_function: { open_application: { bundle_identifier: 'com.apple.Spotlight' } } }], [remoteUnless], 'Win+S opens Spotlight.'),
+    basic('r', ['command'], [{ apple_vendor_keyboard_key_code: 'spotlight', repeat: false }], [remoteUnless], 'Win+R opens Spotlight.'),
+    basic('s', ['command'], [{ apple_vendor_keyboard_key_code: 'spotlight', repeat: false }], [remoteUnless], 'Win+S opens Spotlight.'),
     basic('l', ['command'], [toKey('q', ['left_control', 'left_command'])], [remoteUnless], 'Win+L locks the Mac.'),
     basic('tab', ['command'], [toKey('mission_control')], [remoteUnless], 'Win+Tab opens Mission Control.'),
     basic('d', ['command'], [toKey('f11', ['fn'])], [remoteUnless], 'Win+D shows the desktop.'),
@@ -347,9 +348,8 @@ function main() {
     )
     tap.to_if_alone = [
       {
-        software_function: {
-          open_application: { bundle_identifier: 'com.apple.Spotlight' },
-        },
+        apple_vendor_keyboard_key_code: 'spotlight',
+        repeat: false,
       },
     ]
     tap.parameters = { 'basic.to_if_alone_timeout_milliseconds': 250 }


### PR DESCRIPTION
Windows-key taps and Win+R/S in the Windows Keyboard for Mac community rule use `open_application` for `com.apple.Spotlight`. On our macOS Tahoe 26.2 machine, all three shortcuts produced no visible search UI.

This changes the four outputs (left/right tap, Win+R, Win+S) to `apple_vendor_keyboard_key_code: "spotlight"` with repeat disabled, matching Karabiner's native Apple Spotlight key action. Tap timing, lazy modifiers, remote exclusions, and Win+Space remain unchanged. The generator and generated JSON are updated together.

Validation: `make all` passed; the generated JSON also passed the installed Karabiner-Elements 16.1.0 CLI lint. Normalizing the four output objects back to the old action makes the generated JSON identical to the upstream version. A physical Windows keyboard on macOS 26.2 confirmed that a quick Windows-key tap, Win+R, and Win+S now visibly open Spotlight after applying the same output changes to the device-scoped companion profile. The initial failure was on Karabiner 16.1.0, while the post-retest environment reported 16.3.0; this was not a controlled comparison on one Karabiner version. This was a device-scoped local test, not a separate all-keyboards community-profile smoke test.

Related report: https://github.com/Fuzzy-and-Fluffy/windows-keyboard-for-mac/issues/7
